### PR TITLE
fix: remove unused chromadb optional dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.5
+pkgver=0.25.6
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.5"
+version = "0.25.6"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -61,9 +61,6 @@ dev = [
     "ruff>=0.1.0",
     "pre-commit>=3.0.0",
     "tomli>=2.0.0",
-]
-semantic = [
-    "chromadb>=1.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Removes the unused `semantic` optional dependency containing chromadb
- Fixes Python 3.14 compatibility issues (chromadb depends on onnxruntime which doesn't support 3.14 yet)

## Details
The `semantic = ["chromadb>=1.0.0"]` optional dependency was defined in pyproject.toml but never used anywhere in the codebase. Removing it:
1. Simplifies the dependency tree
2. Resolves #99 (Python 3.14 package conflict)

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)