### PR TITLE
fix(terminal): replace tmux polling loop with wait-for channel

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.20
+pkgver=0.25.21
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.20"
+version = "0.25.21"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/common/terminal.py
+++ b/src/mcp_handley_lab/common/terminal.py
@@ -2,9 +2,7 @@
 
 import contextlib
 import os
-import re
 import subprocess
-import time
 import uuid
 
 
@@ -38,11 +36,10 @@ def launch_interactive(
     if in_tmux and prefer_tmux:
         if wait:
             unique_id = str(uuid.uuid4())[:8]
-            window_name = f"task-{unique_id}"
-            done_name = f"done-{unique_id}"
+            channel = f"wait-{unique_id}"
 
-            sync_command = f"{command}; tmux rename-window '{done_name}'"
-            tmux_cmd = ["tmux", "new-window", "-n", window_name, sync_command]
+            sync_command = f"{command}; tmux wait-for -S {channel}"
+            tmux_cmd = ["tmux", "new-window", sync_command]
 
             current_window = subprocess.check_output(
                 ["tmux", "display-message", "-p", "#{window_index}"], text=True
@@ -51,13 +48,7 @@ def launch_interactive(
             subprocess.run(tmux_cmd, check=True)
             print(f"Waiting for user input from {window_title or 'tmux window'}...")
 
-            while True:
-                output = subprocess.check_output(["tmux", "list-windows"], text=True)
-                if re.search(rf"{done_name}", output):
-                    break
-                if not re.search(rf"{window_name}", output):
-                    break
-                time.sleep(0.1)
+            subprocess.run(["tmux", "wait-for", channel], check=True)
 
             if current_window:
                 with contextlib.suppress(subprocess.CalledProcessError):


### PR DESCRIPTION
## Summary
- Replace busy-wait polling loop (`tmux list-windows` every 100ms) with native `tmux wait-for` channel
- Zero CPU while waiting for user input in interactive terminal windows (Mutt, Vim)

## Investigation
The polling loop spawned 10 subprocesses/second for the entire duration the user had an interactive window open. While our MCP server process was only at ~0.7% CPU, the `tmux` server itself was at ~8% from fielding all the polling requests.

Closes #158

## Test plan
- [ ] Send email via MCP, observe CPU while Mutt is open
- [ ] Verify tmux window returns focus after command completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)