### PR TITLE
feat(email): add body_file parameter for loading email content from files

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.24.2
+pkgver=0.24.3
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.24.2"
+version = "0.24.3"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/email/mutt/shared.py
+++ b/src/mcp_handley_lab/email/mutt/shared.py
@@ -3,14 +3,52 @@
 Identical interface to MCP tools, usable without MCP server.
 """
 
+from email.parser import HeaderParser
+from pathlib import Path
+
 from mcp_handley_lab.email.mutt.tool import _compose_email
 from mcp_handley_lab.shared.models import OperationResult
+
+
+def _load_body_file(path: str) -> tuple[str, dict[str, str]]:
+    """Load email content from a file, parsing RFC822 headers if present.
+
+    If the file starts with RFC822 headers (e.g. To:, Subject:) followed by
+    a blank line, headers are extracted and returned separately. Otherwise
+    the entire file content is returned as body text.
+
+    Returns:
+        (body_text, headers_dict) where headers_dict may contain:
+        to, subject, cc, bcc keys.
+    """
+    content = Path(path).read_text(encoding="utf-8")
+
+    # Check if file starts with RFC822 headers (Key: Value pattern)
+    lines = content.split("\n")
+    if lines and ":" in lines[0]:
+        # Try to parse as headers + body
+        msg = HeaderParser().parsestr(content)
+        headers = {}
+        for key, param in [
+            ("to", "To"),
+            ("subject", "Subject"),
+            ("cc", "Cc"),
+            ("bcc", "Bcc"),
+        ]:
+            value = msg.get(param)
+            if value:
+                headers[key] = value
+        body = msg.get_payload() or ""
+        return body, headers
+
+    return content, {}
 
 
 def send(
     to: str = "",
     subject: str = "",
     body: str = "",
+    body_file: str = "",
     cc: str | None = None,
     bcc: str | None = None,
     attachments: list[str] | None = None,
@@ -31,6 +69,9 @@ def send(
             Required for compose/forward, auto-populated for reply.
         subject: The subject line of the email.
         body: Email body text. For reply/forward, added above quoted/forwarded content.
+        body_file: Path to a file containing the email body. Supports RFC822 format
+            (headers + blank line + body). Headers from the file are used as defaults
+            unless overridden by explicit parameters. Mutually exclusive with body.
         cc: Carbon copy address. Prefer 'Firstname Lastname <email>' format.
         bcc: Blind carbon copy address. Prefer 'Firstname Lastname <email>' format.
         attachments: A list of local file paths to attach to the email.
@@ -44,6 +85,22 @@ def send(
     Returns:
         OperationResult with send status and details.
     """
+    if body and body_file:
+        raise ValueError("'body' and 'body_file' are mutually exclusive")
+
+    if body_file:
+        file_body, file_headers = _load_body_file(body_file)
+        body = file_body
+        # File headers are defaults — explicit params override
+        if not to and "to" in file_headers:
+            to = file_headers["to"]
+        if not subject and "subject" in file_headers:
+            subject = file_headers["subject"]
+        if cc is None and "cc" in file_headers:
+            cc = file_headers["cc"]
+        if bcc is None and "bcc" in file_headers:
+            bcc = file_headers["bcc"]
+
     if mode == "compose":
         if not to:
             raise ValueError("'to' is required for compose mode")

--- a/src/mcp_handley_lab/email/mutt/tool.py
+++ b/src/mcp_handley_lab/email/mutt/tool.py
@@ -716,6 +716,11 @@ def send(
         default="",
         description="Email body text. For reply/forward, added above quoted/forwarded content.",
     ),
+    body_file: str = Field(
+        default="",
+        description="Path to file containing email body. Supports RFC822 format (headers + blank line + body). "
+        "File headers (To, Subject, Cc, Bcc) used as defaults unless overridden. Mutually exclusive with body.",
+    ),
     cc: str = Field(
         default=None,
         description="Carbon copy address. Prefer 'Firstname Lastname <email>' format.",
@@ -751,6 +756,7 @@ def send(
         to=to,
         subject=subject,
         body=body,
+        body_file=body_file,
         cc=cc,
         bcc=bcc,
         attachments=attachments,


### PR DESCRIPTION
## Summary
- Add `body_file` parameter to email `send()` for loading content from files
- Supports RFC822 format: headers (To, Subject, Cc, Bcc) + blank line + body
- File headers are used as defaults unless explicitly overridden by parameters
- Mutually exclusive with `body` parameter

Replaces #94.

## Example Usage
```python
# Load a pre-composed email draft
send(body_file="/path/to/draft.eml")

# Load body from file, override recipient
send(body_file="/path/to/template.eml", to="alice@example.com")
```

## Test plan
- [ ] Verify plain text file loads as body
- [ ] Verify RFC822 file parses headers and body correctly
- [ ] Verify explicit params override file headers
- [ ] Verify body + body_file raises ValueError

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>