### PR TITLE
feat: add email attachment extraction functionality

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.6.3
+pkgver=0.6.4
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.6.3"
+version = "0.6.4"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Adds comprehensive email attachment extraction functionality to the notmuch email tool, enabling users to save email attachments to local directories.

**Key Features:**
- Extract all attachments or specific files by filename
- Default save location: `~/Downloads/email_attachments` with custom directory support
- Automatic filename sanitization and conflict resolution (`file.pdf` → `file_2.pdf`)
- Seamless integration with existing `search → show → extract` workflow
- Regex parsing for `show` command compatibility (`"file.pdf (application/pdf)"` → `"file.pdf"`)

**Technical Implementation:**
- Fail-fast error handling following codebase philosophy (no defensive programming)
- Type-safe implementation with no Union types (`str = ""` defaults instead of `str = None`)
- Fixed mutable default arguments in `tag` function
- Leverages existing `_get_message_from_raw_source()` and Python's `email` library
- Follows aggressive concision principles with elegant path handling

**Usage Examples:**
```python
# Extract all attachments
extract_attachments(message_id="some_email_id")

# Extract specific attachment
extract_attachments(message_id="some_email_id", filename="report.pdf")

# Custom save directory
extract_attachments(message_id="some_email_id", output_dir="/tmp/attachments")
```

## Test plan

- [x] Function imports and model work correctly
- [x] Fails fast with proper exceptions for invalid message IDs
- [x] Filename parsing works for `show` command integration
- [x] JSON-RPC integration properly handles errors
- [x] Version bump applied (0.6.3 → 0.6.4)
- [x] Code review by Gemini for codebase philosophy compliance

🤖 Generated with [Claude Code](https://claude.ai/code)