### PR TITLE
fix: correct Gemini Files API mime type parameter for large files

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.12.9b1
+pkgver=0.12.10
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.12.9b1"
+version = "0.12.10"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/gemini/tool.py
+++ b/src/mcp_handley_lab/llm/gemini/tool.py
@@ -21,6 +21,7 @@ from google.genai.types import (
     GoogleSearchRetrieval,
     Part,
     Tool,
+    UploadFileConfig,
 )
 from mcp.server.fastmcp import FastMCP
 from PIL import Image
@@ -135,9 +136,10 @@ def _resolve_files(
         if file_size > GEMINI_INLINE_FILE_LIMIT_BYTES:
             # Large file - use Files API
             used_files_api = True
+            config = UploadFileConfig(mimeType=get_gemini_safe_mime_type(file_path))
             uploaded_file = _get_client().files.upload(
                 file=str(file_path),
-                mime_type=get_gemini_safe_mime_type(file_path),
+                config=config,
             )
             parts.append(Part(fileData=FileData(fileUri=uploaded_file.uri)))
         else:


### PR DESCRIPTION
## Summary
- Fixed `TypeError` when uploading files >20MB to Gemini Files API
- The `Files.upload()` method requires `mime_type` to be passed via `UploadFileConfig` config parameter with camelCase `mimeType`, not as a direct argument

## Changes
- Added `UploadFileConfig` import from `google.genai.types`
- Created config object with `mimeType` parameter for file uploads
- Pass config to `Files.upload()` method instead of direct `mime_type` parameter

## Testing
- ✅ Tested with 26MB PDF file (Hertig_PhDThesis.pdf) - successfully analyzed
- ✅ Tested with 25MB PNG file - successfully processed
- ✅ All 25 MIME handling unit tests pass
- ✅ All 11 Gemini unit tests pass

## Root Cause
The Google Genai SDK's `Files.upload()` method signature requires:
```python
upload(file=..., config=UploadFileConfig(mimeType=...))
```

Previous code incorrectly used:
```python
upload(file=..., mime_type=...)  # TypeError!
```

## Version
Bumped from 0.12.9b1 to 0.12.10 (patch release for bug fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)