### PR TITLE
Simplify email compose/reply/forward parameters

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.12.1
+pkgver=0.12.2
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.12.1"
+version = "0.12.2"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Removed `auto_send` parameter from compose/reply/forward functions 
- Renamed `initial_body` to `body` for consistency across email functions
- All email composition now requires interactive confirmation via Mutt

## Changes Made
- Updated function signatures to remove `auto_send` parameter
- Renamed `initial_body` to `body` in all three functions
- Removed unused `_prepare_body_with_signature` helper function
- Simplified `_execute_mutt_interactive_or_auto` to `_execute_mutt_interactive`
- Updated all function calls to use new parameter names

## Test plan
- [x] Unit tests pass
- [x] Functions import correctly
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)