### PR TITLE
fix: align temperature defaults with official API defaults

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.5.2
+pkgver=0.5.3
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.5.2"
+version = "0.5.3"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/claude/tool.py
+++ b/src/mcp_handley_lab/llm/claude/tool.py
@@ -156,7 +156,7 @@ def _claude_generation_adapter(
 ) -> dict[str, Any]:
     """Claude-specific text generation function for the shared processor."""
     # Extract Claude-specific parameters
-    temperature = kwargs.get("temperature", 0.7)
+    temperature = kwargs.get("temperature", 1.0)
     files = kwargs.get("files")
     max_output_tokens = kwargs.get("max_output_tokens")
 
@@ -259,7 +259,7 @@ def _claude_image_analysis_adapter(
         "model": resolved_model,
         "messages": claude_history,
         "max_tokens": output_tokens,
-        "temperature": 0.7,
+        "temperature": 1.0,
         "timeout": 599,
     }
 
@@ -293,7 +293,7 @@ def ask(
     output_file: str = "-",
     agent_name: str = "session",
     model: str = DEFAULT_MODEL,
-    temperature: float = 0.7,
+    temperature: float = 1.0,
     files: list[str] = [],
     max_output_tokens: int = 0,
 ) -> LLMResult:

--- a/src/mcp_handley_lab/llm/gemini/tool.py
+++ b/src/mcp_handley_lab/llm/gemini/tool.py
@@ -148,7 +148,7 @@ def _gemini_generation_adapter(
 ) -> dict[str, Any]:
     """Gemini-specific text generation function for the shared processor."""
     # Extract Gemini-specific parameters
-    temperature = kwargs.get("temperature", 0.7)
+    temperature = kwargs.get("temperature", 1.0)
     grounding = kwargs.get("grounding", False)
     files = kwargs.get("files")
     max_output_tokens = kwargs.get("max_output_tokens")
@@ -299,7 +299,7 @@ def _gemini_image_analysis_adapter(
     content = [prompt] + image_list
 
     # Prepare the config
-    config_params = {"max_output_tokens": output_tokens, "temperature": 0.7}
+    config_params = {"max_output_tokens": output_tokens, "temperature": 1.0}
     if system_instruction:
         config_params["system_instruction"] = system_instruction
 
@@ -333,7 +333,7 @@ def ask(
     output_file: str = "-",
     agent_name: str = "session",
     model: str = DEFAULT_MODEL,
-    temperature: float = 0.7,
+    temperature: float = 1.0,
     grounding: bool = False,
     files: list[str] = [],
     max_output_tokens: int = 0,

--- a/src/mcp_handley_lab/llm/openai/tool.py
+++ b/src/mcp_handley_lab/llm/openai/tool.py
@@ -52,7 +52,7 @@ def _openai_generation_adapter(
 ) -> dict[str, Any]:
     """OpenAI-specific text generation function for the shared processor."""
     # Extract OpenAI-specific parameters
-    temperature = kwargs.get("temperature", 0.7)
+    temperature = kwargs.get("temperature", 1.0)
     files = kwargs.get("files")
     max_output_tokens = kwargs.get("max_output_tokens")
     enable_logprobs = kwargs["enable_logprobs"]
@@ -216,7 +216,7 @@ def _openai_image_analysis_adapter(
 
     # Only add temperature for models that support it (reasoning models don't)
     if not model.startswith(("o1", "o3", "o4")):
-        request_params["temperature"] = 0.7
+        request_params["temperature"] = 1.0
 
     # Add max tokens with correct parameter name
     if max_output_tokens > 0:
@@ -253,7 +253,7 @@ def ask(
     output_file: str = "-",
     agent_name: str = "session",
     model: str = DEFAULT_MODEL,
-    temperature: float = 0.7,
+    temperature: float = 1.0,
     max_output_tokens: int = 0,
     files: list[str] = [],
     enable_logprobs: bool = False,


### PR DESCRIPTION
## Summary

• Change OpenAI temperature default from 0.7 to 1.0 (matches API default)
• Change Claude temperature default from 0.7 to 1.0 (matches Anthropic API default)  
• Change Gemini temperature default from 0.7 to 1.0 (matches Google API default)

## Background

All major LLM providers (OpenAI, Anthropic, Google) use **1.0** as their default temperature value in their official APIs. The previous 0.7 defaults in our codebase were arbitrary choices that deviated from official API behavior.

This was discovered when trying to use OpenAI's o4 reasoning models, which only support the default temperature (1.0) and reject custom values like 0.7.

## API Documentation Verification

- **OpenAI**: Default temperature is 1.0 (confirmed via platform.openai.com docs)
- **Anthropic Claude**: Default temperature is 1.0 (confirmed via docs.anthropic.com)  
- **Google Gemini**: Default temperature is 1.0 (confirmed via cloud.google.com docs)

## Test plan

- [x] Verify all temperature defaults changed from 0.7 to 1.0
- [x] Run version bump script (0.5.2 → 0.5.3)
- [x] Confirm pre-commit hooks pass
- [ ] Test OpenAI tool with o4 model to ensure no temperature errors
- [ ] Verify all LLM tools still function correctly with new defaults

🤖 Generated with [Claude Code](https://claude.ai/code)