### PR TITLE
feat(email): add thread context to replies and fix sent folder reply-to

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.18.1
+pkgver=0.18.2
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.18.1"
+version = "0.18.2"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/email/mutt/tool.py
+++ b/src/mcp_handley_lab/email/mutt/tool.py
@@ -389,7 +389,7 @@ def _compose_email(
 
 
 @mcp.tool(
-    description="""Send an email via Mutt. Supports compose (new), reply, and forward modes. All emails open in Mutt for user sign-off before sending."""
+    description="""Send an email via Mutt. Supports compose (new), reply, and forward modes. For replying, prefer using 'reply' mode with a message_id to maintain thread context - the full conversation thread will be included in quotes. All emails open in Mutt for user sign-off before sending."""
 )
 def send(
     to: str = Field(
@@ -423,6 +423,10 @@ def send(
         default=False,
         description="For reply mode: if True, reply to all recipients (To and Cc).",
     ),
+    thread_context: int = Field(
+        default=5,
+        description="For reply mode: number of previous thread messages to include (0 to disable, -1 for all).",
+    ),
 ) -> OperationResult:
     """Send an email using mutt's interactive interface."""
     if mode == "compose":
@@ -444,6 +448,8 @@ def send(
         # Import notmuch functions to get original message data
         from mcp_handley_lab.email.notmuch.tool import (
             _get_message_from_raw_source,
+            _get_thread_messages,
+            _is_sent_message,
             _show_email,
         )
 
@@ -452,9 +458,14 @@ def send(
         original_msg = result[0]
         raw_msg = _get_message_from_raw_source(message_id)
 
-        # Extract reply data - use Reply-To if available, otherwise From
+        # Extract reply data - for sent emails, reply to recipient; otherwise use Reply-To/From
         reply_to_header = raw_msg.get("Reply-To")
-        reply_to = reply_to_header if reply_to_header else original_msg.from_address
+        if _is_sent_message(message_id):
+            # Replying to my own sent email - use original recipient
+            reply_to = original_msg.to_address
+        else:
+            # Normal reply - use Reply-To or From
+            reply_to = reply_to_header if reply_to_header else original_msg.from_address
 
         # For reply-all, CC should be original To + original Cc recipients
         reply_cc = cc  # Start with user-provided cc
@@ -493,18 +504,38 @@ def send(
             else in_reply_to
         )
 
-        # Build reply body
+        # Get thread context (excluding the message being replied to)
+        max_msgs = None if thread_context < 0 else thread_context
+        thread_messages = _get_thread_messages(message_id, max_messages=max_msgs)
+
+        # Build thread history (older messages first)
+        thread_parts = []
+        for msg_date, from_addr, _subj, msg_body in thread_messages:
+            separator = f"\n--- On {msg_date}, {from_addr} wrote ---\n"
+            quoted = "\n".join(f"> {line}" for line in msg_body.splitlines())
+            thread_parts.append(f"{separator}{quoted}")
+
+        thread_history = "\n".join(thread_parts)
+
+        # Build reply with immediate parent at top, then thread history
         reply_separator = f"On {original_msg.date}, {original_msg.from_address} wrote:"
         quoted_body_lines = [
             f"> {line}" for line in original_msg.body_markdown.splitlines()
         ]
         quoted_body = "\n".join(quoted_body_lines)
 
-        complete_reply_body = (
-            f"{body}\n\n{reply_separator}\n{quoted_body}"
-            if body
-            else f"{reply_separator}\n{quoted_body}"
-        )
+        if thread_history:
+            complete_reply_body = (
+                f"{body}\n\n{reply_separator}\n{quoted_body}\n\n--- Previous messages in thread ---{thread_history}"
+                if body
+                else f"{reply_separator}\n{quoted_body}\n\n--- Previous messages in thread ---{thread_history}"
+            )
+        else:
+            complete_reply_body = (
+                f"{body}\n\n{reply_separator}\n{quoted_body}"
+                if body
+                else f"{reply_separator}\n{quoted_body}"
+            )
 
         return _compose_email(
             to=reply_to,

--- a/src/mcp_handley_lab/email/notmuch/tool.py
+++ b/src/mcp_handley_lab/email/notmuch/tool.py
@@ -677,3 +677,97 @@ def move(
         moved_files_count=moved_count,
         status=status_message,
     )
+
+
+def _is_sent_message(message_id: str) -> bool:
+    """Check if message is from Sent folder. Uses tags first, path fallback."""
+    # Check for 'sent' tag (most reliable)
+    stdout, _ = run_command(["notmuch", "search", "--output=tags", f"id:{message_id}"])
+    tags = stdout.decode().strip().lower().split("\n")
+    if "sent" in tags:
+        return True
+
+    # Fallback: check file paths (handles multiple files)
+    stdout, _ = run_command(["notmuch", "search", "--output=files", f"id:{message_id}"])
+    file_paths = stdout.decode().strip().lower().split("\n")
+    sent_patterns = ["/sent/", "/sent items/", "/outbox/", "/.sent/", "/sent messages/"]
+    return any(
+        any(pattern in path for pattern in sent_patterns) for path in file_paths if path
+    )
+
+
+def _get_thread_message_ids(message_id: str) -> list[str]:
+    """Get all message IDs in the same thread, oldest first."""
+    # Get thread ID for this message
+    stdout, _ = run_command(
+        ["notmuch", "search", "--output=threads", f"id:{message_id}"]
+    )
+    thread_id = stdout.decode().strip()
+
+    if not thread_id:
+        return []
+
+    # Normalize thread ID format (ensure it starts with "thread:")
+    if not thread_id.startswith("thread:"):
+        thread_id = f"thread:{thread_id}"
+
+    # Get all message IDs in thread, oldest first
+    stdout, _ = run_command(
+        ["notmuch", "search", "--output=messages", "--sort=oldest-first", thread_id]
+    )
+    return [m.strip() for m in stdout.decode().strip().split("\n") if m.strip()]
+
+
+def _get_thread_messages(
+    message_id: str,
+    max_messages: int = 5,
+) -> list[tuple[str, str, str, str]]:
+    """Get messages in thread for reply context.
+
+    Args:
+        message_id: The message being replied to (will be excluded)
+        max_messages: Max previous messages to include (0=none, -1=all, default 5)
+
+    Returns: List of (date, from_address, subject, body) tuples, oldest first
+    """
+    thread_message_ids = _get_thread_message_ids(message_id)
+
+    # Exclude the message being replied to
+    thread_message_ids = [m for m in thread_message_ids if m != message_id]
+
+    if not thread_message_ids:
+        return []
+
+    # Limit to most recent N messages (take from end since sorted oldest-first)
+    if max_messages == 0:
+        return []
+    if max_messages > 0 and len(thread_message_ids) > max_messages:
+        thread_message_ids = thread_message_ids[-max_messages:]
+
+    # Fetch each message directly (more efficient than _show_email)
+    messages = []
+    for mid in thread_message_ids:
+        try:
+            msg = _get_message_from_raw_source(mid)
+            # Get body without quote stripping for full thread context
+            body_part = msg.get_body(preferencelist=("plain", "html"))
+            if body_part:
+                content = body_part.get_content()
+                if body_part.get_content_type() == "text/html":
+                    content = process_html_content(content)
+                body = normalize_whitespace(ftfy.fix_text(content))
+            else:
+                body = ""
+
+            messages.append(
+                (
+                    msg.get("Date", "[Unknown Date]"),
+                    msg.get("From", "[Unknown Sender]"),
+                    msg.get("Subject", "[No Subject]"),
+                    body,
+                )
+            )
+        except Exception:
+            continue  # Skip messages that fail to parse
+
+    return messages


### PR DESCRIPTION
## Summary
- Add `thread_context` parameter to control thread message inclusion in replies (default 5, -1 for all, 0 to disable)
- Fix reply-to address for sent folder emails: use original recipient (To:) instead of sender (From:)
- Detect sent emails via `tag:sent` first, with file path fallback for common folder names
- Include thread history in quoted reply body with clear separators
- Update tool description to encourage thread-based replies

## Changes
- `src/mcp_handley_lab/email/notmuch/tool.py`: Add `_is_sent_message()`, `_get_thread_message_ids()`, `_get_thread_messages()` helpers
- `src/mcp_handley_lab/email/mutt/tool.py`: Update `send()` with thread context and sent folder detection

## Test plan
- [x] All 864 tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)