### PR TITLE
fix(common): include stderr in error messages for command failures

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.21.4
+pkgver=0.21.5
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.21.4"
+version = "0.21.5"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/common/process.py
+++ b/src/mcp_handley_lab/common/process.py
@@ -17,15 +17,22 @@ def run_command(
         Tuple of (stdout, stderr) as bytes
 
     Raises:
-        subprocess.CalledProcessError: If command fails with non-zero exit code
+        RuntimeError: If command fails (includes stderr in message)
         subprocess.TimeoutExpired: If command times out
         FileNotFoundError: If command is not found
     """
-    result = subprocess.run(
-        cmd,
-        input=input_data,
-        capture_output=True,
-        timeout=timeout,
-        check=True,
-    )
-    return result.stdout, result.stderr
+    try:
+        result = subprocess.run(
+            cmd,
+            input=input_data,
+            capture_output=True,
+            timeout=timeout,
+            check=True,
+        )
+        return result.stdout, result.stderr
+    except subprocess.CalledProcessError as e:
+        stderr_msg = e.stderr.decode(errors="replace").strip() if e.stderr else ""
+        cmd_str = " ".join(cmd)
+        raise RuntimeError(
+            f"Command failed (exit {e.returncode}): {cmd_str}\n{stderr_msg}"
+        ) from e


### PR DESCRIPTION
## Summary
- Include stderr content in error messages when commands fail
- Makes debugging much easier when notmuch/other commands fail

## Problem
When commands failed, only exit code was shown:
```
Command '['notmuch', 'show', ...]' returned non-zero exit status 1.
```

## Solution  
Now shows the actual error:
```
Command failed (exit 1): notmuch show --format=raw id:nonexistent
Error: search term did not match precisely one message (matched 0 messages).
```

## Test plan
- [x] Tested with invalid notmuch query - shows actual error reason

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)