### PR TITLE
fix(llm): create parent directories for output_file paths

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.24.3
+pkgver=0.24.4
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.24.3"
+version = "0.24.4"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/audio/tool.py
+++ b/src/mcp_handley_lab/llm/audio/tool.py
@@ -48,6 +48,8 @@ def transcribe(
     )
 
     if output_file:
-        Path(output_file).write_text(json.dumps(result, indent=2))
+        output_path = Path(output_file)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(result, indent=2))
 
     return result

--- a/src/mcp_handley_lab/llm/embeddings/tool.py
+++ b/src/mcp_handley_lab/llm/embeddings/tool.py
@@ -93,7 +93,9 @@ def get_embeddings(
     }
 
     if output_file:
-        Path(output_file).write_text(json.dumps(result, indent=2))
+        output_path = Path(output_file)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(result, indent=2))
 
     return result
 
@@ -172,7 +174,9 @@ def index_documents(
     }
 
     # Save index
-    Path(output_index_path).write_text(json.dumps(index, indent=2))
+    index_path = Path(output_index_path)
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(json.dumps(index, indent=2))
 
     return {
         "message": f"Indexed {len(documents)} documents",

--- a/src/mcp_handley_lab/llm/ocr/tool.py
+++ b/src/mcp_handley_lab/llm/ocr/tool.py
@@ -47,7 +47,9 @@ def process(
     }
 
     if output_file:
-        Path(output_file).write_text(json.dumps(result, indent=2))
+        output_path = Path(output_file)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(result, indent=2))
         response["output_file"] = output_file
         response["message"] += f" Full results saved to {output_file}"
 

--- a/src/mcp_handley_lab/llm/shared.py
+++ b/src/mcp_handley_lab/llm/shared.py
@@ -330,6 +330,7 @@ def process_llm_request(
     # Handle output - write to file if path provided
     if output_file:
         output_path = Path(output_file).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(metadata["response_text"])
 
     usage_stats = UsageStats(

--- a/tests/integration/test_llm_unhappy_paths.py
+++ b/tests/integration/test_llm_unhappy_paths.py
@@ -770,9 +770,22 @@ class TestLLMOutputFileErrors:
             # If successful, file should exist
             assert Path(output_file).exists()
 
-        except (ValueError, RuntimeError, FileNotFoundError, ToolError) as e:
-            # Directory creation errors are acceptable
+        except (
+            ValueError,
+            RuntimeError,
+            FileNotFoundError,
+            PermissionError,
+            ToolError,
+        ) as e:
+            # Directory creation or permission errors are acceptable
             assert any(
                 keyword in str(e).lower()
-                for keyword in ["directory", "not found", "no such", "path", "create"]
+                for keyword in [
+                    "directory",
+                    "not found",
+                    "no such",
+                    "path",
+                    "create",
+                    "permission",
+                ]
             )


### PR DESCRIPTION
## Summary
- Add `parent.mkdir(parents=True, exist_ok=True)` before writing output files in LLM tools
- Affects: audio transcription, embeddings (output_file + index), OCR, and chat output_file
- Prevents `FileNotFoundError` when `output_file` path includes non-existent directories

Replaces #163.

## Test plan
- [ ] Verify output files with nested paths are created successfully
- [ ] Verify existing paths still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>