### PR TITLE
fix: add missing AUR dependencies to PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.12.8
+pkgver=0.12.9
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')
@@ -38,6 +38,12 @@ depends=(
     'python-xai-sdk'
     'jupyter-nbformat'
     'python-dateparser'
+    'python-ftfy'
+    'python-inscriptis'
+    'python-selectolax'
+    'python-email-reply-parser'
+    'python-anthropic'
+    'python-wolframclient'
 )
 makedepends=(
     'python-build'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.12.8"
+version = "0.12.9"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Add missing AUR dependencies to PKGBUILD that were causing makepkg test collection failures
- All dependencies already exist in pyproject.toml but were missing from system package dependencies
- Fixes `ERROR tests/test_email_move_unit.py` during makepkg build process

## Dependencies Added
- `python-ftfy` (AUR) - text fixing library
- `python-inscriptis` (AUR) - HTML to text conversion  
- `python-selectolax` (AUR) - fast HTML parser
- `python-email-reply-parser` (AUR) - email reply parsing (new package created)
- `python-anthropic` (AUR) - Claude API client
- `python-wolframclient` (AUR) - Mathematica integration

## Test plan
- [x] Version bumped using automated script (0.12.8 → 0.12.9)
- [x] All dependencies verified available in AUR
- [x] Pre-commit hooks pass
- [ ] Verify makepkg -sri succeeds after installing AUR dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)