### PR TITLE
docs(email): encourage Firstname Lastname <email> format in schema

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.21.9
+pkgver=0.21.10
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.21.9"
+version = "0.21.10"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/email/mutt/tool.py
+++ b/src/mcp_handley_lab/email/mutt/tool.py
@@ -709,7 +709,7 @@ def _compose_email(
 def send(
     to: str = Field(
         default="",
-        description="Recipient email address. Required for compose/forward, auto-populated for reply.",
+        description="Recipient address. Prefer 'Firstname Lastname <email>' format. Required for compose/forward, auto-populated for reply.",
     ),
     subject: str = Field(default="", description="The subject line of the email."),
     body: str = Field(
@@ -717,11 +717,12 @@ def send(
         description="Email body text. For reply/forward, added above quoted/forwarded content.",
     ),
     cc: str = Field(
-        default=None, description="Email address for the 'Cc' (carbon copy) field."
+        default=None,
+        description="Carbon copy address. Prefer 'Firstname Lastname <email>' format.",
     ),
     bcc: str = Field(
         default=None,
-        description="Email address for the 'Bcc' (blind carbon copy) field.",
+        description="Blind carbon copy address. Prefer 'Firstname Lastname <email>' format.",
     ),
     attachments: list[str] = Field(
         default=None, description="A list of local file paths to attach to the email."


### PR DESCRIPTION
## Summary

Update MCP tool descriptions for `to`, `cc`, and `bcc` parameters to guide Claude toward using the preferred email address format: `Firstname Lastname <email>`.

## Changes

- `to`: "Prefer 'Firstname Lastname <email>' format"
- `cc`: "Prefer 'Firstname Lastname <email>' format"  
- `bcc`: "Prefer 'Firstname Lastname <email>' format"

🤖 Generated with [Claude Code](https://claude.com/claude-code)