### PR TITLE
feat(calendar): add recurring events support and fix CalendarInfo validation (#48, #49)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.4
+pkgver=0.25.5
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.4"
+version = "0.25.5"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/google_calendar/shared.py
+++ b/src/mcp_handley_lab/google_calendar/shared.py
@@ -16,11 +16,13 @@ from mcp_handley_lab.google_calendar.tool import (
     _get_calendar_service,
     _get_calendar_timezone,
     _get_normalization_patch,
+    _get_series_master_id,
     _has_timezone_inconsistency,
     _is_all_day_event,
     _parse_datetime_to_utc,
     _prepare_event_datetime,
     _resolve_calendar_id,
+    _validate_recurrence,
     _would_be_timed_event,
     logger,
 )
@@ -36,6 +38,9 @@ def read(
     search_fields: list[str] | None = None,
     case_sensitive: bool = False,
     match_all_terms: bool = True,
+    get_instances: bool = False,
+    time_min: str = "",
+    time_max: str = "",
 ) -> list[CalendarEvent]:
     """Read calendar events - either get by ID or search.
 
@@ -51,6 +56,9 @@ def read(
             None=API search only, []=search all fields.
         case_sensitive: If True, search is case-sensitive.
         match_all_terms: If True (AND), all words must match. If False (OR), any can match.
+        get_instances: If True with event_id, return all instances of the recurring series.
+        time_min: For get_instances: start of time range (YYYY-MM-DD). Defaults to today.
+        time_max: For get_instances: end of time range (YYYY-MM-DD). Defaults to 1 year from time_min.
 
     Returns:
         List of CalendarEvent objects.
@@ -63,6 +71,82 @@ def read(
             raise ValueError("Cannot use calendar_id='all' when fetching by event_id")
         resolved_id = _resolve_calendar_id(calendar_id, service)
         event = service.events().get(calendarId=resolved_id, eventId=event_id).execute()
+
+        # Get instances of recurring series
+        if get_instances:
+            master_id = _get_series_master_id(event)
+            if not master_id:
+                return []  # Not a recurring event
+
+            # Get calendar name for consistency
+            calendar_list_response = service.calendarList().list().execute()
+            calendar_name = resolved_id
+            for cal in calendar_list_response.get("items", []):
+                if cal["id"] == resolved_id:
+                    calendar_name = cal.get("summary", resolved_id)
+                    break
+
+            # Set time bounds (required for instances API)
+            # Use calendar's timezone for interpreting date-only inputs
+            calendar_tz = _get_calendar_timezone(service, resolved_id)
+
+            if not time_min:
+                # Default to start of today in calendar's timezone
+                today = datetime.now().strftime("%Y-%m-%d")
+                time_min_utc = _parse_datetime_to_utc(today, calendar_tz)
+            else:
+                time_min_utc = _parse_datetime_to_utc(time_min, calendar_tz)
+
+            if not time_max:
+                # Default to 1 year from time_min
+                time_min_dt = datetime.fromisoformat(
+                    time_min_utc.replace("Z", "+00:00")
+                )
+                time_max_dt = time_min_dt + timedelta(days=365)
+                time_max_utc = time_max_dt.isoformat().replace("+00:00", "Z")
+            else:
+                if "T" not in time_max:
+                    time_max = time_max + "T23:59:59"
+                time_max_utc = _parse_datetime_to_utc(time_max, calendar_tz)
+
+            # Fetch instances with pagination
+            all_instances: list[dict[str, Any]] = []
+            instances_result = (
+                service.events()
+                .instances(
+                    calendarId=resolved_id,
+                    eventId=master_id,
+                    timeMin=time_min_utc,
+                    timeMax=time_max_utc,
+                    maxResults=max_results,
+                    showDeleted=False,
+                )
+                .execute()
+            )
+
+            all_instances.extend(instances_result.get("items", []))
+
+            while "nextPageToken" in instances_result:
+                instances_result = (
+                    service.events()
+                    .instances(
+                        calendarId=resolved_id,
+                        eventId=master_id,
+                        timeMin=time_min_utc,
+                        timeMax=time_max_utc,
+                        maxResults=max_results,
+                        showDeleted=False,
+                        pageToken=instances_result["nextPageToken"],
+                    )
+                    .execute()
+                )
+                all_instances.extend(instances_result.get("items", []))
+
+            # Add calendar_name for consistency
+            for inst in all_instances:
+                inst["calendar_name"] = calendar_name
+
+            return [_build_event_model(inst) for inst in all_instances]
 
         if _has_timezone_inconsistency(event):
             logger.warning(
@@ -166,6 +250,7 @@ def create(
     start_timezone: str = "",
     end_timezone: str = "",
     attendees: list[str] | None = None,
+    recurrence: list[str] | None = None,
 ) -> CreatedEventResult:
     """Create a new calendar event with intelligent datetime parsing.
 
@@ -179,6 +264,7 @@ def create(
         start_timezone: Explicit IANA timezone for the start time (e.g., 'America/Los_Angeles').
         end_timezone: Explicit IANA timezone for the end time.
         attendees: A list of attendee email addresses to invite.
+        recurrence: Recurrence rules as RRULE strings (e.g., ['RRULE:FREQ=WEEKLY;COUNT=10']).
 
     Returns:
         CreatedEventResult with event details.
@@ -187,9 +273,15 @@ def create(
         - Natural language: create("Meeting", "tomorrow at 2pm", "tomorrow at 3pm")
         - Mixed timezones: create("Flight", "10:00am", "6:30pm",
             start_timezone="America/Los_Angeles", end_timezone="America/New_York")
+        - Recurring: create("Standup", "Monday 9am", "Monday 9:30am",
+            recurrence=["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;COUNT=50"])
     """
     service = _get_calendar_service()
     resolved_id = _resolve_calendar_id(calendar_id, service)
+
+    # Validate recurrence rules if provided
+    if recurrence:
+        _validate_recurrence(recurrence)
 
     # Get calendar's default timezone as fallback context
     calendar_tz = _get_calendar_timezone(service, resolved_id)
@@ -217,6 +309,9 @@ def create(
     if attendees:
         event_body["attendees"] = [{"email": email} for email in attendees]
 
+    if recurrence:
+        event_body["recurrence"] = recurrence
+
     created_event = (
         service.events()
         .insert(calendarId=resolved_id, body=event_body, sendUpdates="all")
@@ -238,6 +333,36 @@ def create(
     )
 
 
+def _merge_recurrence(existing: list[str], new: list[str] | None) -> list[str] | None:
+    """Merge recurrence rules, preserving EXDATE/RDATE unless explicitly provided.
+
+    Args:
+        existing: Current recurrence rules from the event
+        new: New recurrence rules. None=no change, []=clear all recurrence
+
+    Returns:
+        Merged recurrence rules, None if no change, or empty list to clear
+    """
+    if new is None:
+        return None  # No change
+
+    if new == []:
+        return []  # Clear all recurrence (convert to single event)
+
+    # Check if caller provided EXDATE/RDATE
+    new_has_exceptions = any(r.startswith(("EXDATE:", "RDATE:")) for r in new)
+
+    if new_has_exceptions:
+        # Caller provided full recurrence spec - use as-is
+        return new
+
+    # Caller only provided RRULE - preserve existing exceptions
+    existing_exceptions = [r for r in existing if r.startswith(("EXDATE:", "RDATE:"))]
+    new_rrules = [r for r in new if r.startswith("RRULE:")]
+
+    return new_rrules + existing_exceptions
+
+
 def update(
     event_id: str,
     calendar_id: str = "primary",
@@ -250,6 +375,8 @@ def update(
     start_timezone: str = "",
     end_timezone: str = "",
     normalize_timezone: bool = False,
+    update_series: bool = False,
+    recurrence: list[str] | None = None,
 ) -> UpdateEventResult:
     """Update or move a calendar event.
 
@@ -266,12 +393,25 @@ def update(
         start_timezone: New IANA timezone for start. If empty, preserves existing.
         end_timezone: New IANA timezone for end. If empty, preserves existing.
         normalize_timezone: Fix timezone inconsistencies (UTC time with non-UTC label).
+        update_series: If True, update the entire recurring series (resolves instance to master).
+        recurrence: New recurrence rules. None=no change. []=remove recurrence.
 
     Returns:
         UpdateEventResult with update details.
     """
     service = _get_calendar_service()
     resolved_id = _resolve_calendar_id(calendar_id, service)
+
+    # Validate recurrence parameter usage
+    if recurrence is not None and not update_series:
+        raise ValueError(
+            "Cannot modify recurrence without update_series=True. "
+            "Set update_series=True to modify the entire series."
+        )
+
+    # Validate recurrence rules if provided
+    if recurrence:
+        _validate_recurrence(recurrence)
 
     # Handle move operation
     if destination_calendar_id:
@@ -288,6 +428,11 @@ def update(
             raise ValueError(
                 "Cannot combine move (destination_calendar_id) with normalize_timezone. "
                 "Move first, then normalize in a separate call."
+            )
+        if update_series:
+            raise ValueError(
+                "Cannot combine move (destination_calendar_id) with update_series. "
+                "Move first, then update series in a separate call."
             )
 
         dest_resolved_id = _resolve_calendar_id(destination_calendar_id, service)
@@ -313,11 +458,26 @@ def update(
     update_body: dict[str, Any] = {}
     updated_fields: list[str] = []
 
+    # Determine target event ID (may need to resolve to master for series updates)
+    target_event_id = event_id
     current_event = None
-    if normalize_timezone or start_datetime or end_datetime:
+
+    if update_series or normalize_timezone or start_datetime or end_datetime:
         current_event = (
             service.events().get(calendarId=resolved_id, eventId=event_id).execute()
         )
+
+        # For series updates, resolve instance to master
+        if update_series:
+            master_id = _get_series_master_id(current_event)
+            if master_id and master_id != event_id:
+                # Need to fetch the master event
+                target_event_id = master_id
+                current_event = (
+                    service.events()
+                    .get(calendarId=resolved_id, eventId=master_id)
+                    .execute()
+                )
 
     if normalize_timezone and current_event:
         normalization_patch = _get_normalization_patch(current_event)
@@ -334,6 +494,19 @@ def update(
     if location is not None:
         update_body["location"] = location
         updated_fields.append("location")
+
+    # Handle recurrence updates (only valid with update_series=True, already validated above)
+    if recurrence is not None and current_event:
+        existing_recurrence = current_event.get("recurrence", [])
+        merged_recurrence = _merge_recurrence(existing_recurrence, recurrence)
+        if merged_recurrence is not None:
+            if merged_recurrence == []:
+                # Remove recurrence - Google API requires empty list to clear
+                update_body["recurrence"] = []
+                updated_fields.append("recurrence_removed")
+            else:
+                update_body["recurrence"] = merged_recurrence
+                updated_fields.append("recurrence")
 
     if start_datetime or end_datetime:
         calendar_tz = _get_calendar_timezone(service, resolved_id)
@@ -378,7 +551,7 @@ def update(
         service.events()
         .patch(
             calendarId=resolved_id,
-            eventId=event_id,
+            eventId=target_event_id,
             body=update_body,
             sendUpdates="all",
         )
@@ -386,6 +559,8 @@ def update(
     )
 
     result_msg = f"Event (ID: {updated_event['id']}) updated successfully."
+    if update_series and target_event_id != event_id:
+        result_msg = f"Series master (ID: {updated_event['id']}) updated successfully."
     if updated_fields:
         result_msg += f" Modified fields: {', '.join(updated_fields)}"
     if normalize_timezone and ("start" in update_body or "end" in update_body):
@@ -399,12 +574,15 @@ def update(
     )
 
 
-def delete(event_id: str, calendar_id: str = "primary") -> str:
+def delete(
+    event_id: str, calendar_id: str = "primary", delete_series: bool = False
+) -> str:
     """Delete a calendar event permanently.
 
     Args:
         event_id: The unique identifier of the event to delete.
         calendar_id: The calendar where the event is located. Defaults to primary.
+        delete_series: If True, delete entire recurring series (resolves instance to master).
 
     Returns:
         Confirmation message.
@@ -414,7 +592,19 @@ def delete(event_id: str, calendar_id: str = "primary") -> str:
     service = _get_calendar_service()
     resolved_id = _resolve_calendar_id(calendar_id, service)
 
-    service.events().delete(calendarId=resolved_id, eventId=event_id).execute()
+    target_event_id = event_id
+
+    # For series deletion, resolve instance to master
+    if delete_series:
+        event = service.events().get(calendarId=resolved_id, eventId=event_id).execute()
+        master_id = _get_series_master_id(event)
+        if master_id:
+            target_event_id = master_id
+
+    service.events().delete(calendarId=resolved_id, eventId=target_event_id).execute()
+
+    if delete_series and target_event_id != event_id:
+        return f"Recurring series (master ID: {target_event_id}) has been permanently deleted."
     return f"Event (ID: {event_id}) has been permanently deleted."
 
 
@@ -431,7 +621,8 @@ def list_calendars() -> list[CalendarInfo]:
             id=cal["id"],
             summary=cal.get("summary", "Unknown"),
             accessRole=cal.get("accessRole", "unknown"),
-            colorId=cal.get("colorId", "default"),
+            colorId=cal.get("colorId", ""),
         )
         for cal in calendar_list_response.get("items", [])
+        if "id" in cal  # Skip malformed entries (should never happen)
     ]

--- a/src/mcp_handley_lab/google_calendar/tool.py
+++ b/src/mcp_handley_lab/google_calendar/tool.py
@@ -79,6 +79,18 @@ class CalendarEvent(BaseModel):
         default="",
         description="The last modification time of the event as an ISO 8601 string.",
     )
+    recurrence: list[str] = Field(
+        default_factory=list,
+        description="RRULE/EXDATE/RDATE strings. Empty for single events or instances.",
+    )
+    recurringEventId: str = Field(
+        default="",
+        description="For instances: ID of parent series master. Empty for single events or masters.",
+    )
+    originalStartTime: EventDateTime | None = Field(
+        default=None,
+        description="For instances: scheduled start per recurrence rule (may differ from actual start if rescheduled).",
+    )
 
 
 class CreatedEventResult(BaseModel):
@@ -127,13 +139,17 @@ class CalendarInfo(BaseModel):
     """Calendar information."""
 
     id: str = Field(..., description="The unique identifier of the calendar.")
-    summary: str = Field(..., description="The title or name of the calendar.")
+    summary: str = Field(
+        default="Unknown",
+        description="The title or name of the calendar.",
+    )
     accessRole: str = Field(
-        ...,
+        default="unknown",
         description="The user's access level to the calendar (e.g., 'owner', 'reader', 'writer').",
     )
     colorId: str = Field(
-        ..., description="The color identifier used to display the calendar."
+        default="",
+        description="The color identifier used to display the calendar.",
     )
 
 
@@ -358,6 +374,13 @@ def _build_event_model(event_data: dict) -> CalendarEvent:
         for att in event_data.get("attendees", [])
     ]
 
+    # Parse originalStartTime for recurring event instances
+    original_start_raw = event_data.get("originalStartTime")
+    original_start = None
+    if original_start_raw:
+        original_start_normalized = _normalize_datetime_for_output(original_start_raw)
+        original_start = EventDateTime(**original_start_normalized)
+
     return CalendarEvent(
         id=event_data["id"],
         summary=event_data.get("summary", "No Title"),
@@ -369,6 +392,9 @@ def _build_event_model(event_data: dict) -> CalendarEvent:
         calendar_name=event_data.get("calendar_name", ""),
         created=event_data.get("created", ""),
         updated=event_data.get("updated", ""),
+        recurrence=event_data.get("recurrence", []),
+        recurringEventId=event_data.get("recurringEventId", ""),
+        originalStartTime=original_start,
     )
 
 
@@ -577,6 +603,58 @@ def _client_side_filter(
     return filtered_events
 
 
+def _get_series_master_id(event_data: dict) -> str | None:
+    """Get the master event ID for a recurring series.
+
+    Returns:
+        - event ID if event is a series master (has recurrence rules)
+        - recurringEventId if event is an instance of a series
+        - None if event is not recurring
+    """
+    if event_data.get("recurrence"):
+        return event_data["id"]
+    if event_data.get("recurringEventId"):
+        return event_data["recurringEventId"]
+    return None
+
+
+def _validate_recurrence(recurrence: list[str]) -> None:
+    """Validate recurrence rules. Raises ValueError if invalid.
+
+    Args:
+        recurrence: List of RRULE/EXDATE/RDATE strings
+
+    Raises:
+        ValueError: If any rule is invalid or has conflicting COUNT/UNTIL
+    """
+    if not recurrence:
+        return  # Empty list is valid (no recurrence)
+
+    has_count = False
+    has_until = False
+
+    for rule in recurrence:
+        rule = rule.strip()
+        if not rule:
+            raise ValueError("Empty recurrence rule string")
+
+        # Check valid prefix (case-sensitive per RFC 5545)
+        if not rule.startswith(("RRULE:", "EXDATE:", "RDATE:")):
+            raise ValueError(
+                f"Invalid recurrence rule: '{rule}'. "
+                "Must start with RRULE:, EXDATE:, or RDATE:"
+            )
+
+        if rule.startswith("RRULE:"):
+            if "COUNT=" in rule:
+                has_count = True
+            if "UNTIL=" in rule:
+                has_until = True
+
+    if has_count and has_until:
+        raise ValueError("Cannot use both COUNT and UNTIL in RRULE")
+
+
 # =============================================================================
 # MCP Resource: Calendars
 # =============================================================================
@@ -592,9 +670,10 @@ def calendar_list() -> list[CalendarInfo]:
             id=cal["id"],
             summary=cal.get("summary", "Unknown"),
             accessRole=cal.get("accessRole", "unknown"),
-            colorId=cal.get("colorId", "default"),
+            colorId=cal.get("colorId", ""),
         )
         for cal in calendar_list_response.get("items", [])
+        if "id" in cal  # Skip malformed entries (should never happen)
     ]
 
 
@@ -640,6 +719,18 @@ def read(
         True,
         description="If True (AND), all words must match. If False (OR), any can match.",
     ),
+    get_instances: bool = Field(
+        False,
+        description="If True with event_id, return all instances of the recurring series. Returns empty list if event is not recurring.",
+    ),
+    time_min: str = Field(
+        "",
+        description="For get_instances: start of time range (YYYY-MM-DD). Defaults to today.",
+    ),
+    time_max: str = Field(
+        "",
+        description="For get_instances: end of time range (YYYY-MM-DD). Defaults to 1 year from time_min.",
+    ),
 ) -> list[CalendarEvent]:
     """Read calendar events - either get by ID or search."""
     from mcp_handley_lab.google_calendar.shared import read as _read
@@ -654,6 +745,9 @@ def read(
         search_fields=search_fields,
         case_sensitive=case_sensitive,
         match_all_terms=match_all_terms,
+        get_instances=get_instances,
+        time_min=time_min,
+        time_max=time_max,
     )
 
 
@@ -677,8 +771,8 @@ def create(
         "", description="The physical location or meeting link for the event."
     ),
     calendar_id: str = Field(
-        ...,
-        description="The ID or name of the calendar to add the event to. Use calendar://list resource to discover options. Required parameter - no default.",
+        "primary",
+        description="The ID or name of the calendar to add the event to. Use calendar://list resource to discover options. Defaults to 'primary'.",
     ),
     start_timezone: str = Field(
         "",
@@ -688,9 +782,13 @@ def create(
         "",
         description="Explicit IANA timezone for the end time. Essential for events spanning timezones, like flights.",
     ),
-    attendees: list[str] = Field(
-        default_factory=list,
+    attendees: list[str] | None = Field(
+        None,
         description="A list of attendee email addresses to invite to the event.",
+    ),
+    recurrence: list[str] | None = Field(
+        None,
+        description="Recurrence rules as RRULE strings (e.g., ['RRULE:FREQ=WEEKLY;COUNT=10']). None for single event.",
     ),
 ) -> CreatedEventResult:
     """Create a new calendar event with intelligent datetime parsing and flexible timezone handling."""
@@ -706,6 +804,7 @@ def create(
         start_timezone=start_timezone,
         end_timezone=end_timezone,
         attendees=attendees,
+        recurrence=recurrence,
     )
 
 
@@ -753,6 +852,14 @@ def update(
         False,
         description="Fix timezone inconsistencies (UTC time with non-UTC label).",
     ),
+    update_series: bool = Field(
+        False,
+        description="If True, update the entire recurring series (resolves instance to master). If False, update only this instance/event.",
+    ),
+    recurrence: list[str] | None = Field(
+        None,
+        description="New recurrence rules. None=no change. Empty list=remove recurrence (convert to single event). Only valid with update_series=True.",
+    ),
 ) -> UpdateEventResult:
     """Update or move an event. Move and update are mutually exclusive."""
     from mcp_handley_lab.google_calendar.shared import update as _update
@@ -769,6 +876,8 @@ def update(
         start_timezone=start_timezone,
         end_timezone=end_timezone,
         normalize_timezone=normalize_timezone,
+        update_series=update_series,
+        recurrence=recurrence,
     )
 
 
@@ -783,8 +892,14 @@ def delete(
         "primary",
         description="The calendar where the event is located. Defaults to primary.",
     ),
+    delete_series: bool = Field(
+        False,
+        description="If True, delete entire recurring series (resolves instance to master). If False, delete only this instance.",
+    ),
 ) -> str:
     """Delete a calendar event permanently."""
     from mcp_handley_lab.google_calendar.shared import delete as _delete
 
-    return _delete(event_id=event_id, calendar_id=calendar_id)
+    return _delete(
+        event_id=event_id, calendar_id=calendar_id, delete_series=delete_series
+    )

--- a/tests/unit/test_google_calendar_recurring.py
+++ b/tests/unit/test_google_calendar_recurring.py
@@ -1,0 +1,194 @@
+"""Unit tests for Google Calendar recurring event functionality."""
+
+import pytest
+
+from mcp_handley_lab.google_calendar.shared import _merge_recurrence
+from mcp_handley_lab.google_calendar.tool import (
+    _build_event_model,
+    _get_series_master_id,
+    _validate_recurrence,
+)
+
+
+class TestValidateRecurrence:
+    """Tests for recurrence rule validation."""
+
+    def test_empty_list_is_valid(self):
+        """Empty list means no recurrence - valid."""
+        _validate_recurrence([])
+
+    def test_single_rrule_is_valid(self):
+        """Single RRULE is valid."""
+        _validate_recurrence(["RRULE:FREQ=WEEKLY;COUNT=10"])
+
+    def test_rrule_with_until_is_valid(self):
+        """RRULE with UNTIL is valid."""
+        _validate_recurrence(["RRULE:FREQ=WEEKLY;UNTIL=20261231T235959Z"])
+
+    def test_rrule_with_byday_is_valid(self):
+        """RRULE with BYDAY is valid."""
+        _validate_recurrence(["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"])
+
+    def test_multiple_rules_with_exdate(self):
+        """Multiple rules with EXDATE is valid."""
+        _validate_recurrence(["RRULE:FREQ=WEEKLY;COUNT=10", "EXDATE:20260115T090000Z"])
+
+    def test_multiple_rules_with_rdate(self):
+        """Multiple rules with RDATE is valid."""
+        _validate_recurrence(["RRULE:FREQ=WEEKLY", "RDATE:20260115T090000Z"])
+
+    def test_count_and_until_together_invalid(self):
+        """Cannot use both COUNT and UNTIL in RRULE."""
+        with pytest.raises(ValueError, match="Cannot use both COUNT and UNTIL"):
+            _validate_recurrence(["RRULE:FREQ=WEEKLY;COUNT=10;UNTIL=20261231T235959Z"])
+
+    def test_invalid_prefix_rejected(self):
+        """Invalid rule prefix is rejected."""
+        with pytest.raises(ValueError, match="Invalid recurrence rule"):
+            _validate_recurrence(["INVALID:FREQ=WEEKLY"])
+
+    def test_empty_string_rejected(self):
+        """Empty string rule is rejected."""
+        with pytest.raises(ValueError, match="Empty recurrence rule"):
+            _validate_recurrence([""])
+
+    def test_whitespace_only_rejected(self):
+        """Whitespace-only rule is rejected."""
+        with pytest.raises(ValueError, match="Empty recurrence rule"):
+            _validate_recurrence(["   "])
+
+
+class TestGetSeriesMasterId:
+    """Tests for series master ID resolution."""
+
+    def test_master_event_returns_own_id(self):
+        """Event with recurrence rules returns its own ID."""
+        event = {"id": "master123", "recurrence": ["RRULE:FREQ=WEEKLY"]}
+        assert _get_series_master_id(event) == "master123"
+
+    def test_instance_returns_master_id(self):
+        """Instance event returns its recurringEventId."""
+        event = {"id": "instance456", "recurringEventId": "master123"}
+        assert _get_series_master_id(event) == "master123"
+
+    def test_single_event_returns_none(self):
+        """Non-recurring event returns None."""
+        event = {"id": "single789"}
+        assert _get_series_master_id(event) is None
+
+    def test_prefers_recurrence_over_recurring_event_id(self):
+        """If both recurrence and recurringEventId exist, prefers recurrence (is master)."""
+        # This case shouldn't happen in practice, but tests priority
+        event = {
+            "id": "event123",
+            "recurrence": ["RRULE:FREQ=WEEKLY"],
+            "recurringEventId": "other456",
+        }
+        assert _get_series_master_id(event) == "event123"
+
+
+class TestMergeRecurrence:
+    """Tests for recurrence merge logic."""
+
+    def test_none_means_no_change(self):
+        """None input means no change to recurrence."""
+        existing = ["RRULE:FREQ=WEEKLY"]
+        assert _merge_recurrence(existing, None) is None
+
+    def test_empty_list_clears_recurrence(self):
+        """Empty list clears all recurrence (converts to single event)."""
+        existing = ["RRULE:FREQ=WEEKLY"]
+        assert _merge_recurrence(existing, []) == []
+
+    def test_new_rrule_preserves_exceptions(self):
+        """New RRULE preserves existing EXDATE/RDATE."""
+        existing = [
+            "RRULE:FREQ=WEEKLY;COUNT=10",
+            "EXDATE:20260115T090000Z",
+            "RDATE:20260120T090000Z",
+        ]
+        new = ["RRULE:FREQ=DAILY;COUNT=5"]
+        result = _merge_recurrence(existing, new)
+        assert "RRULE:FREQ=DAILY;COUNT=5" in result
+        assert "EXDATE:20260115T090000Z" in result
+        assert "RDATE:20260120T090000Z" in result
+        # Old RRULE should be replaced
+        assert "RRULE:FREQ=WEEKLY;COUNT=10" not in result
+
+    def test_full_spec_replaces_everything(self):
+        """If caller provides EXDATE/RDATE, use new spec as-is."""
+        existing = [
+            "RRULE:FREQ=WEEKLY;COUNT=10",
+            "EXDATE:20260115T090000Z",
+        ]
+        new = ["RRULE:FREQ=DAILY;COUNT=5", "EXDATE:20260122T090000Z"]
+        result = _merge_recurrence(existing, new)
+        assert result == new
+        # Old exception should not be preserved
+        assert "EXDATE:20260115T090000Z" not in result
+
+
+class TestBuildEventModelRecurrence:
+    """Tests for _build_event_model with recurring event fields."""
+
+    def test_builds_master_event_with_recurrence(self):
+        """Master event includes recurrence rules."""
+        event_data = {
+            "id": "master123",
+            "summary": "Weekly Meeting",
+            "start": {"dateTime": "2026-01-15T10:00:00+00:00", "timeZone": "UTC"},
+            "end": {"dateTime": "2026-01-15T11:00:00+00:00", "timeZone": "UTC"},
+            "recurrence": ["RRULE:FREQ=WEEKLY;COUNT=10"],
+        }
+        event = _build_event_model(event_data)
+        assert event.recurrence == ["RRULE:FREQ=WEEKLY;COUNT=10"]
+        assert event.recurringEventId == ""
+        assert event.originalStartTime is None
+
+    def test_builds_instance_with_original_start_time(self):
+        """Instance event includes recurringEventId and originalStartTime."""
+        event_data = {
+            "id": "instance456",
+            "summary": "Weekly Meeting",
+            "start": {"dateTime": "2026-01-22T10:30:00+00:00", "timeZone": "UTC"},
+            "end": {"dateTime": "2026-01-22T11:30:00+00:00", "timeZone": "UTC"},
+            "recurringEventId": "master123",
+            "originalStartTime": {
+                "dateTime": "2026-01-22T10:00:00+00:00",
+                "timeZone": "UTC",
+            },
+        }
+        event = _build_event_model(event_data)
+        assert event.recurrence == []
+        assert event.recurringEventId == "master123"
+        assert event.originalStartTime is not None
+        assert event.originalStartTime.dateTime == "2026-01-22T10:00:00+00:00"
+
+    def test_builds_single_event_with_empty_recurrence_fields(self):
+        """Single event has empty recurrence fields."""
+        event_data = {
+            "id": "single789",
+            "summary": "One-time Meeting",
+            "start": {"dateTime": "2026-01-15T10:00:00+00:00", "timeZone": "UTC"},
+            "end": {"dateTime": "2026-01-15T11:00:00+00:00", "timeZone": "UTC"},
+        }
+        event = _build_event_model(event_data)
+        assert event.recurrence == []
+        assert event.recurringEventId == ""
+        assert event.originalStartTime is None
+
+    def test_all_day_instance_with_date_original_start(self):
+        """All-day instance can have originalStartTime with date instead of dateTime."""
+        event_data = {
+            "id": "instance456",
+            "summary": "Weekly Review",
+            "start": {"date": "2026-01-22"},
+            "end": {"date": "2026-01-23"},
+            "recurringEventId": "master123",
+            "originalStartTime": {"date": "2026-01-22"},
+        }
+        event = _build_event_model(event_data)
+        assert event.recurringEventId == "master123"
+        assert event.originalStartTime is not None
+        assert event.originalStartTime.date == "2026-01-22"
+        assert event.originalStartTime.dateTime == ""


### PR DESCRIPTION
## Summary

- **Issue #48**: Fixed CalendarInfo model validation error (`'summary' is a required property`) by changing fields from required to having defaults
- **Issue #49**: Added full recurring events support for Google Calendar

## Changes

### CalendarInfo Fix (#48)
- Changed `summary`, `accessRole`, `colorId` fields from required (`...`) to defaulted values
- Added defensive `if "id" in cal` filter in calendar list comprehensions

### Recurring Events Support (#49)
- Added `recurrence`, `recurringEventId`, `originalStartTime` fields to `CalendarEvent` model
- Enhanced `read()` with `get_instances`, `time_min`, `time_max` parameters for listing instances
- Enhanced `create()` with `recurrence` parameter for creating recurring events
- Enhanced `update()` with `update_series`, `recurrence` parameters for series modification
- Enhanced `delete()` with `delete_series` parameter for deleting entire series
- Added helper functions: `_get_series_master_id()`, `_validate_recurrence()`, `_merge_recurrence()`

### Other Fixes
- Fixed recurrence clearing to use `[]` instead of `None`
- Fixed `create()` calendar_id default to `"primary"` in MCP tool to match shared.py
- Aligned `attendees`/`recurrence` params to use `None` default (not `[]`)
- Use calendar timezone for `get_instances` time bounds interpretation

## Test plan

- [x] All 104 Google Calendar unit tests pass
- [x] 22 new unit tests added for recurrence validation, series master ID resolution, and event model building
- [ ] Manual testing with real Google Calendar API

🤖 Generated with [Claude Code](https://claude.ai/code)