### PR TITLE
feat(word): add list creation, content controls, and hyperlink replace

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.0b1
+pkgver=0.25.0b3
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.0b1"
+version = "0.25.0b3"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/microsoft/word/document.py
+++ b/src/mcp_handley_lab/microsoft/word/document.py
@@ -144,6 +144,7 @@ from mcp_handley_lab.microsoft.word.ops.lists import (  # noqa: F401
     _resolve_abstract_num_id,
     _resolve_level_format,
     add_to_list,
+    create_list,
     demote_list_item,
     get_list_info,
     promote_list_item,
@@ -190,6 +191,7 @@ from mcp_handley_lab.microsoft.word.ops.revisions import (  # noqa: F401
 )
 from mcp_handley_lab.microsoft.word.ops.sdt import (  # noqa: F401
     _SDT_NSMAP,
+    _generate_sdt_id,
     _get_sdt_checked_state,
     _get_sdt_date_format,
     _get_sdt_dropdown_options,
@@ -200,6 +202,7 @@ from mcp_handley_lab.microsoft.word.ops.sdt import (  # noqa: F401
     _set_text_value,
     build_block_id_from_element,
     build_content_controls,
+    create_content_control,
     set_content_control_value,
 )
 from mcp_handley_lab.microsoft.word.ops.sections import (  # noqa: F401

--- a/src/mcp_handley_lab/microsoft/word/ops/__init__.py
+++ b/src/mcp_handley_lab/microsoft/word/ops/__init__.py
@@ -126,6 +126,8 @@ from mcp_handley_lab.microsoft.word.ops.lists import (
     _numbering_xpath,
     _resolve_abstract_num_id,
     _resolve_level_format,
+    add_to_list,
+    create_list,
     demote_list_item,
     get_list_info,
     promote_list_item,
@@ -169,6 +171,7 @@ from mcp_handley_lab.microsoft.word.ops.revisions import (
 )
 from mcp_handley_lab.microsoft.word.ops.sdt import (
     _SDT_NSMAP,
+    _generate_sdt_id,
     _get_sdt_checked_state,
     _get_sdt_date_format,
     _get_sdt_dropdown_options,
@@ -179,6 +182,7 @@ from mcp_handley_lab.microsoft.word.ops.sdt import (
     _set_text_value,
     build_block_id_from_element,
     build_content_controls,
+    create_content_control,
     set_content_control_value,
 )
 from mcp_handley_lab.microsoft.word.ops.sections import (
@@ -353,6 +357,8 @@ __all__ = [
     "demote_list_item",
     "restart_numbering",
     "remove_list_formatting",
+    "create_list",
+    "add_to_list",
     # Images
     "_WRAP_API_TO_XML",
     "_WRAP_XML_TO_API",
@@ -474,7 +480,9 @@ __all__ = [
     "_get_sdt_date_format",
     "build_block_id_from_element",
     "build_content_controls",
+    "create_content_control",
     "set_content_control_value",
+    "_generate_sdt_id",
     "_set_checkbox_value",
     "_set_dropdown_value",
     "_set_text_value",

--- a/src/mcp_handley_lab/microsoft/word/ops/core.py
+++ b/src/mcp_handley_lab/microsoft/word/ops/core.py
@@ -46,7 +46,10 @@ _CELL_RE = re.compile(r"^r(\d+)c(\d+)$")
 _PARA_RE = re.compile(r"^p(\d+)$")
 _TABLE_RE = re.compile(r"^tbl(\d+)$")
 
-# Unit conversions - import from common module
+# Unit conversions - re-export from common module for backwards compatibility
+from mcp_handley_lab.microsoft.common.constants import (
+    EMU_PER_INCH as _EMU_PER_INCH,  # noqa: F401
+)
 
 # PathSegment: (kind, indices) where kind='cell'|'para'|'tbl'
 PathSegment = tuple[str, tuple[int, ...]]

--- a/src/mcp_handley_lab/microsoft/word/ops/lists.py
+++ b/src/mcp_handley_lab/microsoft/word/ops/lists.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from lxml import etree
 from lxml.etree import ElementBase as _LxmlElementBase
 
-from mcp_handley_lab.microsoft.word.constants import qn
+from mcp_handley_lab.microsoft.word.constants import CT, RT, qn
 from mcp_handley_lab.microsoft.word.ops.core import mark_dirty
 
 # Namespace for numbering XPath queries
@@ -221,6 +221,8 @@ def set_list_level(pkg, p_el: etree._Element, level: int) -> None:
     Only works on paragraphs already in a list.
     Raises ValueError if paragraph is not in a list.
     """
+    if not 0 <= level <= 8:
+        raise ValueError(f"List level must be 0-8, got {level}")
     numPr = _require_numPr(p_el)
     _ensure_ilvl(numPr).set(qn("w:val"), str(level))
     mark_dirty(pkg)
@@ -357,6 +359,149 @@ def remove_list_formatting(pkg, p_el: etree._Element) -> None:
 
 
 # =============================================================================
+# List Creation
+# =============================================================================
+
+
+# Bullet characters per level (cycling pattern)
+_BULLET_CHARS = ["\u2022", "\u25cb", "\u25aa"]  # •, ○, ▪
+
+# Numbered format cycling pattern: (numFmt, lvlText_template)
+_NUMBERED_FMTS = [
+    ("decimal", "%{lvl}."),
+    ("lowerLetter", "%{lvl}."),
+    ("lowerRoman", "%{lvl}."),
+]
+
+
+def _ensure_numbering_xml(pkg) -> etree._Element:
+    """Ensure numbering.xml exists, creating it if missing.
+
+    Returns the root <w:numbering> element.
+    """
+    root = _get_numbering_xml(pkg)
+    if root is not None:
+        return root
+
+    # Create new numbering.xml
+    W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    root = etree.Element(qn("w:numbering"), nsmap={"w": W_NS})
+
+    # Register part with content type and relationship
+    pkg.set_xml("/word/numbering.xml", root, CT.WML_NUMBERING)
+    pkg.relate_to("/word/document.xml", "numbering.xml", RT.NUMBERING)
+
+    return root
+
+
+def _get_max_abstract_num_id(pkg) -> int:
+    """Get the maximum abstractNumId currently in use."""
+    numbering_xml = _get_numbering_xml(pkg)
+    if numbering_xml is None:
+        return -1
+
+    max_id = -1
+    for abs_num in _numbering_xpath(numbering_xml, ".//w:abstractNum"):
+        aid = int(abs_num.get(qn("w:abstractNumId"), "0"))
+        max_id = max(max_id, aid)
+    return max_id
+
+
+def create_list(
+    pkg,
+    p_el: etree._Element,
+    list_type: str = "bullet",
+    level: int = 0,
+) -> int:
+    """Create a new list and apply it to a paragraph.
+
+    Creates an abstract numbering definition with 9 levels (0-8),
+    a concrete w:num referencing it, and sets w:numPr on the paragraph.
+
+    Args:
+        pkg: WordPackage
+        p_el: w:p element to make into the first list item
+        list_type: "bullet" or "numbered"
+        level: Initial indentation level (0-8)
+
+    Returns the numId (for subsequent add_to_list calls).
+    """
+    if level < 0 or level > 8:
+        raise ValueError(f"List level must be 0-8, got {level}")
+    if list_type not in ("bullet", "numbered"):
+        raise ValueError(f"list_type must be 'bullet' or 'numbered', got {list_type!r}")
+
+    numbering_root = _ensure_numbering_xml(pkg)
+
+    # Create abstractNum with 9 levels
+    abstract_num_id = _get_max_abstract_num_id(pkg) + 1
+    abstract_num = etree.SubElement(numbering_root, qn("w:abstractNum"))
+    abstract_num.set(qn("w:abstractNumId"), str(abstract_num_id))
+
+    multi_level = etree.SubElement(abstract_num, qn("w:multiLevelType"))
+    multi_level.set(qn("w:val"), "hybridMultilevel")
+
+    for ilvl in range(9):
+        lvl_el = etree.SubElement(abstract_num, qn("w:lvl"))
+        lvl_el.set(qn("w:ilvl"), str(ilvl))
+
+        start_el = etree.SubElement(lvl_el, qn("w:start"))
+        start_el.set(qn("w:val"), "1")
+
+        num_fmt_el = etree.SubElement(lvl_el, qn("w:numFmt"))
+        lvl_text_el = etree.SubElement(lvl_el, qn("w:lvlText"))
+
+        if list_type == "bullet":
+            num_fmt_el.set(qn("w:val"), "bullet")
+            lvl_text_el.set(qn("w:val"), _BULLET_CHARS[ilvl % len(_BULLET_CHARS)])
+            # Add rPr with rFonts for bullet rendering
+            rPr = etree.SubElement(lvl_el, qn("w:rPr"))
+            rFonts = etree.SubElement(rPr, qn("w:rFonts"))
+            rFonts.set(qn("w:ascii"), "Calibri")
+            rFonts.set(qn("w:hAnsi"), "Calibri")
+        else:
+            fmt, tmpl = _NUMBERED_FMTS[ilvl % len(_NUMBERED_FMTS)]
+            num_fmt_el.set(qn("w:val"), fmt)
+            lvl_text_el.set(qn("w:val"), tmpl.format(lvl=ilvl + 1))
+
+        lvl_jc = etree.SubElement(lvl_el, qn("w:lvlJc"))
+        lvl_jc.set(qn("w:val"), "left")
+
+        pPr = etree.SubElement(lvl_el, qn("w:pPr"))
+        ind = etree.SubElement(pPr, qn("w:ind"))
+        ind.set(qn("w:left"), str(720 * (ilvl + 1)))
+        ind.set(qn("w:hanging"), "360")
+
+    # Create w:num referencing the abstractNum
+    num_id = _get_max_num_id(pkg) + 1
+    num_el = etree.SubElement(numbering_root, qn("w:num"))
+    num_el.set(qn("w:numId"), str(num_id))
+    abstract_ref = etree.SubElement(num_el, qn("w:abstractNumId"))
+    abstract_ref.set(qn("w:val"), str(abstract_num_id))
+
+    _mark_numbering_dirty(pkg)
+
+    # Set numPr on the target paragraph
+    pPr = _ensure_pPr(p_el)
+    numPr = _ensure_numPr(pPr)
+
+    # Set or update ilvl
+    ilvl_el = numPr.find(qn("w:ilvl"))
+    if ilvl_el is None:
+        ilvl_el = etree.SubElement(numPr, qn("w:ilvl"))
+    ilvl_el.set(qn("w:val"), str(level))
+
+    # Set or update numId
+    num_id_el = numPr.find(qn("w:numId"))
+    if num_id_el is None:
+        num_id_el = etree.SubElement(numPr, qn("w:numId"))
+    num_id_el.set(qn("w:val"), str(num_id))
+
+    mark_dirty(pkg)
+    return num_id
+
+
+# =============================================================================
 # Add List Item
 # =============================================================================
 
@@ -380,6 +525,9 @@ def add_to_list(
     Returns the new w:p element.
     Raises ValueError if reference paragraph is not in a list (no w:numPr).
     """
+    if position not in ("before", "after"):
+        raise ValueError(f"position must be 'before' or 'after', got {position!r}")
+
     # Get list info from reference
     list_info = get_list_info(pkg, reference_p_el)
     if list_info is None:
@@ -390,6 +538,8 @@ def add_to_list(
     # Determine level
     if level is None:
         level = list_info["level"]
+    if not 0 <= level <= 8:
+        raise ValueError(f"List level must be 0-8, got {level}")
 
     # Create new paragraph using reference's tag for namespace context
     new_p = etree.Element(reference_p_el.tag)

--- a/src/mcp_handley_lab/microsoft/word/ops/sdt.py
+++ b/src/mcp_handley_lab/microsoft/word/ops/sdt.py
@@ -49,7 +49,7 @@ def _get_sdt_type(sdt_pr) -> str:
     if sdt_pr.find("w:dropDownList", namespaces=_SDT_NSMAP) is not None:
         return "dropdown"
     if sdt_pr.find("w:comboBox", namespaces=_SDT_NSMAP) is not None:
-        return "dropdown"
+        return "comboBox"
     if sdt_pr.find("w:date", namespaces=_SDT_NSMAP) is not None:
         return "date"
     if sdt_pr.find("w15:color", namespaces=_SDT_NSMAP) is not None:
@@ -201,7 +201,11 @@ def build_content_controls(pkg) -> list[dict]:
 
         # Get type-specific info
         checked = _get_sdt_checked_state(sdt_pr) if sdt_type == "checkbox" else None
-        options = _get_sdt_dropdown_options(sdt_pr) if sdt_type == "dropdown" else []
+        options = (
+            _get_sdt_dropdown_options(sdt_pr)
+            if sdt_type in ("dropdown", "comboBox")
+            else []
+        )
         date_format = _get_sdt_date_format(sdt_pr) if sdt_type == "date" else None
 
         # Build block_id (find nearest parent paragraph or use document body)
@@ -271,7 +275,7 @@ def set_content_control_value(pkg, sdt_id: int, value: str) -> None:
 
         if sdt_type == "checkbox":
             _set_checkbox_value(sdt, sdt_pr, value)
-        elif sdt_type == "dropdown":
+        elif sdt_type in ("dropdown", "comboBox"):
             _set_dropdown_value(sdt, sdt_pr, value)
         else:
             # Text, richText, date, etc.
@@ -363,3 +367,156 @@ def _set_text_value(sdt: etree._Element, value: str) -> None:
     text = etree.SubElement(run, qn("w:t"))
     text.text = value
     sdt_content.append(p)
+
+
+# =============================================================================
+# SDT Creation
+# =============================================================================
+
+
+def _generate_sdt_id(anchor: etree._Element) -> int:
+    """Generate a unique SDT id by scanning all existing w:id values in the document tree."""
+    max_id = 0
+    root = anchor.getroottree().getroot()
+    for sdt in root.iter(qn("w:sdt")):
+        sdt_pr = sdt.find("w:sdtPr", namespaces=NSMAP)
+        if sdt_pr is not None:
+            id_el = sdt_pr.find("w:id", namespaces=NSMAP)
+            if id_el is not None:
+                val = int(id_el.get(qn("w:val"), "0"))
+                max_id = max(max_id, val)
+    return max_id + 1
+
+
+_VALID_SDT_TYPES = {"text", "richText", "dropdown", "comboBox", "checkbox", "date"}
+
+
+def create_content_control(
+    pkg,
+    body: etree._Element | None,
+    p_el: etree._Element,
+    sdt_type: str,
+    tag: str | None = None,
+    alias: str | None = None,
+    placeholder: str = "Click here",
+    position: str = "after",
+    options: list[str] | None = None,
+    checked: bool = False,
+    date_format: str = "yyyy-MM-dd",
+) -> etree._Element:
+    """Create a new block-level content control (SDT).
+
+    Args:
+        pkg: WordPackage
+        body: Deprecated, ignored. ID generation scans from p_el's root tree.
+        p_el: Reference paragraph element for insertion position
+        sdt_type: One of "text", "richText", "dropdown", "comboBox", "checkbox", "date"
+        tag: Optional tag string
+        alias: Optional alias/title string
+        placeholder: Placeholder text displayed in the content control
+        position: "before" or "after" the reference paragraph
+        options: List of option strings (for dropdown/comboBox)
+        checked: Initial checked state (for checkbox)
+        date_format: Date format string (for date type)
+
+    Returns the created w:sdt element.
+    """
+    if position not in ("before", "after"):
+        raise ValueError(f"position must be 'before' or 'after', got {position!r}")
+
+    if sdt_type not in _VALID_SDT_TYPES:
+        raise ValueError(
+            f"sdt_type must be one of {sorted(_VALID_SDT_TYPES)}, got {sdt_type!r}"
+        )
+
+    # Validate parent is a block-level context
+    parent = p_el.getparent()
+    if parent is None or parent.tag not in (qn("w:body"), qn("w:tc")):
+        raise ValueError(
+            "Content controls can only be inserted as siblings of block-level "
+            "elements (in w:body or w:tc)"
+        )
+
+    sdt_id = _generate_sdt_id(p_el)
+
+    # Build w:sdt
+    sdt = etree.Element(qn("w:sdt"))
+
+    # -- w:sdtPr --
+    sdt_pr = etree.SubElement(sdt, qn("w:sdtPr"))
+
+    id_el = etree.SubElement(sdt_pr, qn("w:id"))
+    id_el.set(qn("w:val"), str(sdt_id))
+
+    if tag:
+        tag_el = etree.SubElement(sdt_pr, qn("w:tag"))
+        tag_el.set(qn("w:val"), tag)
+
+    if alias:
+        alias_el = etree.SubElement(sdt_pr, qn("w:alias"))
+        alias_el.set(qn("w:val"), alias)
+
+    # Type-specific sdtPr children
+    ns_w14 = "http://schemas.microsoft.com/office/word/2010/wordml"
+
+    if sdt_type == "text":
+        etree.SubElement(sdt_pr, qn("w:text"))
+
+    elif sdt_type == "richText":
+        etree.SubElement(sdt_pr, qn("w:richText"))
+
+    elif sdt_type == "dropdown":
+        dd = etree.SubElement(sdt_pr, qn("w:dropDownList"))
+        for opt in options or []:
+            item = etree.SubElement(dd, qn("w:listItem"))
+            item.set(qn("w:displayText"), opt)
+            item.set(qn("w:value"), opt)
+
+    elif sdt_type == "comboBox":
+        cb = etree.SubElement(sdt_pr, qn("w:comboBox"))
+        for opt in options or []:
+            item = etree.SubElement(cb, qn("w:listItem"))
+            item.set(qn("w:displayText"), opt)
+            item.set(qn("w:value"), opt)
+
+    elif sdt_type == "checkbox":
+        checkbox = etree.SubElement(
+            sdt_pr, f"{{{ns_w14}}}checkbox", nsmap={"w14": ns_w14}
+        )
+        checked_el = etree.SubElement(checkbox, f"{{{ns_w14}}}checked")
+        checked_el.set(f"{{{ns_w14}}}val", "1" if checked else "0")
+        checked_state = etree.SubElement(checkbox, f"{{{ns_w14}}}checkedState")
+        checked_state.set(f"{{{ns_w14}}}val", "2612")
+        checked_state.set(f"{{{ns_w14}}}font", "MS Gothic")
+        unchecked_state = etree.SubElement(checkbox, f"{{{ns_w14}}}uncheckedState")
+        unchecked_state.set(f"{{{ns_w14}}}val", "2610")
+        unchecked_state.set(f"{{{ns_w14}}}font", "MS Gothic")
+
+    elif sdt_type == "date":
+        date_el = etree.SubElement(sdt_pr, qn("w:date"))
+        date_fmt = etree.SubElement(date_el, qn("w:dateFormat"))
+        date_fmt.set(qn("w:val"), date_format)
+        lid = etree.SubElement(date_el, qn("w:lid"))
+        lid.set(qn("w:val"), "en-US")
+        store = etree.SubElement(date_el, qn("w:storeMappedDataAs"))
+        store.set(qn("w:val"), "dateTime")
+
+    # -- w:sdtContent --
+    sdt_content = etree.SubElement(sdt, qn("w:sdtContent"))
+    p = etree.SubElement(sdt_content, qn("w:p"))
+    run = etree.SubElement(p, qn("w:r"))
+    t = etree.SubElement(run, qn("w:t"))
+
+    if sdt_type == "checkbox":
+        t.text = "\u2612" if checked else "\u2610"
+    else:
+        t.text = placeholder
+
+    # Insert relative to reference paragraph
+    if position == "before":
+        p_el.addprevious(sdt)
+    else:
+        p_el.addnext(sdt)
+
+    mark_dirty(pkg)
+    return sdt

--- a/src/mcp_handley_lab/microsoft/word/ops/styles.py
+++ b/src/mcp_handley_lab/microsoft/word/ops/styles.py
@@ -309,6 +309,7 @@ def add_hyperlink(
     text: str,
     address: str = "",
     fragment: str = "",
+    replace: bool = False,
 ) -> None:
     """Add hyperlink to paragraph.
 
@@ -318,6 +319,8 @@ def add_hyperlink(
         text: Visible link text
         address: URL or file path (external link)
         fragment: Bookmark name (internal link) or URL anchor
+        replace: If True, remove all existing content (preserving only w:pPr)
+                 before adding the hyperlink. Prevents text duplication.
 
     Either address or fragment must be provided.
     For external links: address="https://example.com"
@@ -363,6 +366,13 @@ def add_hyperlink(
     run_text.text = text
     run.append(run_text)
     hyperlink.append(run)
+
+    # Optionally clear all content (preserve only pPr) before adding
+    if replace:
+        pPr_tag = qn("w:pPr")
+        for child in list(p_el):
+            if child.tag != pPr_tag:
+                p_el.remove(child)
 
     # Append hyperlink to paragraph
     p_el.append(hyperlink)

--- a/src/mcp_handley_lab/microsoft/word/tool.py
+++ b/src/mcp_handley_lab/microsoft/word/tool.py
@@ -353,6 +353,19 @@ def _apply_operation(pkg: WordPackage, file_path: str, params: dict) -> OpResult
         word_ops.remove_list_formatting(pkg, p_el)
         message = "Removed list formatting"
 
+    elif operation == "create_list":
+        t = word_ops.resolve_target(pkg, target_id)
+        from mcp_handley_lab.microsoft.word.constants import qn as _qn
+
+        if t.leaf_el.tag != _qn("w:p"):
+            raise ValueError("create_list requires a paragraph target")
+        data = json.loads(content_data) if content_data else {}
+        list_type = data.get("list_type", "bullet")
+        level = data.get("level", 0)
+        num_id = word_ops.create_list(pkg, t.leaf_el, list_type, level)
+        element_id = word_ops.get_element_id_ooxml(pkg, t.leaf_el)
+        message = f"Created {list_type} list (numId={num_id})"
+
     elif operation == "add_to_list":
         t = word_ops.resolve_target(pkg, target_id)
         if t.base_kind not in (
@@ -473,6 +486,49 @@ def _apply_operation(pkg: WordPackage, file_path: str, params: dict) -> OpResult
         word_ops.set_content_control_value(pkg, sdt_id, content_data)
         element_id = ""
         message = f"Set content control {sdt_id} to '{content_data}'"
+
+    elif operation == "create_content_control":
+        if not target_id:
+            raise ValueError("target_id required for create_content_control")
+        if not content_data:
+            raise ValueError(
+                "content_data (JSON with type and optional tag/alias/options) "
+                "required for create_content_control"
+            )
+        data = json.loads(content_data)
+        sdt_type_val = data.get("type", "text")
+        t = word_ops.resolve_target(pkg, target_id)
+        from mcp_handley_lab.microsoft.word.constants import qn as _qn
+
+        if t.leaf_el.tag != _qn("w:p"):
+            raise ValueError("create_content_control requires a paragraph target")
+        parent = t.leaf_el.getparent()
+        if parent is None or parent.tag not in (_qn("w:body"), _qn("w:tc")):
+            raise ValueError(
+                "Content controls can only be inserted in block-level contexts "
+                "(w:body or w:tc)"
+            )
+        sdt_el = word_ops.create_content_control(
+            pkg,
+            None,
+            t.leaf_el,
+            sdt_type=sdt_type_val,
+            tag=data.get("tag"),
+            alias=data.get("alias"),
+            placeholder=data.get("placeholder", "Click here"),
+            position=data.get("position", "after"),
+            options=data.get("options"),
+            checked=data.get("checked", False),
+            date_format=data.get("date_format", "yyyy-MM-dd"),
+        )
+        # Extract the SDT id for the response (numeric id usable with set_content_control)
+        sdt_pr = sdt_el.find(_qn("w:sdtPr"))
+        id_el = sdt_pr.find(_qn("w:id")) if sdt_pr is not None else None
+        created_id = id_el.get(_qn("w:val")) if id_el is not None else ""
+        if not created_id or not created_id.isdigit():
+            raise ValueError("Failed to determine created content control id")
+        element_id = created_id
+        message = f"Created {sdt_type_val} content control (id={created_id})"
 
     elif operation == "set_margins":
         margins = json.loads(formatting)
@@ -689,7 +745,8 @@ def _apply_operation(pkg: WordPackage, file_path: str, params: dict) -> OpResult
                 f"Cannot add hyperlink to {target.leaf_kind}. "
                 "Hyperlinks can only be added to paragraphs or table cells."
             )
-        word_ops.add_hyperlink(pkg, p_el, text, address, fragment)
+        replace = link_data.get("replace", False)
+        word_ops.add_hyperlink(pkg, p_el, text, address, fragment, replace)
         if target.leaf_kind == "cell":
             element_id = word_ops.get_element_id_ooxml(pkg, target.base_el)
         else:
@@ -912,13 +969,13 @@ def render(
 
 
 @mcp.tool(
-    description="Edit Word document with batch operations. Supported ops: 'insert_before', 'insert_after', 'append', 'delete', 'replace', 'style', 'edit_cell', 'edit_run', 'edit_style', 'add_comment', 'reply_comment', 'resolve_comment', 'unresolve_comment', 'set_header', 'set_footer', 'set_first_page_header', 'set_first_page_footer', 'set_even_page_header', 'set_even_page_footer', 'append_header', 'append_footer', 'clear_header', 'clear_footer', 'set_margins', 'set_orientation', 'set_columns', 'set_line_numbering', 'set_page_borders', 'set_custom_property', 'delete_custom_property', 'create_style', 'delete_style', 'insert_image', 'insert_floating_image', 'delete_image', 'add_row', 'add_column', 'delete_row', 'delete_column', 'add_page_break', 'add_break', 'set_meta', 'add_section', 'merge_cells', 'set_table_alignment', 'set_table_autofit', 'set_table_fixed_layout', 'set_row_height', 'set_cell_width', 'set_cell_vertical_alignment', 'set_cell_borders', 'set_cell_shading', 'set_header_row', 'add_tab_stop', 'clear_tab_stops', 'insert_field', 'insert_page_x_of_y', 'accept_change', 'reject_change', 'accept_all_changes', 'reject_all_changes', 'set_list_level', 'promote_list', 'demote_list', 'restart_numbering', 'remove_list', 'add_to_list', 'edit_text_box', 'add_bookmark', 'add_hyperlink', 'insert_cross_ref', 'insert_caption', 'insert_toc', 'update_toc', 'add_footnote', 'delete_footnote', 'set_content_control', 'add_source', 'delete_source', 'insert_citation', 'insert_bibliography'. Block IDs are content-addressed and CHANGE when content changes or after inserts/deletes shift occurrence index. Always use element_id from response for chaining operations on modified content. Use separate create() tool to create new documents. 'update_toc' sets dirty flag; Word updates content on open. 'add_to_list' adds a new paragraph to an existing list; content_data: {\"text\": \"...\", \"position\": \"before|after\", \"level\": 0-8 (optional)}."
+    description="Edit Word document with batch operations. Supported ops: 'insert_before', 'insert_after', 'append', 'delete', 'replace', 'style', 'edit_cell', 'edit_run', 'edit_style', 'add_comment', 'reply_comment', 'resolve_comment', 'unresolve_comment', 'set_header', 'set_footer', 'set_first_page_header', 'set_first_page_footer', 'set_even_page_header', 'set_even_page_footer', 'append_header', 'append_footer', 'clear_header', 'clear_footer', 'set_margins', 'set_orientation', 'set_columns', 'set_line_numbering', 'set_page_borders', 'set_custom_property', 'delete_custom_property', 'create_style', 'delete_style', 'insert_image', 'insert_floating_image', 'delete_image', 'add_row', 'add_column', 'delete_row', 'delete_column', 'add_page_break', 'add_break', 'set_meta', 'add_section', 'merge_cells', 'set_table_alignment', 'set_table_autofit', 'set_table_fixed_layout', 'set_row_height', 'set_cell_width', 'set_cell_vertical_alignment', 'set_cell_borders', 'set_cell_shading', 'set_header_row', 'add_tab_stop', 'clear_tab_stops', 'insert_field', 'insert_page_x_of_y', 'accept_change', 'reject_change', 'accept_all_changes', 'reject_all_changes', 'create_list', 'set_list_level', 'promote_list', 'demote_list', 'restart_numbering', 'remove_list', 'add_to_list', 'edit_text_box', 'add_bookmark', 'add_hyperlink', 'insert_cross_ref', 'insert_caption', 'insert_toc', 'update_toc', 'add_footnote', 'delete_footnote', 'set_content_control', 'create_content_control', 'add_source', 'delete_source', 'insert_citation', 'insert_bibliography'. Block IDs are content-addressed and CHANGE when content changes or after inserts/deletes shift occurrence index. Always use element_id from response for chaining operations on modified content. Use separate create() tool to create new documents. 'update_toc' sets dirty flag; Word updates content on open. 'add_to_list' adds a new paragraph to an existing list; content_data: {\"text\": \"...\", \"position\": \"before|after\", \"level\": 0-8 (optional)}. 'add_hyperlink' content_data: {\"text\": \"...\", \"address\"?: \"...\", \"fragment\"?: \"...\", \"replace\"?: true}."
 )
 def edit(
     file_path: str = Field(..., description="Path to .docx file"),
     ops: str = Field(
         ...,
-        description='JSON array of operation objects. Each object must have an "op" field and operation-specific parameters. Example: [{"op": "edit_cell", "target_id": "table_abc_0", "row": 0, "col": 0, "content_data": "A1"}]. Use $prev[N] in target_id to reference element_id from operation N (0-indexed). Supported ops: insert_before, insert_after, append, delete, replace, style, edit_cell, edit_run, edit_style, add_comment, reply_comment, resolve_comment, unresolve_comment, set_header, set_footer, set_first_page_header, set_first_page_footer, set_even_page_header, set_even_page_footer, append_header, append_footer, clear_header, clear_footer, set_margins, set_orientation, set_columns, set_line_numbering, set_page_borders, set_custom_property, delete_custom_property, create_style, delete_style, insert_image, insert_floating_image, delete_image, add_row, add_column, delete_row, delete_column, add_page_break, add_break, set_meta, add_section, merge_cells, set_table_alignment, set_table_autofit, set_table_fixed_layout, set_row_height, set_cell_width, set_cell_vertical_alignment, set_cell_borders, set_cell_shading, set_header_row, add_tab_stop, clear_tab_stops, insert_field, insert_page_x_of_y, accept_change, reject_change, accept_all_changes, reject_all_changes, set_list_level, promote_list, demote_list, restart_numbering, remove_list, add_to_list, edit_text_box, add_bookmark, add_hyperlink, insert_cross_ref, insert_caption, insert_toc, update_toc, add_footnote, delete_footnote, set_content_control, add_source, delete_source, insert_citation, insert_bibliography. Excluded from batch: create (use separately).',
+        description='JSON array of operation objects. Each object must have an "op" field and operation-specific parameters. Example: [{"op": "edit_cell", "target_id": "table_abc_0", "row": 0, "col": 0, "content_data": "A1"}]. Use $prev[N] in target_id to reference element_id from operation N (0-indexed). Supported ops: insert_before, insert_after, append, delete, replace, style, edit_cell, edit_run, edit_style, add_comment, reply_comment, resolve_comment, unresolve_comment, set_header, set_footer, set_first_page_header, set_first_page_footer, set_even_page_header, set_even_page_footer, append_header, append_footer, clear_header, clear_footer, set_margins, set_orientation, set_columns, set_line_numbering, set_page_borders, set_custom_property, delete_custom_property, create_style, delete_style, insert_image, insert_floating_image, delete_image, add_row, add_column, delete_row, delete_column, add_page_break, add_break, set_meta, add_section, merge_cells, set_table_alignment, set_table_autofit, set_table_fixed_layout, set_row_height, set_cell_width, set_cell_vertical_alignment, set_cell_borders, set_cell_shading, set_header_row, add_tab_stop, clear_tab_stops, insert_field, insert_page_x_of_y, accept_change, reject_change, accept_all_changes, reject_all_changes, create_list, set_list_level, promote_list, demote_list, restart_numbering, remove_list, add_to_list, edit_text_box, add_bookmark, add_hyperlink, insert_cross_ref, insert_caption, insert_toc, update_toc, add_footnote, delete_footnote, set_content_control, create_content_control, add_source, delete_source, insert_citation, insert_bibliography. Excluded from batch: create (use separately).',
     ),
     mode: str = Field(
         "atomic",

--- a/tests/word/test_word_hyperlinks.py
+++ b/tests/word/test_word_hyperlinks.py
@@ -1,0 +1,182 @@
+"""Tests for hyperlink operations (Issue #136).
+
+Tests the add_hyperlink replace parameter that prevents text duplication
+when replacing paragraph content with a hyperlink.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mcp_handley_lab.microsoft.word.tool import mcp
+
+
+@pytest.fixture
+async def doc_with_paragraph():
+    """Create a document with a single paragraph containing text."""
+    with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as f:
+        path = Path(f.name)
+
+    await mcp.call_tool(
+        "create",
+        {
+            "file_path": str(path),
+            "content_type": "paragraph",
+            "content_data": "Original text here",
+        },
+    )
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_add_hyperlink_append(doc_with_paragraph):
+    """Default behavior: hyperlink is appended, preserving existing text."""
+    path = doc_with_paragraph
+
+    # Read to get paragraph ID
+    _, read_data = await mcp.call_tool(
+        "read", {"file_path": str(path), "scope": "blocks"}
+    )
+    p_id = read_data["blocks"][0]["id"]
+
+    # Add hyperlink (default: append)
+    _, edit_data = await mcp.call_tool(
+        "edit",
+        {
+            "file_path": str(path),
+            "ops": json.dumps(
+                [
+                    {
+                        "op": "add_hyperlink",
+                        "target_id": p_id,
+                        "content_data": json.dumps(
+                            {"text": "Click me", "address": "https://example.com"}
+                        ),
+                    }
+                ]
+            ),
+        },
+    )
+    assert edit_data["results"][0]["success"] is True
+
+    # Read hyperlinks - should have the link
+    _, hyper_data = await mcp.call_tool(
+        "read", {"file_path": str(path), "scope": "hyperlinks"}
+    )
+    assert len(hyper_data["hyperlinks"]) == 1
+    assert hyper_data["hyperlinks"][0]["text"] == "Click me"
+
+    # Read blocks - original text should still be there (appended)
+    _, blocks_data = await mcp.call_tool(
+        "read", {"file_path": str(path), "scope": "blocks"}
+    )
+    paragraph_text = blocks_data["blocks"][0]["text"]
+    assert "Original text here" in paragraph_text
+
+
+@pytest.mark.asyncio
+async def test_add_hyperlink_replace(doc_with_paragraph):
+    """replace=True clears all content except pPr before adding hyperlink."""
+    path = doc_with_paragraph
+
+    # Read to get paragraph ID
+    _, read_data = await mcp.call_tool(
+        "read", {"file_path": str(path), "scope": "blocks"}
+    )
+    p_id = read_data["blocks"][0]["id"]
+
+    # Add hyperlink with replace=True
+    _, edit_data = await mcp.call_tool(
+        "edit",
+        {
+            "file_path": str(path),
+            "ops": json.dumps(
+                [
+                    {
+                        "op": "add_hyperlink",
+                        "target_id": p_id,
+                        "content_data": json.dumps(
+                            {
+                                "text": "New link",
+                                "address": "https://example.com",
+                                "replace": True,
+                            }
+                        ),
+                    }
+                ]
+            ),
+        },
+    )
+    assert edit_data["results"][0]["success"] is True
+
+    # Read blocks - original text should be gone, only link text
+    _, blocks_data = await mcp.call_tool(
+        "read", {"file_path": str(path), "scope": "blocks"}
+    )
+    paragraph_text = blocks_data["blocks"][0]["text"]
+    assert "Original text here" not in paragraph_text
+    assert "New link" in paragraph_text
+
+
+@pytest.mark.asyncio
+async def test_add_hyperlink_replace_preserves_p_pr(doc_with_paragraph):
+    """replace=True preserves paragraph properties (w:pPr)."""
+    path = doc_with_paragraph
+
+    # Read to get paragraph ID
+    _, read_data = await mcp.call_tool(
+        "read", {"file_path": str(path), "scope": "blocks"}
+    )
+    p_id = read_data["blocks"][0]["id"]
+
+    # Apply formatting to create pPr
+    _, edit_data = await mcp.call_tool(
+        "edit",
+        {
+            "file_path": str(path),
+            "ops": json.dumps(
+                [
+                    {
+                        "op": "style",
+                        "target_id": p_id,
+                        "formatting": json.dumps({"alignment": "center"}),
+                    }
+                ]
+            ),
+        },
+    )
+    new_p_id = edit_data["results"][0]["element_id"]
+
+    # Now replace with hyperlink
+    _, edit_data2 = await mcp.call_tool(
+        "edit",
+        {
+            "file_path": str(path),
+            "ops": json.dumps(
+                [
+                    {
+                        "op": "add_hyperlink",
+                        "target_id": new_p_id,
+                        "content_data": json.dumps(
+                            {
+                                "text": "Centered link",
+                                "address": "https://example.com",
+                                "replace": True,
+                            }
+                        ),
+                    }
+                ]
+            ),
+        },
+    )
+    assert edit_data2["results"][0]["success"] is True
+
+    # Verify link text is there and original text is gone
+    _, blocks_data = await mcp.call_tool(
+        "read", {"file_path": str(path), "scope": "blocks"}
+    )
+    assert "Centered link" in blocks_data["blocks"][0]["text"]
+    assert "Original text here" not in blocks_data["blocks"][0]["text"]

--- a/tests/word/test_word_lists.py
+++ b/tests/word/test_word_lists.py
@@ -1,0 +1,232 @@
+"""Tests for list creation operations (Issue #148).
+
+Tests create_list which bootstraps numbering.xml and applies numPr to paragraphs,
+enabling bullet and numbered lists from scratch.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mcp_handley_lab.microsoft.word.constants import qn
+from mcp_handley_lab.microsoft.word.ops.lists import (
+    create_list,
+    get_list_info,
+)
+from mcp_handley_lab.microsoft.word.package import WordPackage
+from mcp_handley_lab.microsoft.word.tool import mcp
+
+
+@pytest.fixture
+async def doc_with_paragraph():
+    """Create a document with a single paragraph."""
+    with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as f:
+        path = Path(f.name)
+
+    await mcp.call_tool(
+        "create",
+        {
+            "file_path": str(path),
+            "content_type": "paragraph",
+            "content_data": "First item",
+        },
+    )
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_create_bullet_list(doc_with_paragraph):
+    """create_list creates numPr on paragraph with bullet abstractNum."""
+    path = doc_with_paragraph
+
+    pkg = WordPackage.open(str(path))
+    body = pkg.body
+    p_el = body.find(qn("w:p"))
+    num_id = create_list(pkg, p_el, "bullet", level=0)
+    pkg.save(str(path))
+
+    assert num_id >= 1
+
+    # Verify via get_list_info
+    pkg2 = WordPackage.open(str(path))
+    body2 = pkg2.body
+    p_el2 = body2.find(qn("w:p"))
+    info = get_list_info(pkg2, p_el2)
+
+    assert info is not None
+    assert info["num_id"] == num_id
+    assert info["level"] == 0
+    assert info["format_type"] == "bullet"
+
+
+@pytest.mark.asyncio
+async def test_create_numbered_list(doc_with_paragraph):
+    """create_list with numbered type uses decimal numFmt at level 0."""
+    path = doc_with_paragraph
+
+    pkg = WordPackage.open(str(path))
+    body = pkg.body
+    p_el = body.find(qn("w:p"))
+    create_list(pkg, p_el, "numbered", level=0)
+    pkg.save(str(path))
+
+    pkg2 = WordPackage.open(str(path))
+    body2 = pkg2.body
+    p_el2 = body2.find(qn("w:p"))
+    info = get_list_info(pkg2, p_el2)
+
+    assert info is not None
+    assert info["format_type"] == "decimal"
+    assert info["level_text"] == "%1."
+
+
+@pytest.mark.asyncio
+async def test_create_list_no_numbering_xml():
+    """create_list bootstraps numbering.xml when it doesn't exist."""
+    with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as f:
+        path = Path(f.name)
+
+    try:
+        await mcp.call_tool(
+            "create",
+            {
+                "file_path": str(path),
+                "content_type": "paragraph",
+                "content_data": "Item",
+            },
+        )
+
+        # Verify numbering.xml doesn't exist yet
+        pkg = WordPackage.open(str(path))
+        assert pkg.numbering_xml is None
+
+        # Create list via MCP tool
+        _, read_data = await mcp.call_tool(
+            "read", {"file_path": str(path), "scope": "blocks"}
+        )
+        p_id = read_data["blocks"][0]["id"]
+
+        _, edit_data = await mcp.call_tool(
+            "edit",
+            {
+                "file_path": str(path),
+                "ops": json.dumps(
+                    [
+                        {
+                            "op": "create_list",
+                            "target_id": p_id,
+                            "content_data": json.dumps({"list_type": "bullet"}),
+                        }
+                    ]
+                ),
+            },
+        )
+        assert edit_data["results"][0]["success"] is True
+
+        # Verify numbering.xml now exists
+        pkg2 = WordPackage.open(str(path))
+        assert pkg2.numbering_xml is not None
+        assert pkg2.has_part("/word/numbering.xml")
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_create_list_then_add_to_list(doc_with_paragraph):
+    """Second item added via add_to_list uses the same numId."""
+    path = doc_with_paragraph
+
+    # Read paragraph ID
+    _, read_data = await mcp.call_tool(
+        "read", {"file_path": str(path), "scope": "blocks"}
+    )
+    p_id = read_data["blocks"][0]["id"]
+
+    # Create list
+    _, edit_data = await mcp.call_tool(
+        "edit",
+        {
+            "file_path": str(path),
+            "ops": json.dumps(
+                [
+                    {
+                        "op": "create_list",
+                        "target_id": p_id,
+                        "content_data": json.dumps({"list_type": "bullet"}),
+                    }
+                ]
+            ),
+        },
+    )
+    new_p_id = edit_data["results"][0]["element_id"]
+
+    # Add second item
+    _, edit_data2 = await mcp.call_tool(
+        "edit",
+        {
+            "file_path": str(path),
+            "ops": json.dumps(
+                [
+                    {
+                        "op": "add_to_list",
+                        "target_id": new_p_id,
+                        "content_data": json.dumps({"text": "Second item"}),
+                    }
+                ]
+            ),
+        },
+    )
+    assert edit_data2["results"][0]["success"] is True
+
+    # Both paragraphs should have the same numId
+    pkg = WordPackage.open(str(path))
+    body = pkg.body
+    paragraphs = body.findall(qn("w:p"))
+    info1 = get_list_info(pkg, paragraphs[0])
+    info2 = get_list_info(pkg, paragraphs[1])
+
+    assert info1 is not None
+    assert info2 is not None
+    assert info1["num_id"] == info2["num_id"]
+
+
+@pytest.mark.asyncio
+async def test_create_list_roundtrip(doc_with_paragraph):
+    """get_list_info reads back correctly after create_list."""
+    path = doc_with_paragraph
+
+    pkg = WordPackage.open(str(path))
+    body = pkg.body
+    p_el = body.find(qn("w:p"))
+    num_id = create_list(pkg, p_el, "numbered", level=2)
+    pkg.save(str(path))
+
+    pkg2 = WordPackage.open(str(path))
+    body2 = pkg2.body
+    p_el2 = body2.find(qn("w:p"))
+    info = get_list_info(pkg2, p_el2)
+
+    assert info is not None
+    assert info["num_id"] == num_id
+    assert info["level"] == 2
+    assert info["format_type"] == "lowerRoman"  # Level 2 cycles to lowerRoman
+    assert info["level_text"] == "%3."
+
+
+@pytest.mark.asyncio
+async def test_create_list_level_validation(doc_with_paragraph):
+    """Rejects level outside 0-8."""
+    path = doc_with_paragraph
+
+    pkg = WordPackage.open(str(path))
+    body = pkg.body
+    p_el = body.find(qn("w:p"))
+
+    with pytest.raises(ValueError, match="List level must be 0-8"):
+        create_list(pkg, p_el, "bullet", level=9)
+
+    with pytest.raises(ValueError, match="List level must be 0-8"):
+        create_list(pkg, p_el, "bullet", level=-1)

--- a/tests/word/test_word_sdt.py
+++ b/tests/word/test_word_sdt.py
@@ -1,0 +1,277 @@
+"""Tests for content control (SDT) creation (Issue #126).
+
+Tests create_content_control for text, checkbox, dropdown, comboBox, and date types.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+from lxml import etree
+
+from mcp_handley_lab.microsoft.word.constants import NSMAP, qn
+from mcp_handley_lab.microsoft.word.ops.sdt import (
+    build_content_controls,
+    create_content_control,
+)
+from mcp_handley_lab.microsoft.word.package import WordPackage
+from mcp_handley_lab.microsoft.word.tool import mcp
+
+
+@pytest.fixture
+async def doc_with_paragraph():
+    """Create a document with a single paragraph."""
+    with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as f:
+        path = Path(f.name)
+
+    await mcp.call_tool(
+        "create",
+        {
+            "file_path": str(path),
+            "content_type": "paragraph",
+            "content_data": "Reference paragraph",
+        },
+    )
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_create_text_control(doc_with_paragraph):
+    """Create a text content control and read it back."""
+    path = doc_with_paragraph
+
+    pkg = WordPackage.open(str(path))
+    body = pkg.body
+    p_el = body.find(qn("w:p"))
+    sdt = create_content_control(pkg, body, p_el, "text", tag="myTag", alias="My Alias")
+    pkg.save(str(path))
+
+    assert sdt is not None
+
+    # Read back via build_content_controls
+    pkg2 = WordPackage.open(str(path))
+    controls = build_content_controls(pkg2)
+
+    assert len(controls) == 1
+    cc = controls[0]
+    assert cc["type"] == "text"
+    assert cc["tag"] == "myTag"
+    assert cc["alias"] == "My Alias"
+    assert cc["value"] == "Click here"  # Default placeholder
+
+
+@pytest.mark.asyncio
+async def test_create_checkbox(doc_with_paragraph):
+    """Create a checkbox control, verify checked state and structural elements."""
+    path = doc_with_paragraph
+
+    pkg = WordPackage.open(str(path))
+    body = pkg.body
+    p_el = body.find(qn("w:p"))
+    create_content_control(pkg, body, p_el, "checkbox", checked=True)
+    pkg.save(str(path))
+
+    pkg2 = WordPackage.open(str(path))
+    controls = build_content_controls(pkg2)
+
+    assert len(controls) == 1
+    cc = controls[0]
+    assert cc["type"] == "checkbox"
+    assert cc["checked"] is True
+    assert cc["value"] == "\u2612"  # ☒
+
+    # Verify structural elements in XML
+    body2 = pkg2.body
+    sdt_el = list(body2.iter(qn("w:sdt")))[0]
+    sdt_pr = sdt_el.find("w:sdtPr", namespaces=NSMAP)
+    ns_w14 = "http://schemas.microsoft.com/office/word/2010/wordml"
+    checkbox = sdt_pr.find(f"{{{ns_w14}}}checkbox")
+    assert checkbox is not None
+
+    checked_state = checkbox.find(f"{{{ns_w14}}}checkedState")
+    assert checked_state is not None
+    assert checked_state.get(f"{{{ns_w14}}}val") == "2612"
+
+    unchecked_state = checkbox.find(f"{{{ns_w14}}}uncheckedState")
+    assert unchecked_state is not None
+    assert unchecked_state.get(f"{{{ns_w14}}}val") == "2610"
+
+
+@pytest.mark.asyncio
+async def test_create_checkbox_unchecked(doc_with_paragraph):
+    """Create an unchecked checkbox."""
+    path = doc_with_paragraph
+
+    pkg = WordPackage.open(str(path))
+    body = pkg.body
+    p_el = body.find(qn("w:p"))
+    create_content_control(pkg, body, p_el, "checkbox", checked=False)
+    pkg.save(str(path))
+
+    pkg2 = WordPackage.open(str(path))
+    controls = build_content_controls(pkg2)
+
+    assert controls[0]["checked"] is False
+    assert controls[0]["value"] == "\u2610"  # ☐
+
+
+@pytest.mark.asyncio
+async def test_create_dropdown(doc_with_paragraph):
+    """Create a dropdown control with options."""
+    path = doc_with_paragraph
+    options = ["Red", "Green", "Blue"]
+
+    pkg = WordPackage.open(str(path))
+    body = pkg.body
+    p_el = body.find(qn("w:p"))
+    create_content_control(pkg, body, p_el, "dropdown", options=options, tag="color")
+    pkg.save(str(path))
+
+    pkg2 = WordPackage.open(str(path))
+    controls = build_content_controls(pkg2)
+
+    assert len(controls) == 1
+    cc = controls[0]
+    assert cc["type"] == "dropdown"
+    assert cc["options"] == ["Red", "Green", "Blue"]
+    assert cc["tag"] == "color"
+
+
+@pytest.mark.asyncio
+async def test_create_combobox(doc_with_paragraph):
+    """Create a comboBox control with options."""
+    path = doc_with_paragraph
+    options = ["Option A", "Option B"]
+
+    pkg = WordPackage.open(str(path))
+    body = pkg.body
+    p_el = body.find(qn("w:p"))
+    create_content_control(pkg, body, p_el, "comboBox", options=options)
+    pkg.save(str(path))
+
+    pkg2 = WordPackage.open(str(path))
+    controls = build_content_controls(pkg2)
+
+    assert len(controls) == 1
+    cc = controls[0]
+    assert cc["type"] == "comboBox"
+    assert cc["options"] == ["Option A", "Option B"]
+
+
+@pytest.mark.asyncio
+async def test_create_date(doc_with_paragraph):
+    """Create a date control with custom format."""
+    path = doc_with_paragraph
+
+    pkg = WordPackage.open(str(path))
+    body = pkg.body
+    p_el = body.find(qn("w:p"))
+    create_content_control(pkg, body, p_el, "date", date_format="dd/MM/yyyy")
+    pkg.save(str(path))
+
+    pkg2 = WordPackage.open(str(path))
+    controls = build_content_controls(pkg2)
+
+    assert len(controls) == 1
+    cc = controls[0]
+    assert cc["type"] == "date"
+    assert cc["date_format"] == "dd/MM/yyyy"
+
+    # Verify XML structure
+    body2 = pkg2.body
+    sdt_el = list(body2.iter(qn("w:sdt")))[0]
+    sdt_pr = sdt_el.find("w:sdtPr", namespaces=NSMAP)
+    date_el = sdt_pr.find("w:date", namespaces=NSMAP)
+    assert date_el is not None
+
+    lid = date_el.find("w:lid", namespaces=NSMAP)
+    assert lid is not None
+    assert lid.get(qn("w:val")) == "en-US"
+
+    store = date_el.find("w:storeMappedDataAs", namespaces=NSMAP)
+    assert store is not None
+    assert store.get(qn("w:val")) == "dateTime"
+
+
+@pytest.mark.asyncio
+async def test_sdt_id_uniqueness(doc_with_paragraph):
+    """Multiple creates produce unique IDs."""
+    path = doc_with_paragraph
+
+    pkg = WordPackage.open(str(path))
+    body = pkg.body
+    p_el = body.find(qn("w:p"))
+    sdt1 = create_content_control(pkg, body, p_el, "text", tag="first")
+    sdt2 = create_content_control(pkg, body, p_el, "text", tag="second")
+    pkg.save(str(path))
+
+    # Extract IDs
+    sdt1_pr = sdt1.find("w:sdtPr", namespaces=NSMAP)
+    sdt2_pr = sdt2.find("w:sdtPr", namespaces=NSMAP)
+    id1 = int(sdt1_pr.find("w:id", namespaces=NSMAP).get(qn("w:val")))
+    id2 = int(sdt2_pr.find("w:id", namespaces=NSMAP).get(qn("w:val")))
+    assert id1 != id2
+
+
+@pytest.mark.asyncio
+async def test_create_sdt_parent_validation(doc_with_paragraph):
+    """Only block-level contexts (w:body, w:tc) are accepted."""
+    path = doc_with_paragraph
+
+    pkg = WordPackage.open(str(path))
+    body = pkg.body
+
+    # Create a detached paragraph (no parent)
+    detached_p = etree.Element(qn("w:p"))
+
+    with pytest.raises(ValueError, match="block-level"):
+        create_content_control(pkg, body, detached_p, "text")
+
+
+@pytest.mark.asyncio
+async def test_create_content_control_via_mcp(doc_with_paragraph):
+    """Test create_content_control via the MCP tool interface."""
+    path = doc_with_paragraph
+
+    # Read paragraph ID
+    _, read_data = await mcp.call_tool(
+        "read", {"file_path": str(path), "scope": "blocks"}
+    )
+    p_id = read_data["blocks"][0]["id"]
+
+    # Create via MCP
+    _, edit_data = await mcp.call_tool(
+        "edit",
+        {
+            "file_path": str(path),
+            "ops": json.dumps(
+                [
+                    {
+                        "op": "create_content_control",
+                        "target_id": p_id,
+                        "content_data": json.dumps(
+                            {
+                                "type": "dropdown",
+                                "tag": "priority",
+                                "options": ["Low", "Medium", "High"],
+                            }
+                        ),
+                    }
+                ]
+            ),
+        },
+    )
+
+    assert edit_data["results"][0]["success"] is True
+    # element_id is the numeric SDT id (usable with set_content_control)
+    assert edit_data["results"][0]["element_id"].isdigit()
+
+    # Verify via read
+    _, cc_data = await mcp.call_tool(
+        "read", {"file_path": str(path), "scope": "content_controls"}
+    )
+    assert len(cc_data["content_controls"]) == 1
+    assert cc_data["content_controls"][0]["type"] == "dropdown"
+    assert cc_data["content_controls"][0]["options"] == ["Low", "Medium", "High"]


### PR DESCRIPTION
## Summary

- **#148**: Add `create_list` operation that bootstraps `numbering.xml` and creates proper abstractNum/num/numPr for bullet and numbered lists
- **#136**: Add `replace` parameter to `add_hyperlink()` to clear paragraph content before inserting, preventing text duplication
- **#126**: Add `create_content_control()` supporting text, richText, dropdown, comboBox, checkbox, and date types with full OOXML structure
- Fix comboBox vs dropdown distinction in SDT type detection
- Add position and level validation across list and SDT operations

## Test plan

- [x] 18 new tests across 3 test files (hyperlinks, lists, SDT)
- [x] All 296 word tests pass (excluding pre-existing render timeouts)
- [x] Full suite: 1459 passed
- [x] Reviewed by OpenAI (5 iterations, approved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)