### PR TITLE
feat: add thinking/reasoning features for Gemini and Claude (v0.14.4)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.14.3
+pkgver=0.14.4
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.14.3"
+version = "0.14.4"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/claude/tool.py
+++ b/src/mcp_handley_lab/llm/claude/tool.py
@@ -146,6 +146,8 @@ def _claude_generation_adapter(
     # Extract Claude-specific parameters
     temperature = kwargs.get("temperature", 1.0)
     files = kwargs.get("files")
+    enable_thinking = kwargs.get("enable_thinking", False)
+    thinking_budget = kwargs.get("thinking_budget", 10000)
 
     # Get model configuration
     resolved_model = _resolve_model_alias(model)
@@ -168,13 +170,22 @@ def _claude_generation_adapter(
 
     # Resolve model alias and prepare request parameters
     resolved_model = _resolve_model_alias(model)
-    request_params = {
+    request_params: dict[str, Any] = {
         "model": resolved_model,
         "messages": claude_history,
         "max_tokens": output_tokens,
-        "temperature": temperature,
         "timeout": 599,
     }
+
+    # Add thinking configuration if enabled (temperature not allowed with thinking)
+    if enable_thinking:
+        request_params["thinking"] = {
+            "type": "enabled",
+            "budget_tokens": thinking_budget,
+        }
+        # Temperature must be 1.0 when thinking is enabled
+    else:
+        request_params["temperature"] = temperature
 
     # Add system instruction if provided
     if system_instruction:
@@ -187,12 +198,28 @@ def _claude_generation_adapter(
         # Convert all API errors to ValueError for consistent error handling
         raise ValueError(f"Claude API error: {str(e)}") from e
 
-    if not response.content or not response.content[0].text:
+    # Extract text and thinking from response content blocks
+    text_parts = []
+    thinking_parts = []
+    for block in response.content:
+        if block.type == "thinking":
+            thinking_parts.append(block.thinking)
+        elif block.type == "text":
+            text_parts.append(block.text)
+
+    # Format output with thinking if present
+    if thinking_parts and enable_thinking:
+        thinking_text = "\n".join(thinking_parts)
+        answer_text = "\n".join(text_parts) if text_parts else ""
+        text = f"<thinking>\n{thinking_text}\n</thinking>\n\n{answer_text}"
+    elif text_parts:
+        text = "\n".join(text_parts)
+    else:
         raise RuntimeError("No response text generated")
 
     # Extract additional Claude metadata
     return {
-        "text": response.content[0].text,
+        "text": text,
         "input_tokens": response.usage.input_tokens,
         "output_tokens": response.usage.output_tokens,
         "finish_reason": response.stop_reason,
@@ -323,6 +350,14 @@ def ask(
         default_factory=dict,
         description="A dictionary of variables for template substitution in the system prompt using ${var} syntax.",
     ),
+    enable_thinking: bool = Field(
+        default=False,
+        description="Enable extended thinking mode for deeper reasoning. Output includes <thinking> tags with model's reasoning process.",
+    ),
+    thinking_budget: int = Field(
+        default=10000,
+        description="Maximum tokens for thinking when enable_thinking is True. Minimum 1024. Higher values allow more thorough reasoning.",
+    ),
 ) -> LLMResult:
     """Ask Claude a question with optional persistent memory."""
     # Resolve model alias to full model name for consistent pricing
@@ -342,6 +377,8 @@ def ask(
         system_prompt=system_prompt,
         system_prompt_file=system_prompt_file,
         system_prompt_vars=system_prompt_vars,
+        enable_thinking=enable_thinking,
+        thinking_budget=thinking_budget,
     )
 
 

--- a/src/mcp_handley_lab/llm/gemini/tool.py
+++ b/src/mcp_handley_lab/llm/gemini/tool.py
@@ -20,6 +20,7 @@ from google.genai.types import (
     GoogleSearch,
     GoogleSearchRetrieval,
     Part,
+    ThinkingConfig,
     Tool,
     UploadFileConfig,
 )
@@ -192,6 +193,9 @@ def _gemini_generation_adapter(
     temperature = kwargs.get("temperature", 1.0)
     grounding = kwargs.get("grounding", False)
     files = kwargs.get("files")
+    include_thoughts = kwargs.get("include_thoughts", False)
+    thinking_level = kwargs.get("thinking_level")
+    thinking_budget = kwargs.get("thinking_budget")
 
     # Configure tools for grounding if requested
     tools = []
@@ -208,8 +212,20 @@ def _gemini_generation_adapter(
     model_config = _get_model_config(model)
     output_tokens = model_config["output_tokens"]
 
+    # Build thinking config if requested
+    thinking_config = None
+    if include_thoughts or thinking_level or thinking_budget is not None:
+        thinking_params: dict[str, Any] = {"include_thoughts": include_thoughts}
+        # Gemini 3 uses thinking_level (LOW/HIGH)
+        if thinking_level:
+            thinking_params["thinking_level"] = thinking_level.upper()
+        # Gemini 2.5 uses thinking_budget (token count, -1=dynamic, 0=disable)
+        if thinking_budget is not None:
+            thinking_params["thinking_budget"] = thinking_budget
+        thinking_config = ThinkingConfig(**thinking_params)
+
     # Prepare config
-    config_params = {
+    config_params: dict[str, Any] = {
         "temperature": temperature,
         "max_output_tokens": output_tokens,
     }
@@ -217,6 +233,8 @@ def _gemini_generation_adapter(
         config_params["system_instruction"] = system_instruction
     if tools:
         config_params["tools"] = tools
+    if thinking_config:
+        config_params["thinking_config"] = thinking_config
 
     config = GenerateContentConfig(**config_params)
 
@@ -255,7 +273,26 @@ def _gemini_generation_adapter(
         # Convert all API errors to ValueError for consistent error handling
         raise ValueError(f"Gemini API error: {str(e)}") from e
 
-    if not response.text:
+    # Extract text, separating thinking from answer
+    text_parts = []
+    thinking_parts = []
+    if response.candidates and response.candidates[0].content:
+        for part in response.candidates[0].content.parts:
+            if hasattr(part, "thought") and part.thought:
+                thinking_parts.append(part.text)
+            elif hasattr(part, "text") and part.text:
+                text_parts.append(part.text)
+
+    # Format output with thinking if present
+    if thinking_parts and include_thoughts:
+        thinking_text = "\n".join(thinking_parts)
+        answer_text = "\n".join(text_parts) if text_parts else ""
+        text = f"<thinking>\n{thinking_text}\n</thinking>\n\n{answer_text}"
+    elif text_parts:
+        text = "\n".join(text_parts)
+    elif response.text:
+        text = response.text
+    else:
         raise RuntimeError("No response text generated")
 
     # Extract grounding metadata - SDK converts to snake_case, fail fast on API changes
@@ -302,10 +339,16 @@ def _gemini_generation_adapter(
             dur_part = server_timing.split("dur=")[1].split(";")[0].split(",")[0]
             generation_time_ms = int(float(dur_part))
 
+    # Extract thinking token count if available
+    thoughts_token_count = (
+        getattr(response.usage_metadata, "thoughts_token_count", 0) or 0
+    )
+
     return {
-        "text": response.text,
+        "text": text,
         "input_tokens": response.usage_metadata.prompt_token_count,
         "output_tokens": response.usage_metadata.candidates_token_count,
+        "thoughts_token_count": thoughts_token_count,
         "grounding_metadata": grounding_metadata,
         "finish_reason": finish_reason,
         "avg_logprobs": avg_logprobs,
@@ -414,6 +457,18 @@ def ask(
         default_factory=dict,
         description="A dictionary of variables for template substitution in the system prompt using ${var} syntax.",
     ),
+    include_thoughts: bool = Field(
+        default=False,
+        description="Include model's thinking/reasoning in the output wrapped in <thinking> tags.",
+    ),
+    thinking_level: str | None = Field(
+        default=None,
+        description="Thinking effort level for Gemini 3 models: 'low' or 'high'. Higher levels provide deeper reasoning.",
+    ),
+    thinking_budget: int | None = Field(
+        default=None,
+        description="Token budget for thinking in Gemini 2.5 models. Use -1 for dynamic, 0 to disable. Range: 128-32768.",
+    ),
 ) -> LLMResult:
     """Ask Gemini a question with optional persistent memory."""
     return process_llm_request(
@@ -432,6 +487,9 @@ def ask(
         system_prompt=system_prompt,
         system_prompt_file=system_prompt_file,
         system_prompt_vars=system_prompt_vars,
+        include_thoughts=include_thoughts,
+        thinking_level=thinking_level,
+        thinking_budget=thinking_budget,
     )
 
 


### PR DESCRIPTION
## Summary
- Add extended thinking/reasoning support to Gemini and Claude LLM providers
- Gemini: `include_thoughts`, `thinking_level` (Gemini 3), `thinking_budget` (Gemini 2.5)
- Claude: `enable_thinking`, `thinking_budget` for extended thinking mode
- Output formatted consistently with `<thinking>` tags across both providers

## Test plan
- [ ] Test Gemini thinking with `include_thoughts=True`
- [ ] Test Claude thinking with `enable_thinking=True`
- [ ] Verify thinking output is wrapped in `<thinking>` tags
- [ ] Confirm existing non-thinking functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)