### PR TITLE
fix(llm): auto-inject web_search_preview tool for deep research models (#115)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.21.10
+pkgver=0.21.10b1
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.21.10"
+version = "0.21.10b1"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/model_loader.py
+++ b/src/mcp_handley_lab/llm/model_loader.py
@@ -105,6 +105,9 @@ def build_model_configs_dict(provider: str) -> dict[str, dict[str, Any]]:
                     "supports_temperature": model_info.get(
                         "supports_temperature", True
                     ),
+                    "supports_reasoning": model_info.get("supports_reasoning", False),
+                    "supports_verbosity": model_info.get("supports_verbosity", False),
+                    "requires_web_search": model_info.get("requires_web_search", False),
                 }
         elif provider == "claude":
             # Claude format - require explicit values in YAML

--- a/src/mcp_handley_lab/llm/providers/openai/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/openai/adapter.py
@@ -120,6 +120,10 @@ def generation_adapter(
         if verbosity in ("low", "medium", "high"):
             request_params["text"] = {"verbosity": verbosity}
 
+    # Add required tools for deep research models
+    if model_config.get("requires_web_search", False):
+        request_params["tools"] = [{"type": "web_search_preview"}]
+
     # Make Responses API call
     response = get_client().responses.create(**request_params)
 

--- a/src/mcp_handley_lab/llm/providers/openai/models.yaml
+++ b/src/mcp_handley_lab/llm/providers/openai/models.yaml
@@ -186,6 +186,7 @@ models:
     param: "max_output_tokens"
     supports_temperature: false
     supports_reasoning: true
+    requires_web_search: true  # Deep research models require web_search_preview tool
 
     # Pricing
     input_per_1m: 10.00
@@ -220,6 +221,7 @@ models:
     param: "max_output_tokens"
     supports_temperature: false
     supports_reasoning: true
+    requires_web_search: true  # Deep research models require web_search_preview tool
 
     # Pricing
     input_per_1m: 2.00


### PR DESCRIPTION
## Summary
- Add `requires_web_search: true` flag to deep research models in YAML config
- Auto-inject `tools=[{"type": "web_search_preview"}]` in OpenAI adapter when flag is set
- Also pass through `supports_reasoning` and `supports_verbosity` flags in model_loader

Fixes #115 (partial - deep research models now work)

## Test plan
- [x] Verified locally via Python that `o4-mini-deep-research` returns a response
- [ ] Test via MCP after Claude Code restart

🤖 Generated with [Claude Code](https://claude.ai/code)