### PR TITLE
fix: .doc detection, OCR text output, calendar notifications

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.24.5
+pkgver=0.24.6
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.24.5"
+version = "0.24.6"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/google_calendar/shared.py
+++ b/src/mcp_handley_lab/google_calendar/shared.py
@@ -218,7 +218,9 @@ def create(
         event_body["attendees"] = [{"email": email} for email in attendees]
 
     created_event = (
-        service.events().insert(calendarId=resolved_id, body=event_body).execute()
+        service.events()
+        .insert(calendarId=resolved_id, body=event_body, sendUpdates="all")
+        .execute()
     )
 
     start = created_event.get("start", {})
@@ -374,7 +376,12 @@ def update(
 
     updated_event = (
         service.events()
-        .patch(calendarId=resolved_id, eventId=event_id, body=update_body)
+        .patch(
+            calendarId=resolved_id,
+            eventId=event_id,
+            body=update_body,
+            sendUpdates="all",
+        )
         .execute()
     )
 

--- a/src/mcp_handley_lab/llm/ocr/tool.py
+++ b/src/mcp_handley_lab/llm/ocr/tool.py
@@ -52,5 +52,10 @@ def process(
         output_path.write_text(json.dumps(result, indent=2))
         response["output_file"] = output_file
         response["message"] += f" Full results saved to {output_file}"
+    else:
+        # Return extracted text directly when no output_file specified
+        response["text"] = "\n\n".join(
+            page.get("markdown", page.get("text", "")) for page in pages
+        )
 
     return response

--- a/src/mcp_handley_lab/microsoft/word/package.py
+++ b/src/mcp_handley_lab/microsoft/word/package.py
@@ -77,6 +77,14 @@ class WordPackage(OpcPackage):
     @classmethod
     def open(cls, file: str | Path | BinaryIO) -> WordPackage:
         """Open a .docx file."""
+        if isinstance(file, str | Path):
+            path = Path(file)
+            if path.suffix.lower() == ".doc":
+                raise ValueError(
+                    f"Legacy .doc format not supported: {path.name}. "
+                    "Convert to .docx first: "
+                    "libreoffice --headless --convert-to docx file.doc"
+                )
         pkg = cls()
         if isinstance(file, str | Path):
             with open(file, "rb") as f:


### PR DESCRIPTION
## Summary
- **#147**: Reject legacy `.doc` files in Word tool with clear error message suggesting `libreoffice --convert-to docx`
- **#154**: Return extracted text directly in OCR response when no `output_file` is specified
- **#128**: Add `sendUpdates="all"` to Google Calendar insert/patch so attendees receive invite notifications

Closes #147, closes #154, closes #128

## Test plan
- [ ] Word tool: verify `.doc` file gives clear ValueError, `.docx` still works
- [ ] OCR tool: verify response includes `text` field when no output_file given
- [ ] Calendar: verify attendees receive email invitations on create/update

🤖 Generated with [Claude Code](https://claude.com/claude-code)