### PR TITLE
feat(llm-image): add Nano Banana Pro support and fix provider adapters

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.21.8
+pkgver=0.21.9
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.21.8"
+version = "0.21.9"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/image/tool.py
+++ b/src/mcp_handley_lab/llm/image/tool.py
@@ -17,7 +17,8 @@ mcp = FastMCP("Image Tool")
 
 @mcp.tool(
     description="Generate an image from a text prompt. "
-    "Supports Gemini (imagen-*), OpenAI (dall-e-*), and Grok (grok-*-image) models. "
+    "Supports Gemini (imagen-*, gemini-*-image), OpenAI (dall-e-*), and Grok (grok-*-image) models. "
+    "Nano Banana models (gemini-*-image) support input_images for editing/reference. "
     "Returns: {file_path, file_size_bytes, model, provider, cost, enhanced_prompt?, original_prompt}."
 )
 def generate(
@@ -27,15 +28,21 @@ def generate(
     ),
     output_file: str = Field(
         ...,
-        description="File path to save the generated image (PNG format).",
+        description="File path to save the generated image. Nano Banana outputs JPEG, Imagen outputs PNG.",
     ),
     model: str = Field(
-        default="imagen-4.0-generate-001",
+        default="gemini-3-pro-image-preview",
         description="Image model. Provider auto-detected from name.",
+    ),
+    input_images: list[str] = Field(
+        default=[],
+        description="Input images for editing (Nano Banana models only). "
+        "Provide images to edit/transform based on the prompt. "
+        "Accepts: local paths, URLs, or data URIs.",
     ),
     size: str = Field(
         default="",
-        description="Image size (e.g., '1024x1024'). Provider-specific.",
+        description="Image size. For Nano Banana: '1K', '2K', '4K'. For others: '1024x1024'.",
     ),
     quality: str = Field(
         default="",
@@ -43,7 +50,7 @@ def generate(
     ),
     aspect_ratio: str = Field(
         default="",
-        description="Aspect ratio (e.g., '16:9'). Provider-specific.",
+        description="Aspect ratio. Nano Banana supports: 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9.",
     ),
 ) -> dict[str, Any]:
     """Generate an image from a text prompt."""
@@ -69,6 +76,8 @@ def generate(
         kwargs["quality"] = quality
     if aspect_ratio:
         kwargs["aspect_ratio"] = aspect_ratio
+    if input_images:
+        kwargs["input_images"] = input_images
 
     # Generate the image
     response_data = generation_func(prompt=prompt, model=canonical_model, **kwargs)

--- a/src/mcp_handley_lab/llm/providers/gemini/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/gemini/adapter.py
@@ -20,6 +20,7 @@ from google.genai.types import (
     GenerateImagesConfig,
     GoogleSearch,
     GoogleSearchRetrieval,
+    ImageConfig,
     Part,
     ThinkingConfig,
     Tool,
@@ -390,16 +391,105 @@ def image_analysis_adapter(
     }
 
 
-def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
-    """Gemini-specific image generation function with comprehensive metadata extraction."""
-    actual_model = model
+def _is_nano_banana_model(model: str) -> bool:
+    """Check if model is a Nano Banana model (uses generate_content API)."""
+    return "gemini-" in model and "-image" in model
 
-    # Extract config parameters for metadata
+
+def _generate_with_nano_banana(prompt: str, model: str, **kwargs) -> dict:
+    """Generate image using Nano Banana models via generate_content API."""
+    # Build image config for aspect ratio and size
+    image_config_params = {}
+    if aspect_ratio := kwargs.get("aspect_ratio"):
+        image_config_params["aspect_ratio"] = aspect_ratio
+    if image_size := kwargs.get("size"):
+        # Must be uppercase K (1K, 2K, 4K)
+        image_config_params["image_size"] = image_size.upper()
+
+    config_params = {"response_modalities": ["image", "text"]}
+    if image_config_params:
+        config_params["image_config"] = ImageConfig(**image_config_params)
+
+    config = GenerateContentConfig(**config_params)
+
+    # Build content parts: prompt text + any input images
+    content_parts = [Part(text=prompt)]
+    input_images = kwargs.get("input_images", [])
+    if input_images:
+        image_list = resolve_images(input_images)
+        for img in image_list:
+            # Convert PIL Image to bytes
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            img_bytes = buf.getvalue()
+            content_parts.append(
+                Part(
+                    inlineData=Blob(
+                        mimeType="image/png",
+                        data=base64.b64encode(img_bytes).decode(),
+                    )
+                )
+            )
+
+    response = get_client().models.generate_content(
+        model=model,
+        contents=content_parts,
+        config=config,
+    )
+
+    # Extract image from response parts
+    image_bytes = None
+    text_response = ""
+    mime_type = "image/png"
+
+    if response.candidates and response.candidates[0].content:
+        for part in response.candidates[0].content.parts:
+            if hasattr(part, "inline_data") and part.inline_data:
+                # SDK returns data as bytes or base64 string depending on version
+                raw_data = part.inline_data.data
+                if isinstance(raw_data, str):
+                    image_bytes = base64.b64decode(raw_data)
+                else:
+                    image_bytes = raw_data
+                mime_type = part.inline_data.mime_type or "image/png"
+            elif hasattr(part, "text") and part.text:
+                text_response = part.text
+
+    if not image_bytes:
+        raise RuntimeError(
+            f"No image generated. Model response: {text_response or 'empty'}"
+        )
+
+    # Extract token usage
+    input_tokens = 0
+    output_tokens = 1
+    if response.usage_metadata:
+        input_tokens = response.usage_metadata.prompt_token_count or 0
+        output_tokens = response.usage_metadata.candidates_token_count or 0
+
+    return {
+        "image_bytes": image_bytes,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "enhanced_prompt": "",
+        "original_prompt": prompt,
+        "mime_type": mime_type,
+        "text_response": text_response,
+        "gemini_metadata": {
+            "actual_model_used": model,
+            "requested_model": model,
+            "generation_type": "nano_banana",
+        },
+    }
+
+
+def _generate_with_imagen(prompt: str, model: str, **kwargs) -> dict:
+    """Generate image using Imagen models via generate_images API."""
     aspect_ratio = kwargs.get("aspect_ratio", "1:1")
     config = GenerateImagesConfig(number_of_images=1, aspect_ratio=aspect_ratio)
 
     response = get_client().models.generate_images(
-        model=actual_model,
+        model=model,
         prompt=prompt,
         config=config,
     )
@@ -407,7 +497,6 @@ def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
     if not response.generated_images or not response.generated_images[0].image:
         raise RuntimeError("Generated image has no data")
 
-    # Extract response data
     generated_image = response.generated_images[0]
     image = generated_image.image
 
@@ -420,16 +509,10 @@ def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
             "content_type": generated_image.safety_attributes.content_type,
         }
 
-    # Extract provider-specific metadata
-    gemini_metadata = {
-        "positive_prompt_safety_attributes": response.positive_prompt_safety_attributes,
-        "actual_model_used": actual_model,
-        "requested_model": model,
-    }
-
     return {
         "image_bytes": image.image_bytes,
-        "input_tokens": 0,  # Not used for Imagen pricing (per-image billing)
+        "input_tokens": 0,
+        "output_tokens": 1,
         "enhanced_prompt": generated_image.enhanced_prompt or "",
         "original_prompt": prompt,
         "aspect_ratio": aspect_ratio,
@@ -438,8 +521,26 @@ def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
         "cloud_uri": image.gcs_uri or "",
         "content_filter_reason": generated_image.rai_filtered_reason or "",
         "safety_attributes": safety_attributes,
-        "gemini_metadata": gemini_metadata,
+        "gemini_metadata": {
+            "positive_prompt_safety_attributes": response.positive_prompt_safety_attributes,
+            "actual_model_used": model,
+            "requested_model": model,
+            "generation_type": "imagen",
+        },
     }
+
+
+def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
+    """Gemini-specific image generation function.
+
+    Routes to appropriate API based on model type:
+    - Nano Banana models (gemini-*-image*): uses generate_content API
+    - Imagen models: uses generate_images API
+    """
+    if _is_nano_banana_model(model):
+        return _generate_with_nano_banana(prompt, model, **kwargs)
+    else:
+        return _generate_with_imagen(prompt, model, **kwargs)
 
 
 def list_api_models() -> set[str]:

--- a/src/mcp_handley_lab/llm/providers/grok/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/grok/adapter.py
@@ -4,7 +4,6 @@ Contains provider-specific generation functions that implement the Grok API call
 These adapters are used by the unified mcp-chat tool.
 """
 
-import base64
 import threading
 from typing import Any
 
@@ -260,33 +259,30 @@ def image_analysis_adapter(
 def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
     """Grok-specific image generation function with comprehensive metadata extraction."""
     # Use xai-sdk's image.sample method
+    # image_format="base64" returns raw bytes via response.image
     response = get_client().image.sample(
         prompt=prompt, model=model, image_format="base64"
     )
 
-    if not response or not response.images:
+    if not response or not response.image:
         raise RuntimeError("No image generated")
 
-    # Get the first (and typically only) image
-    image = response.images[0]
-
-    # Decode base64 image data
-    image_bytes = base64.b64decode(image.image_data)
+    # response.image returns raw image bytes directly (not base64 encoded)
+    image_bytes = response.image
 
     # Extract metadata
     grok_metadata = {
         "model_used": model,
-        "safety_rating": getattr(image, "safety_rating", None),
-        "finish_reason": getattr(image, "finish_reason", None),
     }
 
     return {
         "image_bytes": image_bytes,
-        "generation_timestamp": 0,  # Not provided by xai-sdk
-        "enhanced_prompt": "",  # Not provided by xai-sdk
+        "input_tokens": 0,
+        "output_tokens": 1,
+        "enhanced_prompt": getattr(response, "prompt", "") or "",
         "original_prompt": prompt,
-        "requested_format": "png",  # xai-sdk returns PNG
-        "mime_type": "image/png",
+        "requested_format": "jpg",  # xai-sdk returns JPG
+        "mime_type": "image/jpeg",
         "grok_metadata": grok_metadata,
     }
 

--- a/src/mcp_handley_lab/llm/providers/openai/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/openai/adapter.py
@@ -4,6 +4,7 @@ Contains provider-specific generation functions that implement the OpenAI API ca
 These adapters are used by the unified mcp-chat tool.
 """
 
+import base64
 import threading
 from typing import Any
 
@@ -315,6 +316,9 @@ def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
     size = kwargs.get("size", "1024x1024")
     quality = kwargs.get("quality", "standard")
 
+    # gpt-image-1 models only return b64_json (automatically, no param needed)
+    is_gpt_image = model.startswith("gpt-image")
+
     params = {"model": model, "prompt": prompt, "size": size, "n": 1}
     if model == "dall-e-3":
         params["quality"] = quality
@@ -328,11 +332,18 @@ def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
 
     image = response.data[0]
 
-    # Download the image
-    with httpx.Client() as http_client:
-        image_response = http_client.get(image.url)
-        image_response.raise_for_status()
-        image_bytes = image_response.content
+    # Get image bytes based on response format
+    if is_gpt_image or getattr(image, "b64_json", None):
+        # Decode base64 response
+        image_bytes = base64.b64decode(image.b64_json)
+        original_url = None
+    else:
+        # Download from URL
+        with httpx.Client() as http_client:
+            image_response = http_client.get(image.url)
+            image_response.raise_for_status()
+            image_bytes = image_response.content
+        original_url = image.url
 
     openai_metadata = {
         "background": getattr(response, "background", None),
@@ -342,14 +353,16 @@ def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
 
     return {
         "image_bytes": image_bytes,
+        "input_tokens": 0,
+        "output_tokens": 1,
         "generation_timestamp": response.created,
-        "enhanced_prompt": image.revised_prompt or "",
+        "enhanced_prompt": getattr(image, "revised_prompt", "") or "",
         "original_prompt": prompt,
         "requested_size": size,
         "requested_quality": quality,
         "requested_format": "png",
         "mime_type": "image/png",
-        "original_url": image.url,
+        "original_url": original_url,
         "openai_metadata": openai_metadata,
     }
 


### PR DESCRIPTION
## Summary
- Add Gemini Nano Banana (gemini-*-image) support using generate_content API with aspect_ratio and size controls
- Add input_images parameter for image editing/reference (Nano Banana models only)
- Fix Grok adapter to use correct xai-sdk response structure
- Fix OpenAI adapter to handle b64_json response for gpt-image-1 models

## Test plan
- [x] Test gemini-3-pro-image-preview (Nano Banana Pro)
- [x] Test aspect_ratio parameter (9:16 portrait)
- [x] Test size parameter (4K output)
- [x] Test input_images for editing
- [x] Test imagen-4.0-generate-001
- [x] Test imagen-4.0-fast-generate-001
- [x] Test imagen-4.0-ultra-generate-001
- [x] Test imagen-4.0-generate-preview-06-06
- [x] Test dall-e-3
- [x] Test gpt-image-1
- [x] Test gpt-image-1-mini
- [x] Test gpt-image-1.5
- [x] Test grok-2-image-1212

All 10 image generation models verified working.

🤖 Generated with [Claude Code](https://claude.ai/code)