### PR TITLE
docs: add MCP tool source locations and issue filing guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,49 @@ This is an MCP (Model Context Protocol) framework project designed to bridge var
 - **Academic Research**: ArXiv paper source code retrieval and analysis
 - **Persistent Memory**: Agent management with conversational memory for LLMs
 
+## Filing GitHub Issues for MCP Tool Bugs
+
+When you encounter a bug or issue in an MCP tool, file a GitHub issue with `gh issue create`. Reference the correct source file path so developers can locate the code.
+
+### MCP Tool Source Locations
+
+| MCP Server | Tool File | Description |
+|------------|-----------|-------------|
+| `mcp-llm` | `src/mcp_handley_lab/llm/tool.py` | Chat, vision, image gen, transcribe, OCR, models |
+| `mcp-llm-embeddings` | `src/mcp_handley_lab/llm/embeddings/tool.py` | Text embeddings & semantic search |
+| `mcp-email` | `src/mcp_handley_lab/email/tool.py` (entry); `email/notmuch/tool.py` (read/update), `email/mutt/tool.py` (send), `email/offlineimap/tool.py` (sync) | Email read/send/update/sync |
+| `mcp-google-calendar` | `src/mcp_handley_lab/google_calendar/tool.py` | Calendar CRUD & search |
+| `mcp-google-maps` | `src/mcp_handley_lab/google_maps/tool.py` | Directions & routes |
+| `mcp-repl` | `src/mcp_handley_lab/repl/tool.py` | REPL session management |
+| `mcp-mathematica` | `src/mcp_handley_lab/mathematica/tool.py` | Wolfram Language evaluation |
+| `mcp-word` | `src/mcp_handley_lab/microsoft/word/tool.py` | Word document read/edit |
+| `mcp-excel` | `src/mcp_handley_lab/microsoft/excel/tool.py` | Excel workbook read/edit |
+| `mcp-search` | `src/mcp_handley_lab/search/tool.py` | Conversation transcript search |
+| `mcp-screenshot` | `src/mcp_handley_lab/screenshot/tool.py` | Window/screen capture |
+| `mcp-code2prompt` | `src/mcp_handley_lab/code2prompt/tool.py` | Codebase summarization |
+| `mcp-arxiv` | `src/mcp_handley_lab/arxiv/tool.py` | ArXiv paper download |
+
+### Issue Template
+
+```bash
+gh issue create \
+  --title "fix(<server>): <short description>" \
+  --body "## Description
+<What happened vs what was expected>
+
+## Source
+Tool file: \`<path from table above>\`
+
+## Steps to Reproduce
+1. ...
+2. ...
+
+## Error Output
+\`\`\`
+<paste error>
+\`\`\`"
+```
+
 ## ⚠️ CRITICAL: VERSION MANAGEMENT REQUIRED FOR ALL CHANGES
 
 **BEFORE ANY COMMIT OR PR: ALWAYS BUMP VERSION USING THE AUTOMATED SCRIPT**

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.7
+pkgver=0.25.8
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.7"
+version = "0.25.8"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Add a table mapping all 13 MCP servers to their source file paths in CLAUDE.md
- Include an issue template with `gh issue create` for consistent bug reporting
- Placed early in CLAUDE.md so Claude references correct file paths when filing issues

## Test plan
- [x] Documentation-only change, no code modified
- [x] All file paths verified to exist in the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)