### PR TITLE
fix: add missing dependencies to PKGBUILD for makepkg compatibility

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.6.2
+pkgver=0.6.3
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')
@@ -34,6 +34,10 @@ depends=(
     'python-html2text'
     'python-beautifulsoup4'
     'python-markdownify'
+    'python-pendulum'
+    'python-xai-sdk'
+    'jupyter-nbformat'
+    'python-dateparser'
 )
 makedepends=(
     'python-build'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.6.2"
+version = "0.6.3"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Add python-pendulum, python-xai-sdk, jupyter-nbformat, and python-dateparser to PKGBUILD dependencies
- Resolves import errors during package build with makepkg -s
- Bump version to 0.6.3

## Test plan
- [x] Run makepkg -s to verify package builds successfully
- [x] Version bumped using automated script

🤖 Generated with [Claude Code](https://claude.ai/code)