### PR TITLE
fix: resolve FieldInfo parameter passing error in email reply and forward tools

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.11.0
+pkgver=0.11.1
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.11.0"
+version = "0.11.1"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/email/mutt/tool.py
+++ b/src/mcp_handley_lab/email/mutt/tool.py
@@ -276,12 +276,14 @@ def reply(
     # Use compose with extracted data
     return compose(
         to=reply_to,
-        cc=reply_cc,
         subject=reply_subject,
+        cc=reply_cc,
+        bcc=None,
         initial_body=complete_reply_body,
+        attachments=None,
+        auto_send=auto_send,
         in_reply_to=in_reply_to,
         references=references,
-        auto_send=auto_send,
     )
 
 
@@ -341,8 +343,13 @@ def forward(
     return compose(
         to=to,
         subject=forward_subject,
+        cc=None,
+        bcc=None,
         initial_body=complete_forward_body,
+        attachments=None,
         auto_send=auto_send,
+        in_reply_to=None,
+        references=None,
     )
 
 


### PR DESCRIPTION
## Summary
- Fixed reply() function to explicitly pass all parameters to compose()
- Fixed forward() function to explicitly pass all parameters to compose() 
- Resolves 'FieldInfo' object is not iterable error when tools call each other directly

## Problem
The reply and forward tools were failing with `'FieldInfo' object is not iterable` error because when calling compose() internally, they weren't explicitly passing all Field() parameters. This caused the parameters to retain their Field() descriptor objects instead of actual values.

## Solution
Explicitly pass all parameters (attachments=None, cc=None, bcc=None, etc.) when calling compose() from reply() and forward() functions.

## Test plan
- [x] Reply tool tested and working via MCP interface
- [x] Forward tool tested and working via MCP interface  
- [x] Both tools now properly handle parameter conversion

🤖 Generated with [Claude Code](https://claude.ai/code)