### PR TITLE
advertise pipx/uvx first in readme

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.23.1
+pkgver=0.23.2
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ cd mcp-handley-lab
 pipx install .
 ```
 
+### Arch Linux
+
+A PKGBUILD is included in the repository for native package manager integration:
+
+```bash
+git clone git@github.com:handley-lab/mcp-handley-lab.git
+cd mcp-handley-lab
+makepkg -si
+```
+
+This installs to `/usr/bin/` and is managed by pacman. Note that `uv` and `pipx` are also available in the official Arch repos (`pacman -S uv` or `pacman -S python-pipx`).
+
 ### Development Installation
 
 For contributors who want to modify the code:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.23.1"
+version = "0.23.2"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
### Description
Update the README to favour `uvx` as the install method. Adding a venv to the system path is not advised!

I asked claude to summarise reasons that adding a venv to path is scary:

1. Fragile — The path is tied to a specific directory. Move, rename, or delete the project and your shell config points to nothing (or worse, something unexpected).
2. No managed lifecycle — Unlike pipx/uv tool, there's no clean way to upgrade, uninstall, or list what you've installed this way. You're manually managing PATH entries in your shell config.
3. Shadowing risk — Tools in that venv silently override system tools with the same name, which can cause confusing behaviour.
4. Multiple projects — If you do this for several projects, the order in PATH determines which version wins. Easy to forget and hard to debug.
5. Defeats the purpose — Venvs are designed for project isolation with explicit activation. Permanently adding them to PATH blurs that boundary.

### Related Issue
Closes #159 (issue)

