### PR TITLE
fix(llm): improve chat description and add image preview to generate_image

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.3
+pkgver=0.25.4
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.3"
+version = "0.25.4"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/tool.py
+++ b/src/mcp_handley_lab/llm/tool.py
@@ -10,7 +10,8 @@ import os
 from pathlib import Path
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP, Image
+from mcp.types import TextContent
 from pydantic import Field
 
 from mcp_handley_lab.common.pricing import calculate_cost
@@ -37,12 +38,27 @@ def _resolve_session_branch(branch: str) -> str:
     return f"_session_{client_id}"
 
 
+def _detect_image_format(data: bytes) -> str:
+    """Detect image format from magic bytes."""
+    if len(data) < 12:
+        return "png"  # Too short to detect, default
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "png"
+    if data[:2] == b"\xff\xd8":
+        return "jpeg"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return "gif"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "webp"
+    return "png"  # Default fallback
+
+
 @mcp.tool(
     description="Send a message to an LLM. Provider is auto-detected from model name. "
     "Supports Gemini, OpenAI, Claude, Mistral, Grok, and Groq. "
-    "Use conversation tool to manage branches and retrieve past responses. "
-    "For vision/image analysis, provide images parameter with local paths or data URIs. "
-    "Returns: {content, usage: {input_tokens, output_tokens, cost, model_used}, branch}."
+    "Each response includes commit_sha - use from_ref to fork from any point. "
+    "Use conversation(log/show) to browse history. "
+    "Returns: {content, usage: {input_tokens, output_tokens, cost, model_used}, branch, commit_sha}."
 )
 def chat(
     prompt: str = Field(
@@ -199,7 +215,8 @@ def conversation(
     "Supports Gemini (imagen-*, gemini-*-image), OpenAI (dall-e-*), and Grok (grok-*-image) models. "
     "Use list_models() to discover available image models. "
     "Nano Banana models (gemini-*-image) support input_images for editing/reference. "
-    "Returns: {file_path, file_size_bytes, model, provider, cost, enhanced_prompt?, original_prompt}."
+    "Returns: [TextContent(JSON metadata), Image(preview)]. "
+    "Metadata includes: file_path, file_size_bytes, model, provider, cost, detected_format, enhanced_prompt, original_prompt."
 )
 def generate_image(
     prompt: str = Field(
@@ -240,7 +257,7 @@ def generate_image(
         default="",
         description="Aspect ratio. Nano Banana supports: 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9.",
     ),
-) -> dict[str, Any]:
+):  # No return type - allows mixed TextContent + Image content
     """Generate an image from a text prompt."""
     final_prompt = load_prompt_text(
         prompt or None, prompt_file or None, prompt_vars or None
@@ -271,7 +288,31 @@ def generate_image(
     response_data = generation_func(
         prompt=final_prompt, model=canonical_model, **kwargs
     )
+
+    # Defensive check for missing image_bytes
+    if "image_bytes" not in response_data:
+        raise ValueError(
+            f"Provider {provider} did not return image_bytes. "
+            f"Response keys: {list(response_data.keys())}"
+        )
+
+    # Ensure image_bytes is bytes (not base64 string)
     image_bytes = response_data["image_bytes"]
+    if isinstance(image_bytes, str):
+        import base64
+
+        try:
+            image_bytes = base64.b64decode(image_bytes, validate=True)
+        except Exception as e:
+            raise ValueError(f"Provider {provider} returned invalid base64: {e}") from e
+
+    # Validate image_bytes is valid
+    if not isinstance(image_bytes, bytes | bytearray) or len(image_bytes) == 0:
+        raise ValueError(
+            f"Provider {provider} returned invalid image_bytes: "
+            f"type={type(image_bytes).__name__}, len={len(image_bytes) if image_bytes else 0}"
+        )
+
     input_tokens = response_data.get("input_tokens", 0)
     output_tokens = response_data.get("output_tokens", 1)
 
@@ -283,15 +324,26 @@ def generate_image(
         canonical_model, input_tokens, output_tokens, provider, images_generated=1
     )
 
-    return {
+    # Detect actual format from bytes
+    detected_format = _detect_image_format(image_bytes)
+
+    # Build metadata dict
+    metadata = {
         "file_path": str(filepath),
         "file_size_bytes": len(image_bytes),
         "model": canonical_model,
         "provider": provider,
         "cost": cost,
+        "detected_format": detected_format,
         "enhanced_prompt": response_data.get("enhanced_prompt", ""),
         "original_prompt": final_prompt,
     }
+
+    # Return both metadata and image preview (matches word/render pattern)
+    return [
+        TextContent(type="text", text=json.dumps(metadata, indent=2)),
+        Image(data=image_bytes, format=detected_format),
+    ]
 
 
 @mcp.tool(

--- a/tests/integration/test_image_generation_integration.py
+++ b/tests/integration/test_image_generation_integration.py
@@ -5,6 +5,7 @@ The dummy API keys fixture in conftest.py allows the code to proceed
 to HTTP calls, where VCR intercepts and replays recorded responses.
 """
 
+import json
 import os
 import tempfile
 from pathlib import Path
@@ -13,6 +14,23 @@ import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
 from mcp_handley_lab.llm.tool import mcp
+
+
+def parse_image_result(result) -> tuple[dict, any]:
+    """Parse generate_image result into metadata dict and image.
+
+    FastMCP returns [TextContent(JSON metadata), Image(preview)] directly
+    when a function returns content objects.
+
+    Returns (metadata_dict, image_object).
+    """
+    assert isinstance(result, list), f"Expected list, got {type(result)}"
+    assert len(result) == 2, f"Expected 2 elements, got {len(result)}"
+    # First element is TextContent with JSON metadata
+    metadata = json.loads(result[0].text)
+    # Second element is Image
+    image = result[1]
+    return metadata, image
 
 
 @pytest.fixture
@@ -30,7 +48,8 @@ class TestOpenAIImageGeneration:
     @pytest.mark.asyncio
     async def test_dalle3_basic_generation(self, test_image_file):
         """Test DALL-E 3 basic image generation."""
-        _, result = await mcp.call_tool(
+        # FastMCP returns list directly when function returns content objects
+        result = await mcp.call_tool(
             "generate_image",
             {
                 "prompt": "A simple red circle",
@@ -41,19 +60,27 @@ class TestOpenAIImageGeneration:
             },
         )
 
+        # Parse metadata from [TextContent, Image] result
+        metadata, image = parse_image_result(result)
+
         # Verify core fields
-        assert Path(result["file_path"]).exists()
-        assert result["file_size_bytes"] > 0
-        assert result["model"] == "dall-e-3"
-        assert result["provider"] == "openai"
-        assert result["original_prompt"] == "A simple red circle"
-        assert result["cost"] > 0
+        assert Path(metadata["file_path"]).exists()
+        assert metadata["file_size_bytes"] > 0
+        assert metadata["model"] == "dall-e-3"
+        assert metadata["provider"] == "openai"
+        assert metadata["original_prompt"] == "A simple red circle"
+        assert metadata["cost"] > 0
+        assert metadata["detected_format"] in ("png", "jpeg")
+
+        # Verify Image content present (ImageContent has data and mimeType)
+        assert hasattr(image, "data")
+        assert hasattr(image, "mimeType") or hasattr(image, "format")
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
     async def test_dalle3_enhanced_prompt(self, test_image_file):
         """Test DALL-E 3 prompt enhancement."""
-        _, result = await mcp.call_tool(
+        result = await mcp.call_tool(
             "generate_image",
             {
                 "prompt": "A futuristic city",
@@ -64,19 +91,22 @@ class TestOpenAIImageGeneration:
             },
         )
 
+        # Parse metadata from [TextContent, Image] result
+        metadata, _ = parse_image_result(result)
+
         # Verify core fields
-        assert Path(result["file_path"]).exists()
-        assert result["file_size_bytes"] > 0
-        assert result["original_prompt"] == "A futuristic city"
+        assert Path(metadata["file_path"]).exists()
+        assert metadata["file_size_bytes"] > 0
+        assert metadata["original_prompt"] == "A futuristic city"
 
         # DALL-E 3 enhances prompts
-        assert result["enhanced_prompt"] != ""
+        assert metadata["enhanced_prompt"] != ""
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
     async def test_dalle3_portrait_size(self, test_image_file):
         """Test DALL-E 3 with portrait orientation."""
-        _, result = await mcp.call_tool(
+        result = await mcp.call_tool(
             "generate_image",
             {
                 "prompt": "A mountain landscape",
@@ -87,10 +117,13 @@ class TestOpenAIImageGeneration:
             },
         )
 
+        # Parse metadata from [TextContent, Image] result
+        metadata, _ = parse_image_result(result)
+
         # Verify image was generated
-        assert Path(result["file_path"]).exists()
-        assert result["file_size_bytes"] > 0
-        assert result["provider"] == "openai"
+        assert Path(metadata["file_path"]).exists()
+        assert metadata["file_size_bytes"] > 0
+        assert metadata["provider"] == "openai"
 
 
 class TestGeminiImageGeneration:
@@ -100,7 +133,7 @@ class TestGeminiImageGeneration:
     @pytest.mark.asyncio
     async def test_imagen3_basic_generation(self, test_image_file):
         """Test Imagen 3 basic image generation."""
-        _, result = await mcp.call_tool(
+        result = await mcp.call_tool(
             "generate_image",
             {
                 "prompt": "A peaceful garden",
@@ -109,19 +142,22 @@ class TestGeminiImageGeneration:
             },
         )
 
+        # Parse metadata from [TextContent, Image] result
+        metadata, _ = parse_image_result(result)
+
         # Verify core fields
-        assert Path(result["file_path"]).exists()
-        assert result["file_size_bytes"] > 0
-        assert result["model"] == "imagen-4.0-generate-001"
-        assert result["provider"] == "gemini"
-        assert result["original_prompt"] == "A peaceful garden"
-        assert result["cost"] >= 0
+        assert Path(metadata["file_path"]).exists()
+        assert metadata["file_size_bytes"] > 0
+        assert metadata["model"] == "imagen-4.0-generate-001"
+        assert metadata["provider"] == "gemini"
+        assert metadata["original_prompt"] == "A peaceful garden"
+        assert metadata["cost"] >= 0
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
     async def test_imagen3_with_aspect_ratio(self, test_image_file):
         """Test Imagen 3 with custom aspect ratio."""
-        _, result = await mcp.call_tool(
+        result = await mcp.call_tool(
             "generate_image",
             {
                 "prompt": "A safe, family-friendly cartoon character",
@@ -131,16 +167,19 @@ class TestGeminiImageGeneration:
             },
         )
 
+        # Parse metadata from [TextContent, Image] result
+        metadata, _ = parse_image_result(result)
+
         # Verify image was generated
-        assert Path(result["file_path"]).exists()
-        assert result["file_size_bytes"] > 0
-        assert result["provider"] == "gemini"
+        assert Path(metadata["file_path"]).exists()
+        assert metadata["file_size_bytes"] > 0
+        assert metadata["provider"] == "gemini"
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
     async def test_imagen_model_variants(self, test_image_file):
         """Test different Imagen model variants."""
-        _, result = await mcp.call_tool(
+        result = await mcp.call_tool(
             "generate_image",
             {
                 "prompt": "A modern abstract art piece",
@@ -149,10 +188,13 @@ class TestGeminiImageGeneration:
             },
         )
 
+        # Parse metadata from [TextContent, Image] result
+        metadata, _ = parse_image_result(result)
+
         # Verify model is correctly used
-        assert result["model"] == "imagen-4.0-generate-001"
-        assert result["original_prompt"] == "A modern abstract art piece"
-        assert result["provider"] == "gemini"
+        assert metadata["model"] == "imagen-4.0-generate-001"
+        assert metadata["original_prompt"] == "A modern abstract art piece"
+        assert metadata["provider"] == "gemini"
 
 
 class TestImageGenerationComparison:
@@ -170,7 +212,7 @@ class TestImageGenerationComparison:
             gemini_file = f2.name
 
         try:
-            _, openai_result = await mcp.call_tool(
+            openai_result = await mcp.call_tool(
                 "generate_image",
                 {
                     "prompt": prompt,
@@ -181,7 +223,7 @@ class TestImageGenerationComparison:
                 },
             )
 
-            _, gemini_result = await mcp.call_tool(
+            gemini_result = await mcp.call_tool(
                 "generate_image",
                 {
                     "prompt": prompt,
@@ -190,19 +232,24 @@ class TestImageGenerationComparison:
                 },
             )
 
+            # Parse metadata from [TextContent, Image] results
+            openai_metadata, _ = parse_image_result(openai_result)
+            gemini_metadata, _ = parse_image_result(gemini_result)
+
             # Both should have the same core structure
-            for result in [openai_result, gemini_result]:
-                assert "file_path" in result
-                assert "file_size_bytes" in result
-                assert "model" in result
-                assert "provider" in result
-                assert "cost" in result
-                assert "original_prompt" in result
-                assert "enhanced_prompt" in result
+            for metadata in [openai_metadata, gemini_metadata]:
+                assert "file_path" in metadata
+                assert "file_size_bytes" in metadata
+                assert "model" in metadata
+                assert "provider" in metadata
+                assert "cost" in metadata
+                assert "original_prompt" in metadata
+                assert "enhanced_prompt" in metadata
+                assert "detected_format" in metadata
 
             # Verify correct providers
-            assert openai_result["provider"] == "openai"
-            assert gemini_result["provider"] == "gemini"
+            assert openai_metadata["provider"] == "openai"
+            assert gemini_metadata["provider"] == "gemini"
         finally:
             Path(openai_file).unlink(missing_ok=True)
             Path(gemini_file).unlink(missing_ok=True)
@@ -219,7 +266,7 @@ class TestImageGenerationComparison:
             gemini_file = f2.name
 
         try:
-            _, openai_result = await mcp.call_tool(
+            openai_result = await mcp.call_tool(
                 "generate_image",
                 {
                     "prompt": prompt,
@@ -230,7 +277,7 @@ class TestImageGenerationComparison:
                 },
             )
 
-            _, gemini_result = await mcp.call_tool(
+            gemini_result = await mcp.call_tool(
                 "generate_image",
                 {
                     "prompt": prompt,
@@ -239,16 +286,20 @@ class TestImageGenerationComparison:
                 },
             )
 
+            # Parse metadata from [TextContent, Image] results
+            openai_metadata, _ = parse_image_result(openai_result)
+            gemini_metadata, _ = parse_image_result(gemini_result)
+
             # Both should preserve original prompt
-            assert openai_result["original_prompt"] == prompt
-            assert gemini_result["original_prompt"] == prompt
+            assert openai_metadata["original_prompt"] == prompt
+            assert gemini_metadata["original_prompt"] == prompt
 
             # DALL-E 3 should enhance prompts significantly
-            assert openai_result["enhanced_prompt"] != ""
-            assert len(openai_result["enhanced_prompt"]) > len(prompt)
+            assert openai_metadata["enhanced_prompt"] != ""
+            assert len(openai_metadata["enhanced_prompt"]) > len(prompt)
 
             # Gemini may or may not enhance prompts
-            assert isinstance(gemini_result["enhanced_prompt"], str)
+            assert isinstance(gemini_metadata["enhanced_prompt"], str)
         finally:
             Path(openai_file).unlink(missing_ok=True)
             Path(gemini_file).unlink(missing_ok=True)
@@ -291,18 +342,29 @@ if __name__ == "__main__":
         # Run basic smoke test
         if os.getenv("OPENAI_API_KEY"):
             print("Testing OpenAI...")
-            _, result = await mcp.call_tool(
+            result = await mcp.call_tool(
                 "generate_image",
-                {"prompt": "Test", "model": "dall-e-3", "size": "1024x1024"},
+                {
+                    "prompt": "Test",
+                    "model": "dall-e-3",
+                    "size": "1024x1024",
+                    "output_file": "/tmp/test_openai.png",
+                },
             )
-            print(f"Generated: {result['file_path']}")
+            metadata, _ = parse_image_result(result)
+            print(f"Generated: {metadata['file_path']}")
 
         if os.getenv("GEMINI_API_KEY"):
             print("Testing Gemini...")
-            _, result = await mcp.call_tool(
+            result = await mcp.call_tool(
                 "generate_image",
-                {"prompt": "Test", "model": "imagen-4.0-generate-001"},
+                {
+                    "prompt": "Test",
+                    "model": "imagen-4.0-generate-001",
+                    "output_file": "/tmp/test_gemini.png",
+                },
             )
-            print(f"Generated: {result['file_path']}")
+            metadata, _ = parse_image_result(result)
+            print(f"Generated: {metadata['file_path']}")
 
     asyncio.run(main())


### PR DESCRIPTION
## Summary

- Update chat tool description to highlight `commit_sha`/`from_ref` forking capability (#185)
- Change `generate_image` to return `[TextContent(metadata), Image(preview)]` so Claude Code can see generated images (#171)
- Add `_detect_image_format()` helper for magic byte detection (PNG, JPEG, GIF, WEBP)
- Add `detected_format` to metadata for transparency when format differs from file extension
- Add defensive validation for image_bytes (presence, type, base64 decode errors)

## Test plan

- [x] All 10 image generation integration tests pass
- [x] All 251 LLM-related tests pass
- [x] Verified tool descriptions updated via `list_models` inspection
- [x] OpenAI iterative review approved

Closes #185, closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)