### PR TITLE
fix: remove dead max_output_tokens code from all LLM adapters (v0.14.1)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.14.0
+pkgver=0.14.1
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.14.0"
+version = "0.14.1"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/claude/tool.py
+++ b/src/mcp_handley_lab/llm/claude/tool.py
@@ -146,15 +146,11 @@ def _claude_generation_adapter(
     # Extract Claude-specific parameters
     temperature = kwargs.get("temperature", 1.0)
     files = kwargs.get("files")
-    max_output_tokens = kwargs.get("max_output_tokens")
 
     # Get model configuration
     resolved_model = _resolve_model_alias(model)
     model_config = _get_model_config(resolved_model)
-    max_output = model_config["output_tokens"]
-    output_tokens = (
-        min(max_output_tokens, max_output) if max_output_tokens > 0 else max_output
-    )
+    output_tokens = model_config["output_tokens"]
 
     # Resolve file contents
     file_content = _resolve_files(files)
@@ -221,7 +217,6 @@ def _claude_image_analysis_adapter(
     # Extract image analysis specific parameters
     images = kwargs.get("images", [])
     focus = kwargs.get("focus", "general")
-    max_output_tokens = kwargs.get("max_output_tokens")
 
     # Enhance prompt based on focus
     if focus != "general":
@@ -230,10 +225,7 @@ def _claude_image_analysis_adapter(
     # Get model configuration
     resolved_model = _resolve_model_alias(model)
     model_config = _get_model_config(resolved_model)
-    max_output = model_config["output_tokens"]
-    output_tokens = (
-        min(max_output_tokens, max_output) if max_output_tokens > 0 else max_output
-    )
+    output_tokens = model_config["output_tokens"]
 
     # Resolve images to content blocks
     image_blocks = _resolve_images_to_content_blocks(images)

--- a/src/mcp_handley_lab/llm/gemini/tool.py
+++ b/src/mcp_handley_lab/llm/gemini/tool.py
@@ -192,7 +192,6 @@ def _gemini_generation_adapter(
     temperature = kwargs.get("temperature", 1.0)
     grounding = kwargs.get("grounding", False)
     files = kwargs.get("files")
-    max_output_tokens = kwargs.get("max_output_tokens")
 
     # Configure tools for grounding if requested
     tools = []
@@ -207,10 +206,7 @@ def _gemini_generation_adapter(
 
     # Get model configuration and token limits
     model_config = _get_model_config(model)
-    max_output = model_config["output_tokens"]
-    output_tokens = (
-        min(max_output_tokens, max_output) if max_output_tokens > 0 else max_output
-    )
+    output_tokens = model_config["output_tokens"]
 
     # Prepare config
     config_params = {
@@ -329,17 +325,13 @@ def _gemini_image_analysis_adapter(
     """Gemini-specific image analysis function for the shared processor."""
     # Extract image analysis specific parameters
     images = kwargs.get("images", [])
-    max_output_tokens = kwargs.get("max_output_tokens")
 
     # Load images
     image_list = _resolve_images(images)
 
     # Get model configuration
     model_config = _get_model_config(model)
-    max_output = model_config["output_tokens"]
-    output_tokens = (
-        min(max_output_tokens, max_output) if max_output_tokens > 0 else max_output
-    )
+    output_tokens = model_config["output_tokens"]
 
     # Prepare content with images
     content = [prompt] + image_list

--- a/src/mcp_handley_lab/llm/grok/tool.py
+++ b/src/mcp_handley_lab/llm/grok/tool.py
@@ -61,7 +61,6 @@ def _grok_generation_adapter(
     # Extract Grok-specific parameters
     temperature = kwargs.get("temperature", 1.0)
     files = kwargs.get("files")
-    max_output_tokens = kwargs.get("max_output_tokens")
 
     # Build messages using xai-sdk helpers
     messages = []
@@ -98,10 +97,7 @@ def _grok_generation_adapter(
     }
 
     # Add max tokens
-    if max_output_tokens > 0:
-        request_params["max_tokens"] = max_output_tokens
-    else:
-        request_params["max_tokens"] = default_tokens
+    request_params["max_tokens"] = default_tokens
 
     # Make API call using XAI SDK's two-step process
     chat_session = _get_client().chat.create(**request_params)
@@ -158,7 +154,6 @@ def _grok_image_analysis_adapter(
     # Extract image analysis specific parameters
     images = kwargs.get("images", [])
     focus = kwargs.get("focus", "general")
-    max_output_tokens = kwargs.get("max_output_tokens")
 
     # Use standardized image processing
     from mcp_handley_lab.llm.common import resolve_images_for_multimodal_prompt
@@ -204,10 +199,7 @@ def _grok_image_analysis_adapter(
     }
 
     # Add max tokens
-    if max_output_tokens > 0:
-        request_params["max_tokens"] = max_output_tokens
-    else:
-        request_params["max_tokens"] = default_tokens
+    request_params["max_tokens"] = default_tokens
 
     # Make API call using XAI SDK's two-step process
     chat_session = _get_client().chat.create(**request_params)

--- a/src/mcp_handley_lab/llm/openai/tool.py
+++ b/src/mcp_handley_lab/llm/openai/tool.py
@@ -76,7 +76,6 @@ def _openai_generation_adapter(
     # Extract OpenAI-specific parameters
     temperature = kwargs.get("temperature", 1.0)
     files = kwargs.get("files")
-    max_output_tokens = kwargs.get("max_output_tokens")
     enable_logprobs = kwargs["enable_logprobs"]
     top_logprobs = kwargs["top_logprobs"]
 
@@ -125,7 +124,7 @@ def _openai_generation_adapter(
         request_params["temperature"] = temperature
 
     # Add max tokens with correct parameter name
-    request_params[param_name] = max_output_tokens or default_tokens
+    request_params[param_name] = default_tokens
 
     # Make API call
     response = _get_client().chat.completions.create(**request_params)
@@ -188,7 +187,6 @@ def _openai_image_analysis_adapter(
     # Extract image analysis specific parameters
     images = kwargs.get("images", [])
     focus = kwargs.get("focus", "general")
-    max_output_tokens = kwargs.get("max_output_tokens")
     temperature = kwargs.get("temperature", 1.0)
 
     # Validate temperature parameter
@@ -245,7 +243,7 @@ def _openai_image_analysis_adapter(
         request_params["temperature"] = temperature
 
     # Add max tokens with correct parameter name
-    request_params[param_name] = max_output_tokens or default_tokens
+    request_params[param_name] = default_tokens
 
     # Make API call
     response = _get_client().chat.completions.create(**request_params)


### PR DESCRIPTION
## Summary
- Fix TypeError when calling LLM tools: `'>' not supported between instances of 'NoneType' and 'int'`
- Remove dead `max_output_tokens` extraction code from all LLM adapter functions
- Affected providers: Gemini, OpenAI, Claude, Grok

## Root Cause
The `max_output_tokens` parameter was removed from tool interfaces in a previous refactor, but the adapter functions still tried to:
1. Extract it from kwargs: `max_output_tokens = kwargs.get("max_output_tokens")` (returns None)
2. Compare to 0: `if max_output_tokens > 0` (TypeError: None > 0)

## Fix
All adapters now use `model_config["output_tokens"]` directly instead of the removed parameter.

## Test plan
- [x] All LLM provider tools fixed
- [x] Linting passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)