### PR TITLE
feat: add MCP resources for model, email, and REPL discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -557,6 +557,35 @@ mcp__code2prompt__generate_prompt path="/path/to/code" output_file="/tmp/code_re
 mcp__llm__chat prompt="Review this code for improvements" agent_name="code_reviewer" model="gemini" files=["/tmp/code_review.md"]
 ```
 
+## MCP Resources
+
+MCP resources provide read-only discovery data that can be cached by clients. Check relevant resources before making tool calls that need discovery info.
+
+### Available Resources
+
+| Resource URI | Server | Description |
+|-------------|--------|-------------|
+| `calendar://list` | mcp-google-calendar | All accessible calendars with IDs, names, access levels |
+| `model://list` | mcp-llm | All LLM models grouped by provider with capabilities and pricing |
+| `email://tags` | mcp-email | All tags in the notmuch database |
+| `email://folders` | mcp-email | All maildir folders (Account/Folder format) |
+| `email://accounts` | mcp-email | All configured msmtp email accounts |
+| `repl://backends` | mcp-repl | All available REPL backends (bash, python, julia, etc.) |
+
+### Usage via JSON-RPC
+
+```bash
+# List available resources
+{"jsonrpc": "2.0", "id": 1, "method": "resources/list"}
+
+# Read a specific resource
+{"jsonrpc": "2.0", "id": 2, "method": "resources/read", "params": {"uri": "model://list"}}
+```
+
+### When to Use Resources vs Tools
+
+- **Resources**: Discovery, listing, static/semi-static data (calendars, models, folders)
+- **Tools**: Actions, mutations, queries with parameters (send email, create event, chat)
 
 ## Reference Documentation
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.6
+pkgver=0.25.7
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.6"
+version = "0.25.7"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/email/notmuch/tool.py
+++ b/src/mcp_handley_lab/email/notmuch/tool.py
@@ -850,13 +850,39 @@ def _list_accounts(config_file: str = "") -> list[str]:
     return accounts
 
 
+# =============================================================================
+# MCP Resources: Email Discovery
+# =============================================================================
+
+
+@mcp.resource("email://tags")
+def email_tags() -> list[str]:
+    """All tags in the notmuch email database."""
+    return _list_tags()
+
+
+@mcp.resource("email://folders")
+def email_folders() -> list[str]:
+    """All maildir folders in format 'Account/Folder'."""
+    return _list_folders()
+
+
+@mcp.resource("email://accounts")
+def email_accounts() -> list[str]:
+    """All configured msmtp email accounts."""
+    try:
+        return _list_accounts()
+    except FileNotFoundError:
+        return []  # No msmtprc configured
+
+
 # ============================================================================
 # Unified Tools
 # ============================================================================
 
 
 @mcp.tool(
-    description="""Search and read emails. Returns message IDs needed by send (for replies) and update (for tagging/moving). Supports notmuch query language: sender, subject, date ranges, tags, attachments, and body content filtering with boolean operators."""
+    description="""Search and read emails. Returns message IDs needed by send (for replies) and update (for tagging/moving). Use email://tags, email://folders, email://accounts resources to discover available options. Supports notmuch query language: sender, subject, date ranges, tags, attachments, and body content filtering with boolean operators."""
 )
 def read(
     query: str = Field(

--- a/src/mcp_handley_lab/llm/tool.py
+++ b/src/mcp_handley_lab/llm/tool.py
@@ -29,6 +29,12 @@ from mcp_handley_lab.shared.models import LLMResult  # noqa: F401 - used in type
 mcp = FastMCP("LLM Tool")
 
 
+@mcp.resource("model://list")
+def model_list() -> dict[str, list[dict[str, Any]]]:
+    """All available LLM models grouped by provider with capabilities and pricing."""
+    return list_all_models()
+
+
 def _resolve_session_branch(branch: str) -> str:
     """Resolve 'session' branch to client-scoped ID for MCP context."""
     if branch != "session":
@@ -56,8 +62,8 @@ def _detect_image_format(data: bytes) -> str:
 @mcp.tool(
     description="Send a message to an LLM. Provider is auto-detected from model name. "
     "Supports Gemini, OpenAI, Claude, Mistral, Grok, and Groq. "
-    "Each response includes commit_sha - use from_ref to fork from any point. "
-    "Use conversation(log/show) to browse history. "
+    "Use conversation tool to manage branches and retrieve past responses. "
+    "For vision/image analysis, provide images parameter with local paths or data URIs. "
     "Returns: {content, usage: {input_tokens, output_tokens, cost, model_used}, branch, commit_sha}."
 )
 def chat(
@@ -88,7 +94,7 @@ def chat(
         default="gemini",
         description="Model or provider name. Provider is inferred automatically. "
         "Use provider names (gemini, openai, claude) for latest defaults, "
-        "or specific model IDs. Run list_models() to see available options.",
+        "or specific model IDs. Use model://list resource or list_models() to see available options.",
     ),
     temperature: float = Field(
         default=1.0,
@@ -125,7 +131,7 @@ def chat(
     ),
     options: dict[str, Any] = Field(
         default_factory=dict,
-        description="Provider-specific options. Use list_models() to discover. "
+        description="Provider-specific options. Use model://list resource to discover. "
         "Examples: grounding (Gemini), reasoning_effort (OpenAI), enable_thinking (Claude).",
     ),
     from_ref: str = Field(
@@ -212,8 +218,8 @@ def conversation(
 
 @mcp.tool(
     description="Generate an image from a text prompt. "
+    "Use model://list resource to discover available image models. "
     "Supports Gemini (imagen-*, gemini-*-image), OpenAI (dall-e-*), and Grok (grok-*-image) models. "
-    "Use list_models() to discover available image models. "
     "Nano Banana models (gemini-*-image) support input_images for editing/reference. "
     "Returns: [TextContent(JSON metadata), Image(preview)]. "
     "Metadata includes: file_path, file_size_bytes, model, provider, cost, detected_format, enhanced_prompt, original_prompt."
@@ -348,7 +354,7 @@ def generate_image(
 
 @mcp.tool(
     description="Transcribe audio to text using Mistral Voxtral. "
-    "Supports MP3, WAV, FLAC, OGG, M4A. Use list_models() to discover audio models. "
+    "Supports MP3, WAV, FLAC, OGG, M4A. Use model://list resource to discover audio models. "
     "Returns: {text, segments?: [{start, end, text}]}. Segments included if include_timestamps=true."
 )
 def transcribe(
@@ -387,7 +393,7 @@ def transcribe(
 
 @mcp.tool(
     description="Extract text from documents using Mistral OCR. "
-    "Supports PDFs, images (PNG, JPG), PPTX, and DOCX. Use list_models() to discover OCR models. "
+    "Supports PDFs, images (PNG, JPG), PPTX, and DOCX. Use model://list resource to discover OCR models. "
     "Returns: {status, pages, output_file?, message}. Full OCR JSON saved to output_file if provided."
 )
 def ocr(

--- a/src/mcp_handley_lab/repl/tool.py
+++ b/src/mcp_handley_lab/repl/tool.py
@@ -6,6 +6,12 @@ from mcp_handley_lab.repl.backends import BACKENDS
 mcp = FastMCP("REPL Tool")
 
 
+@mcp.resource("repl://backends")
+def repl_backends() -> list[str]:
+    """All available REPL backends (bash, python, julia, etc.)."""
+    return sorted(BACKENDS.keys())
+
+
 @mcp.tool()
 def session(
     action: str,
@@ -17,6 +23,7 @@ def session(
 ) -> dict:
     """
     Manage REPL sessions. Create a session before using the eval tool.
+    Use repl://backends resource to discover available backends.
 
     Actions:
     - create: Create new session. Returns session_id for use with eval. Params: backend, name (optional), args (optional)


### PR DESCRIPTION
## Summary
- Add MCP resources (`model://list`, `email://tags`, `email://folders`, `email://accounts`, `repl://backends`) for read-only discovery data that clients can cache
- Update tool descriptions across LLM, email, and REPL tools to reference resources
- Document all 6 resources (including existing `calendar://list`) in CLAUDE.md

Closes #119

## Test plan
- [x] Verified all resource functions return correct data (model providers, email tags/folders/accounts, REPL backends)
- [x] Verified resources are registered with MCP servers (`_resource_manager._resources`)
- [x] All 326 existing tests pass (0 failures)
- [x] Iterative review with OpenAI approved after 2 iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)