### PR TITLE
feat(microsoft): cross-format embedded chart support (#200)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.8b3
+pkgver=0.25.11
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.8b3"
+version = "0.25.11"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/microsoft/common/charts.py
+++ b/src/mcp_handley_lab/microsoft/common/charts.py
@@ -1,0 +1,458 @@
+"""Shared DrawingML chart XML builders for Word, Excel, and PowerPoint.
+
+Generates c:chartSpace XML with proper category/series semantics.
+Supports: bar, column, line, pie, scatter, area chart types.
+"""
+
+from __future__ import annotations
+
+from lxml import etree
+
+from mcp_handley_lab.microsoft.opc.constants import CT, RT
+
+# Chart-specific namespaces (not tied to any one format)
+CHART_NSMAP = {
+    "c": "http://schemas.openxmlformats.org/drawingml/2006/chart",
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+    "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+}
+
+# Re-export from opc/constants for convenience
+CT_CHART = CT.CHART
+RT_CHART = RT.CHART
+RT_PACKAGE = RT.PACKAGE
+
+# Content type for embedded xlsx
+CT_XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+VALID_CHART_TYPES = {"bar", "column", "line", "pie", "scatter", "area"}
+
+
+def _qn_c(tag: str) -> str:
+    return f"{{{CHART_NSMAP['c']}}}{tag}"
+
+
+def _qn_a(tag: str) -> str:
+    return f"{{{CHART_NSMAP['a']}}}{tag}"
+
+
+def _qn_r(tag: str) -> str:
+    return f"{{{CHART_NSMAP['r']}}}{tag}"
+
+
+def validate_chart_data(data: list[list]) -> None:
+    """Validate a 2D data array for chart creation.
+
+    Raises ValueError if data is invalid.
+    """
+    if not data:
+        raise ValueError("Data array must not be empty")
+    if len(data) < 2:
+        raise ValueError("Data must have at least 2 rows (header + 1 data row)")
+    if len(data[0]) < 2:
+        raise ValueError("Data must have at least 2 columns (categories + 1 series)")
+    row_len = len(data[0])
+    for i, row in enumerate(data):
+        if len(row) != row_len:
+            raise ValueError(
+                f"Row {i} has {len(row)} columns, expected {row_len} (data must be rectangular)"
+            )
+
+
+def compute_chart_refs(
+    sheet_name: str, n_rows: int, n_cols: int
+) -> tuple[str, list[tuple[str, str, str]]]:
+    """Convert 2D array dimensions to categories_range + series list.
+
+    Assumes row 0 = headers (series names), col 0 = categories, cols 1..n = series values.
+    For scatter charts: col 0 = X values, cols 1..n = Y series.
+
+    Args:
+        sheet_name: Worksheet name
+        n_rows: Total rows including header
+        n_cols: Total columns including category column
+
+    Returns:
+        (categories_range, [(name_ref, name_text, values_range), ...])
+        where name_ref is cell reference for series name, name_text is placeholder,
+        and values_range is the data column reference.
+    """
+    # Categories are in col A, rows 2..n_rows (skip header)
+    cat_range = f"'{sheet_name}'!$A$2:$A${n_rows}"
+
+    series = []
+    for col_idx in range(1, n_cols):
+        col_letter = _col_letter(col_idx)
+        # Series name is in the header row (row 1)
+        name_ref = f"'{sheet_name}'!${col_letter}$1"
+        # Values are rows 2..n_rows
+        values_range = f"'{sheet_name}'!${col_letter}$2:${col_letter}${n_rows}"
+        # name_text is a placeholder; actual text comes from embedded workbook
+        series.append((name_ref, "", values_range))
+
+    return cat_range, series
+
+
+def _col_letter(idx: int) -> str:
+    """Convert 0-based column index to Excel column letter (0=A, 1=B, ..., 25=Z, 26=AA)."""
+    result = []
+    n = idx
+    while True:
+        result.append(chr(ord("A") + n % 26))
+        n = n // 26 - 1
+        if n < 0:
+            break
+    return "".join(reversed(result))
+
+
+def create_chart_xml(
+    chart_type: str,
+    sheet_name: str,
+    categories_range: str | None,
+    series: list[tuple[str, str, str]],
+    title: str | None = None,
+    external_data_rid: str | None = None,
+) -> etree._Element:
+    """Create a c:chartSpace XML element.
+
+    Args:
+        chart_type: bar, column, line, pie, scatter, area
+        sheet_name: Name of the data worksheet
+        categories_range: Cell range for categories (e.g. "'Sheet1'!$A$2:$A$4"),
+            or None to omit category references (Excel simple mode)
+        series: List of (name_ref, name_text, values_range) tuples per series.
+            name_ref can be empty string to omit c:serTx.
+        title: Optional chart title
+        external_data_rid: rId for c:externalData (Word/PPT charts only)
+
+    Returns:
+        c:chartSpace lxml element
+    """
+    chart_type = chart_type.lower()
+    if chart_type not in VALID_CHART_TYPES:
+        raise ValueError(
+            f"Unsupported chart type: {chart_type!r}. "
+            f"Must be one of: {', '.join(sorted(VALID_CHART_TYPES))}"
+        )
+    if not series:
+        raise ValueError("At least one data series is required")
+
+    chart_space = etree.Element(
+        _qn_c("chartSpace"),
+        nsmap={"c": CHART_NSMAP["c"], "a": CHART_NSMAP["a"], "r": CHART_NSMAP["r"]},
+    )
+
+    etree.SubElement(chart_space, _qn_c("date1904"), val="0")
+    etree.SubElement(chart_space, _qn_c("lang"), val="en-US")
+    etree.SubElement(chart_space, _qn_c("roundedCorners"), val="0")
+
+    chart = etree.SubElement(chart_space, _qn_c("chart"))
+
+    if title:
+        _add_title(chart, title)
+
+    etree.SubElement(chart, _qn_c("autoTitleDeleted"), val="0" if title else "1")
+
+    plot_area = etree.SubElement(chart, _qn_c("plotArea"))
+    etree.SubElement(plot_area, _qn_c("layout"))
+
+    if chart_type == "bar":
+        _add_bar_chart(plot_area, categories_range, series, bar_dir="bar")
+    elif chart_type == "column":
+        _add_bar_chart(plot_area, categories_range, series, bar_dir="col")
+    elif chart_type == "line":
+        _add_line_chart(plot_area, categories_range, series)
+    elif chart_type == "pie":
+        _add_pie_chart(plot_area, categories_range, series)
+    elif chart_type == "scatter":
+        _add_scatter_chart(plot_area, categories_range, series)
+    elif chart_type == "area":
+        _add_area_chart(plot_area, categories_range, series)
+
+    if chart_type != "pie":
+        _add_axes(plot_area, chart_type)
+
+    legend = etree.SubElement(chart, _qn_c("legend"))
+    etree.SubElement(legend, _qn_c("legendPos"), val="r")
+    etree.SubElement(legend, _qn_c("overlay"), val="0")
+
+    etree.SubElement(chart, _qn_c("plotVisOnly"), val="1")
+    etree.SubElement(chart, _qn_c("dispBlanksAs"), val="gap")
+    etree.SubElement(chart, _qn_c("showDLblsOverMax"), val="0")
+
+    # External data reference (for Word/PowerPoint embedded charts)
+    if external_data_rid:
+        ext_data = etree.SubElement(chart_space, _qn_c("externalData"))
+        ext_data.set(_qn_r("id"), external_data_rid)
+        etree.SubElement(ext_data, _qn_c("autoUpdate"), val="0")
+
+    # Print settings
+    print_settings = etree.SubElement(chart_space, _qn_c("printSettings"))
+    etree.SubElement(print_settings, _qn_c("headerFooter"))
+    etree.SubElement(
+        print_settings,
+        _qn_c("pageMargins"),
+        b="0.75",
+        l="0.7",
+        r="0.7",
+        t="0.75",
+        header="0.3",
+        footer="0.3",
+    )
+    etree.SubElement(print_settings, _qn_c("pageSetup"))
+
+    return chart_space
+
+
+def _add_title(chart: etree._Element, title: str) -> None:
+    """Add chart title element."""
+    title_elem = etree.SubElement(chart, _qn_c("title"))
+    tx = etree.SubElement(title_elem, _qn_c("tx"))
+    rich = etree.SubElement(tx, _qn_c("rich"))
+    etree.SubElement(rich, _qn_a("bodyPr"))
+    etree.SubElement(rich, _qn_a("lstStyle"))
+    p = etree.SubElement(rich, _qn_a("p"))
+    p_pr = etree.SubElement(p, _qn_a("pPr"))
+    etree.SubElement(p_pr, _qn_a("defRPr"))
+    r = etree.SubElement(p, _qn_a("r"))
+    etree.SubElement(r, _qn_a("rPr"), lang="en-US")
+    t = etree.SubElement(r, _qn_a("t"))
+    t.text = title
+    etree.SubElement(title_elem, _qn_c("overlay"), val="0")
+
+
+def _add_series_common(
+    parent: etree._Element,
+    idx: int,
+    name_ref: str,
+    name_text: str,
+) -> etree._Element:
+    """Add common series elements (idx, order, serTx). Returns the c:ser element."""
+    ser = etree.SubElement(parent, _qn_c("ser"))
+    etree.SubElement(ser, _qn_c("idx"), val=str(idx))
+    etree.SubElement(ser, _qn_c("order"), val=str(idx))
+
+    # Series name reference
+    if name_ref:
+        ser_tx = etree.SubElement(ser, _qn_c("tx"))
+        str_ref = etree.SubElement(ser_tx, _qn_c("strRef"))
+        f = etree.SubElement(str_ref, _qn_c("f"))
+        f.text = name_ref
+
+    return ser
+
+
+def _add_cat_ref(ser: etree._Element, categories_range: str | None) -> None:
+    """Add c:cat element with strRef to a series. No-op if categories_range is None."""
+    if categories_range is None:
+        return
+    cat = etree.SubElement(ser, _qn_c("cat"))
+    str_ref = etree.SubElement(cat, _qn_c("strRef"))
+    f = etree.SubElement(str_ref, _qn_c("f"))
+    f.text = categories_range
+
+
+def _add_val_ref(ser: etree._Element, values_range: str) -> None:
+    """Add c:val element with numRef to a series."""
+    val = etree.SubElement(ser, _qn_c("val"))
+    num_ref = etree.SubElement(val, _qn_c("numRef"))
+    f = etree.SubElement(num_ref, _qn_c("f"))
+    f.text = values_range
+
+
+def _add_data_labels(parent: etree._Element) -> None:
+    """Add standard data labels (all hidden)."""
+    d_lbls = etree.SubElement(parent, _qn_c("dLbls"))
+    for attr in (
+        "showLegendKey",
+        "showVal",
+        "showCatName",
+        "showSerName",
+        "showPercent",
+        "showBubbleSize",
+    ):
+        etree.SubElement(d_lbls, _qn_c(attr), val="0")
+
+
+def _add_bar_chart(
+    plot_area: etree._Element,
+    categories_range: str | None,
+    series: list[tuple[str, str, str]],
+    bar_dir: str = "col",
+) -> None:
+    """Add bar/column chart with categories and multiple series."""
+    bar_chart = etree.SubElement(plot_area, _qn_c("barChart"))
+    etree.SubElement(bar_chart, _qn_c("barDir"), val=bar_dir)
+    etree.SubElement(bar_chart, _qn_c("grouping"), val="clustered")
+    etree.SubElement(bar_chart, _qn_c("varyColors"), val="0")
+
+    for idx, (name_ref, name_text, values_range) in enumerate(series):
+        ser = _add_series_common(bar_chart, idx, name_ref, name_text)
+        _add_cat_ref(ser, categories_range)
+        _add_val_ref(ser, values_range)
+
+    _add_data_labels(bar_chart)
+    etree.SubElement(bar_chart, _qn_c("gapWidth"), val="150")
+    etree.SubElement(bar_chart, _qn_c("axId"), val="100")
+    etree.SubElement(bar_chart, _qn_c("axId"), val="200")
+
+
+def _add_line_chart(
+    plot_area: etree._Element,
+    categories_range: str | None,
+    series: list[tuple[str, str, str]],
+) -> None:
+    """Add line chart with categories and multiple series."""
+    line_chart = etree.SubElement(plot_area, _qn_c("lineChart"))
+    etree.SubElement(line_chart, _qn_c("grouping"), val="standard")
+    etree.SubElement(line_chart, _qn_c("varyColors"), val="0")
+
+    for idx, (name_ref, name_text, values_range) in enumerate(series):
+        ser = _add_series_common(line_chart, idx, name_ref, name_text)
+        marker = etree.SubElement(ser, _qn_c("marker"))
+        etree.SubElement(marker, _qn_c("symbol"), val="none")
+        _add_cat_ref(ser, categories_range)
+        _add_val_ref(ser, values_range)
+
+    _add_data_labels(line_chart)
+    etree.SubElement(line_chart, _qn_c("smooth"), val="0")
+    etree.SubElement(line_chart, _qn_c("axId"), val="100")
+    etree.SubElement(line_chart, _qn_c("axId"), val="200")
+
+
+def _add_pie_chart(
+    plot_area: etree._Element,
+    categories_range: str | None,
+    series: list[tuple[str, str, str]],
+) -> None:
+    """Add pie chart with categories and single value series."""
+    pie_chart = etree.SubElement(plot_area, _qn_c("pieChart"))
+    etree.SubElement(pie_chart, _qn_c("varyColors"), val="1")
+
+    # Pie charts use only the first series
+    if series:
+        name_ref, name_text, values_range = series[0]
+        ser = _add_series_common(pie_chart, 0, name_ref, name_text)
+        _add_cat_ref(ser, categories_range)
+        _add_val_ref(ser, values_range)
+
+    _add_data_labels(pie_chart)
+    etree.SubElement(pie_chart, _qn_c("firstSliceAng"), val="0")
+
+
+def _add_scatter_chart(
+    plot_area: etree._Element,
+    categories_range: str | None,
+    series: list[tuple[str, str, str]],
+) -> None:
+    """Add scatter chart with xVal/yVal per series.
+
+    When categories_range is None (Excel simple mode), only yVal is emitted.
+    """
+    scatter_chart = etree.SubElement(plot_area, _qn_c("scatterChart"))
+    etree.SubElement(scatter_chart, _qn_c("scatterStyle"), val="lineMarker")
+    etree.SubElement(scatter_chart, _qn_c("varyColors"), val="0")
+
+    for idx, (name_ref, name_text, values_range) in enumerate(series):
+        ser = _add_series_common(scatter_chart, idx, name_ref, name_text)
+
+        marker = etree.SubElement(ser, _qn_c("marker"))
+        etree.SubElement(marker, _qn_c("symbol"), val="circle")
+        etree.SubElement(marker, _qn_c("size"), val="5")
+
+        # X values from categories column (omitted in Excel simple mode)
+        if categories_range is not None:
+            x_val = etree.SubElement(ser, _qn_c("xVal"))
+            num_ref_x = etree.SubElement(x_val, _qn_c("numRef"))
+            f_x = etree.SubElement(num_ref_x, _qn_c("f"))
+            f_x.text = categories_range
+
+        # Y values from series column
+        y_val = etree.SubElement(ser, _qn_c("yVal"))
+        num_ref_y = etree.SubElement(y_val, _qn_c("numRef"))
+        f_y = etree.SubElement(num_ref_y, _qn_c("f"))
+        f_y.text = values_range
+
+        etree.SubElement(ser, _qn_c("smooth"), val="0")
+
+    _add_data_labels(scatter_chart)
+    etree.SubElement(scatter_chart, _qn_c("axId"), val="100")
+    etree.SubElement(scatter_chart, _qn_c("axId"), val="200")
+
+
+def _add_area_chart(
+    plot_area: etree._Element,
+    categories_range: str | None,
+    series: list[tuple[str, str, str]],
+) -> None:
+    """Add area chart with categories and multiple series."""
+    area_chart = etree.SubElement(plot_area, _qn_c("areaChart"))
+    etree.SubElement(area_chart, _qn_c("grouping"), val="standard")
+    etree.SubElement(area_chart, _qn_c("varyColors"), val="0")
+
+    for idx, (name_ref, name_text, values_range) in enumerate(series):
+        ser = _add_series_common(area_chart, idx, name_ref, name_text)
+        _add_cat_ref(ser, categories_range)
+        _add_val_ref(ser, values_range)
+
+    _add_data_labels(area_chart)
+    etree.SubElement(area_chart, _qn_c("axId"), val="100")
+    etree.SubElement(area_chart, _qn_c("axId"), val="200")
+
+
+def _add_axes(plot_area: etree._Element, chart_type: str) -> None:
+    """Add axes to plot area. Scatter uses two valAx; others use catAx + valAx."""
+    if chart_type == "scatter":
+        _add_scatter_axes(plot_area)
+    else:
+        _add_category_axes(plot_area)
+
+
+def _add_category_axes(plot_area: etree._Element) -> None:
+    """Add catAx (X) + valAx (Y) for non-scatter charts."""
+    cat_ax = etree.SubElement(plot_area, _qn_c("catAx"))
+    etree.SubElement(cat_ax, _qn_c("axId"), val="100")
+    scaling = etree.SubElement(cat_ax, _qn_c("scaling"))
+    etree.SubElement(scaling, _qn_c("orientation"), val="minMax")
+    etree.SubElement(cat_ax, _qn_c("delete"), val="0")
+    etree.SubElement(cat_ax, _qn_c("axPos"), val="b")
+    etree.SubElement(cat_ax, _qn_c("majorTickMark"), val="out")
+    etree.SubElement(cat_ax, _qn_c("minorTickMark"), val="none")
+    etree.SubElement(cat_ax, _qn_c("tickLblPos"), val="nextTo")
+    etree.SubElement(cat_ax, _qn_c("crossAx"), val="200")
+    etree.SubElement(cat_ax, _qn_c("crosses"), val="autoZero")
+    etree.SubElement(cat_ax, _qn_c("auto"), val="1")
+    etree.SubElement(cat_ax, _qn_c("lblAlgn"), val="ctr")
+    etree.SubElement(cat_ax, _qn_c("lblOffset"), val="100")
+
+    _add_val_ax(plot_area, ax_id="200", cross_ax="100", position="l")
+
+
+def _add_scatter_axes(plot_area: etree._Element) -> None:
+    """Add two valAx (X + Y) for scatter charts. No catAx-specific properties."""
+    _add_val_ax(plot_area, ax_id="100", cross_ax="200", position="b")
+    _add_val_ax(plot_area, ax_id="200", cross_ax="100", position="l")
+
+
+def _add_val_ax(
+    plot_area: etree._Element,
+    ax_id: str,
+    cross_ax: str,
+    position: str,
+) -> None:
+    """Add a single c:valAx element."""
+    val_ax = etree.SubElement(plot_area, _qn_c("valAx"))
+    etree.SubElement(val_ax, _qn_c("axId"), val=ax_id)
+    scaling = etree.SubElement(val_ax, _qn_c("scaling"))
+    etree.SubElement(scaling, _qn_c("orientation"), val="minMax")
+    etree.SubElement(val_ax, _qn_c("delete"), val="0")
+    etree.SubElement(val_ax, _qn_c("axPos"), val=position)
+    if position == "l":
+        etree.SubElement(val_ax, _qn_c("majorGridlines"))
+    etree.SubElement(val_ax, _qn_c("numFmt"), formatCode="General", sourceLinked="1")
+    etree.SubElement(val_ax, _qn_c("majorTickMark"), val="out")
+    etree.SubElement(val_ax, _qn_c("minorTickMark"), val="none")
+    etree.SubElement(val_ax, _qn_c("tickLblPos"), val="nextTo")
+    etree.SubElement(val_ax, _qn_c("crossAx"), val=cross_ax)
+    etree.SubElement(val_ax, _qn_c("crosses"), val="autoZero")
+    etree.SubElement(val_ax, _qn_c("crossBetween"), val="between")

--- a/src/mcp_handley_lab/microsoft/common/embedding.py
+++ b/src/mcp_handley_lab/microsoft/common/embedding.py
@@ -1,0 +1,38 @@
+"""Embedded Excel workbook creation for Word/PowerPoint charts.
+
+Creates in-memory .xlsx files from 2D data arrays for use as chart data sources.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+from mcp_handley_lab.microsoft.excel.package import ExcelPackage
+
+
+def create_embedded_excel(
+    data: list[list], sheet_name: str = "Sheet1"
+) -> tuple[bytes, str, int, int]:
+    """Create an in-memory Excel workbook from a 2D data array.
+
+    Args:
+        data: 2D list, e.g. [["Category", "S1", "S2"], ["A", 10, 30], ["B", 20, 40]]
+        sheet_name: Name for the worksheet
+
+    Returns:
+        (xlsx_bytes, sheet_name, n_rows, n_cols)
+    """
+    from mcp_handley_lab.microsoft.excel.ops.cells import set_cell_value
+    from mcp_handley_lab.microsoft.excel.ops.core import index_to_column_letter
+
+    pkg = ExcelPackage.new()
+
+    for row_idx, row in enumerate(data):
+        for col_idx, value in enumerate(row):
+            col_letter = index_to_column_letter(col_idx + 1)
+            cell_ref = f"{col_letter}{row_idx + 1}"
+            set_cell_value(pkg, sheet_name, cell_ref, value)
+
+    buf = BytesIO()
+    pkg.save(buf)
+    return buf.getvalue(), sheet_name, len(data), len(data[0]) if data else 0

--- a/src/mcp_handley_lab/microsoft/excel/ops/charts.py
+++ b/src/mcp_handley_lab/microsoft/excel/ops/charts.py
@@ -13,6 +13,14 @@ import contextlib
 
 from lxml import etree
 
+from mcp_handley_lab.microsoft.common.charts import (
+    CT_CHART,
+    RT_CHART,
+    _qn_a,
+    _qn_c,
+    _qn_r,
+    create_chart_xml,
+)
 from mcp_handley_lab.microsoft.excel.constants import RT, qn
 from mcp_handley_lab.microsoft.excel.models import ChartInfo
 from mcp_handley_lab.microsoft.excel.ops.core import (
@@ -22,9 +30,12 @@ from mcp_handley_lab.microsoft.excel.ops.core import (
 )
 from mcp_handley_lab.microsoft.excel.package import ExcelPackage
 
-# DrawingML namespaces
+# DrawingML spreadsheetDrawing namespace (Excel-specific)
+_XDR_NS = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+
+# Drawing-specific namespaces (includes xdr which is Excel-only)
 DRAWING_NSMAP = {
-    "xdr": "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing",
+    "xdr": _XDR_NS,
     "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
     "c": "http://schemas.openxmlformats.org/drawingml/2006/chart",
     "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
@@ -32,30 +43,11 @@ DRAWING_NSMAP = {
 
 # Content types
 CT_DRAWING = "application/vnd.openxmlformats-officedocument.drawing+xml"
-CT_CHART = "application/vnd.openxmlformats-officedocument.drawingml.chart+xml"
-
-# Relationship types
-RT_CHART = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"
 
 
 def _qn_xdr(tag: str) -> str:
     """Clark notation for spreadsheetDrawing namespace."""
-    return f"{{{DRAWING_NSMAP['xdr']}}}{tag}"
-
-
-def _qn_a(tag: str) -> str:
-    """Clark notation for drawingml main namespace."""
-    return f"{{{DRAWING_NSMAP['a']}}}{tag}"
-
-
-def _qn_c(tag: str) -> str:
-    """Clark notation for chart namespace."""
-    return f"{{{DRAWING_NSMAP['c']}}}{tag}"
-
-
-def _qn_r(tag: str) -> str:
-    """Clark notation for relationships namespace."""
-    return f"{{{DRAWING_NSMAP['r']}}}{tag}"
+    return f"{{{_XDR_NS}}}{tag}"
 
 
 def _get_sheet_drawing_path(pkg: ExcelPackage, sheet_name: str) -> str | None:
@@ -93,7 +85,7 @@ def _get_or_create_drawing(
             drawing_xml = etree.Element(
                 _qn_xdr("wsDr"),
                 nsmap={
-                    None: DRAWING_NSMAP["xdr"],
+                    None: _XDR_NS,
                     "a": DRAWING_NSMAP["a"],
                     "r": DRAWING_NSMAP["r"],
                 },
@@ -150,332 +142,6 @@ def _parse_position(position: str) -> tuple[int, int]:
 
     col = column_letter_to_index(col_letter)
     return col - 1, row_num - 1  # Convert to 0-indexed
-
-
-def _create_chart_xml(
-    chart_type: str,
-    data_range: str,
-    sheet_name: str,
-    title: str | None,
-) -> etree._Element:
-    """Create chart XML for the given type and data.
-
-    Chart types: bar, column, line, pie, scatter, area
-    """
-    # Normalize chart type
-    chart_type = chart_type.lower()
-
-    # Create chart root
-    chart_space = etree.Element(
-        _qn_c("chartSpace"),
-        nsmap={
-            None: DRAWING_NSMAP["c"],
-            "a": DRAWING_NSMAP["a"],
-            "r": DRAWING_NSMAP["r"],
-        },
-    )
-
-    # Add date1904 element (false for standard date system)
-    etree.SubElement(chart_space, _qn_c("date1904"), val="0")
-
-    # Add lang
-    etree.SubElement(chart_space, _qn_c("lang"), val="en-US")
-
-    # Add roundedCorners
-    etree.SubElement(chart_space, _qn_c("roundedCorners"), val="0")
-
-    # Create chart element
-    chart = etree.SubElement(chart_space, _qn_c("chart"))
-
-    # Add title if provided
-    if title:
-        title_elem = etree.SubElement(chart, _qn_c("title"))
-        tx = etree.SubElement(title_elem, _qn_c("tx"))
-        rich = etree.SubElement(tx, _qn_c("rich"))
-        etree.SubElement(rich, _qn_a("bodyPr"))
-        etree.SubElement(rich, _qn_a("lstStyle"))
-        p = etree.SubElement(rich, _qn_a("p"))
-        pPr = etree.SubElement(p, _qn_a("pPr"))
-        etree.SubElement(pPr, _qn_a("defRPr"))
-        r = etree.SubElement(p, _qn_a("r"))
-        etree.SubElement(r, _qn_a("rPr"), lang="en-US")
-        t = etree.SubElement(r, _qn_a("t"))
-        t.text = title
-        etree.SubElement(title_elem, _qn_c("overlay"), val="0")
-
-    # Add autoTitleDeleted
-    etree.SubElement(chart, _qn_c("autoTitleDeleted"), val="0" if title else "1")
-
-    # Create plot area
-    plot_area = etree.SubElement(chart, _qn_c("plotArea"))
-    etree.SubElement(plot_area, _qn_c("layout"))
-
-    # Format data range with sheet name
-    full_range = f"'{sheet_name}'!{data_range}"
-
-    # Add chart type-specific elements
-    if chart_type == "bar":
-        _add_bar_chart(plot_area, full_range, bar_dir="bar")
-    elif chart_type == "column":
-        _add_bar_chart(plot_area, full_range, bar_dir="col")
-    elif chart_type == "line":
-        _add_line_chart(plot_area, full_range)
-    elif chart_type == "pie":
-        _add_pie_chart(plot_area, full_range)
-    elif chart_type == "scatter":
-        _add_scatter_chart(plot_area, full_range)
-    elif chart_type == "area":
-        _add_area_chart(plot_area, full_range)
-    else:
-        raise ValueError(f"Unsupported chart type: {chart_type}")
-
-    # Add axes for non-pie charts
-    if chart_type != "pie":
-        _add_axes(plot_area, chart_type)
-
-    # Add legend
-    legend = etree.SubElement(chart, _qn_c("legend"))
-    etree.SubElement(legend, _qn_c("legendPos"), val="r")
-    etree.SubElement(legend, _qn_c("overlay"), val="0")
-
-    # Add plotVisOnly
-    etree.SubElement(chart, _qn_c("plotVisOnly"), val="1")
-
-    # Add dispBlanksAs
-    etree.SubElement(chart, _qn_c("dispBlanksAs"), val="gap")
-
-    # Add showDLblsOverMax
-    etree.SubElement(chart, _qn_c("showDLblsOverMax"), val="0")
-
-    # Add printSettings
-    print_settings = etree.SubElement(chart_space, _qn_c("printSettings"))
-    etree.SubElement(print_settings, _qn_c("headerFooter"))
-    etree.SubElement(
-        print_settings,
-        _qn_c("pageMargins"),
-        b="0.75",
-        l="0.7",
-        r="0.7",
-        t="0.75",
-        header="0.3",
-        footer="0.3",
-    )
-    etree.SubElement(print_settings, _qn_c("pageSetup"))
-
-    return chart_space
-
-
-def _add_bar_chart(
-    plot_area: etree._Element, data_range: str, bar_dir: str = "col"
-) -> None:
-    """Add bar/column chart to plot area."""
-    bar_chart = etree.SubElement(plot_area, _qn_c("barChart"))
-    etree.SubElement(bar_chart, _qn_c("barDir"), val=bar_dir)
-    etree.SubElement(bar_chart, _qn_c("grouping"), val="clustered")
-    etree.SubElement(bar_chart, _qn_c("varyColors"), val="0")
-
-    # Add series
-    ser = etree.SubElement(bar_chart, _qn_c("ser"))
-    etree.SubElement(ser, _qn_c("idx"), val="0")
-    etree.SubElement(ser, _qn_c("order"), val="0")
-
-    # Add values reference
-    val = etree.SubElement(ser, _qn_c("val"))
-    num_ref = etree.SubElement(val, _qn_c("numRef"))
-    f = etree.SubElement(num_ref, _qn_c("f"))
-    f.text = data_range
-
-    # Add data labels
-    d_lbls = etree.SubElement(bar_chart, _qn_c("dLbls"))
-    etree.SubElement(d_lbls, _qn_c("showLegendKey"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showVal"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showCatName"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showSerName"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showPercent"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showBubbleSize"), val="0")
-
-    # Gap width
-    etree.SubElement(bar_chart, _qn_c("gapWidth"), val="150")
-
-    # Axis IDs
-    etree.SubElement(bar_chart, _qn_c("axId"), val="100")
-    etree.SubElement(bar_chart, _qn_c("axId"), val="200")
-
-
-def _add_line_chart(plot_area: etree._Element, data_range: str) -> None:
-    """Add line chart to plot area."""
-    line_chart = etree.SubElement(plot_area, _qn_c("lineChart"))
-    etree.SubElement(line_chart, _qn_c("grouping"), val="standard")
-    etree.SubElement(line_chart, _qn_c("varyColors"), val="0")
-
-    # Add series
-    ser = etree.SubElement(line_chart, _qn_c("ser"))
-    etree.SubElement(ser, _qn_c("idx"), val="0")
-    etree.SubElement(ser, _qn_c("order"), val="0")
-
-    # Add marker
-    marker = etree.SubElement(ser, _qn_c("marker"))
-    etree.SubElement(marker, _qn_c("symbol"), val="none")
-
-    # Add values reference
-    val = etree.SubElement(ser, _qn_c("val"))
-    num_ref = etree.SubElement(val, _qn_c("numRef"))
-    f = etree.SubElement(num_ref, _qn_c("f"))
-    f.text = data_range
-
-    # Data labels
-    d_lbls = etree.SubElement(line_chart, _qn_c("dLbls"))
-    etree.SubElement(d_lbls, _qn_c("showLegendKey"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showVal"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showCatName"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showSerName"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showPercent"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showBubbleSize"), val="0")
-
-    # Smooth
-    etree.SubElement(line_chart, _qn_c("smooth"), val="0")
-
-    # Axis IDs
-    etree.SubElement(line_chart, _qn_c("axId"), val="100")
-    etree.SubElement(line_chart, _qn_c("axId"), val="200")
-
-
-def _add_pie_chart(plot_area: etree._Element, data_range: str) -> None:
-    """Add pie chart to plot area."""
-    pie_chart = etree.SubElement(plot_area, _qn_c("pieChart"))
-    etree.SubElement(pie_chart, _qn_c("varyColors"), val="1")
-
-    # Add series
-    ser = etree.SubElement(pie_chart, _qn_c("ser"))
-    etree.SubElement(ser, _qn_c("idx"), val="0")
-    etree.SubElement(ser, _qn_c("order"), val="0")
-
-    # Add values reference
-    val = etree.SubElement(ser, _qn_c("val"))
-    num_ref = etree.SubElement(val, _qn_c("numRef"))
-    f = etree.SubElement(num_ref, _qn_c("f"))
-    f.text = data_range
-
-    # Data labels
-    d_lbls = etree.SubElement(pie_chart, _qn_c("dLbls"))
-    etree.SubElement(d_lbls, _qn_c("showLegendKey"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showVal"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showCatName"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showSerName"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showPercent"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showBubbleSize"), val="0")
-
-    # First slice angle
-    etree.SubElement(pie_chart, _qn_c("firstSliceAng"), val="0")
-
-
-def _add_scatter_chart(plot_area: etree._Element, data_range: str) -> None:
-    """Add scatter chart to plot area."""
-    scatter_chart = etree.SubElement(plot_area, _qn_c("scatterChart"))
-    etree.SubElement(scatter_chart, _qn_c("scatterStyle"), val="lineMarker")
-    etree.SubElement(scatter_chart, _qn_c("varyColors"), val="0")
-
-    # Add series
-    ser = etree.SubElement(scatter_chart, _qn_c("ser"))
-    etree.SubElement(ser, _qn_c("idx"), val="0")
-    etree.SubElement(ser, _qn_c("order"), val="0")
-
-    # Add marker
-    marker = etree.SubElement(ser, _qn_c("marker"))
-    etree.SubElement(marker, _qn_c("symbol"), val="circle")
-    etree.SubElement(marker, _qn_c("size"), val="5")
-
-    # Y values reference
-    y_val = etree.SubElement(ser, _qn_c("yVal"))
-    num_ref = etree.SubElement(y_val, _qn_c("numRef"))
-    f = etree.SubElement(num_ref, _qn_c("f"))
-    f.text = data_range
-
-    # Smooth
-    etree.SubElement(ser, _qn_c("smooth"), val="0")
-
-    # Data labels
-    d_lbls = etree.SubElement(scatter_chart, _qn_c("dLbls"))
-    etree.SubElement(d_lbls, _qn_c("showLegendKey"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showVal"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showCatName"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showSerName"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showPercent"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showBubbleSize"), val="0")
-
-    # Axis IDs
-    etree.SubElement(scatter_chart, _qn_c("axId"), val="100")
-    etree.SubElement(scatter_chart, _qn_c("axId"), val="200")
-
-
-def _add_area_chart(plot_area: etree._Element, data_range: str) -> None:
-    """Add area chart to plot area."""
-    area_chart = etree.SubElement(plot_area, _qn_c("areaChart"))
-    etree.SubElement(area_chart, _qn_c("grouping"), val="standard")
-    etree.SubElement(area_chart, _qn_c("varyColors"), val="0")
-
-    # Add series
-    ser = etree.SubElement(area_chart, _qn_c("ser"))
-    etree.SubElement(ser, _qn_c("idx"), val="0")
-    etree.SubElement(ser, _qn_c("order"), val="0")
-
-    # Add values reference
-    val = etree.SubElement(ser, _qn_c("val"))
-    num_ref = etree.SubElement(val, _qn_c("numRef"))
-    f = etree.SubElement(num_ref, _qn_c("f"))
-    f.text = data_range
-
-    # Data labels
-    d_lbls = etree.SubElement(area_chart, _qn_c("dLbls"))
-    etree.SubElement(d_lbls, _qn_c("showLegendKey"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showVal"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showCatName"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showSerName"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showPercent"), val="0")
-    etree.SubElement(d_lbls, _qn_c("showBubbleSize"), val="0")
-
-    # Axis IDs
-    etree.SubElement(area_chart, _qn_c("axId"), val="100")
-    etree.SubElement(area_chart, _qn_c("axId"), val="200")
-
-
-def _add_axes(plot_area: etree._Element, chart_type: str) -> None:
-    """Add category and value axes to plot area."""
-    # Category axis (X)
-    if chart_type == "scatter":
-        cat_ax = etree.SubElement(plot_area, _qn_c("valAx"))
-    else:
-        cat_ax = etree.SubElement(plot_area, _qn_c("catAx"))
-
-    etree.SubElement(cat_ax, _qn_c("axId"), val="100")
-    scaling = etree.SubElement(cat_ax, _qn_c("scaling"))
-    etree.SubElement(scaling, _qn_c("orientation"), val="minMax")
-    etree.SubElement(cat_ax, _qn_c("delete"), val="0")
-    etree.SubElement(cat_ax, _qn_c("axPos"), val="b")
-    etree.SubElement(cat_ax, _qn_c("majorTickMark"), val="out")
-    etree.SubElement(cat_ax, _qn_c("minorTickMark"), val="none")
-    etree.SubElement(cat_ax, _qn_c("tickLblPos"), val="nextTo")
-    etree.SubElement(cat_ax, _qn_c("crossAx"), val="200")
-    etree.SubElement(cat_ax, _qn_c("crosses"), val="autoZero")
-    etree.SubElement(cat_ax, _qn_c("auto"), val="1")
-    etree.SubElement(cat_ax, _qn_c("lblAlgn"), val="ctr")
-    etree.SubElement(cat_ax, _qn_c("lblOffset"), val="100")
-
-    # Value axis (Y)
-    val_ax = etree.SubElement(plot_area, _qn_c("valAx"))
-    etree.SubElement(val_ax, _qn_c("axId"), val="200")
-    scaling2 = etree.SubElement(val_ax, _qn_c("scaling"))
-    etree.SubElement(scaling2, _qn_c("orientation"), val="minMax")
-    etree.SubElement(val_ax, _qn_c("delete"), val="0")
-    etree.SubElement(val_ax, _qn_c("axPos"), val="l")
-    etree.SubElement(val_ax, _qn_c("majorGridlines"))
-    etree.SubElement(val_ax, _qn_c("numFmt"), formatCode="General", sourceLinked="1")
-    etree.SubElement(val_ax, _qn_c("majorTickMark"), val="out")
-    etree.SubElement(val_ax, _qn_c("minorTickMark"), val="none")
-    etree.SubElement(val_ax, _qn_c("tickLblPos"), val="nextTo")
-    etree.SubElement(val_ax, _qn_c("crossAx"), val="100")
-    etree.SubElement(val_ax, _qn_c("crosses"), val="autoZero")
-    etree.SubElement(val_ax, _qn_c("crossBetween"), val="between")
 
 
 def _next_drawing_object_id(drawing_xml: etree._Element) -> int:
@@ -726,11 +392,18 @@ def create_chart(
     # Get or create drawing for sheet
     drawing_path, drawing_xml = _get_or_create_drawing(pkg, sheet_name)
 
-    # Create chart part
+    # Create chart part using shared builder
     chart_num = _find_next_chart_number(pkg)
     chart_path = f"/xl/charts/chart{chart_num}.xml"
 
-    chart_xml = _create_chart_xml(chart_type, data_range, sheet_name, title)
+    full_range = f"'{sheet_name}'!{data_range}"
+    chart_xml = create_chart_xml(
+        chart_type=chart_type,
+        sheet_name=sheet_name,
+        categories_range=None,
+        series=[("", "", full_range)],
+        title=title,
+    )
     pkg.set_xml(chart_path, chart_xml, CT_CHART)
 
     # Create relationship from drawing to chart
@@ -749,7 +422,7 @@ def create_chart(
         id=make_chart_id(chart_path),
         type=chart_type.lower(),
         title=title,
-        data_range=f"'{sheet_name}'!{data_range}",
+        data_range=full_range,
         position=position,
     )
 

--- a/src/mcp_handley_lab/microsoft/opc/constants.py
+++ b/src/mcp_handley_lab/microsoft/opc/constants.py
@@ -21,6 +21,9 @@ class CT:
     # Generic XML
     XML = "application/xml"
 
+    # DrawingML charts (shared across formats)
+    CHART = "application/vnd.openxmlformats-officedocument.drawingml.chart+xml"
+
     # Images (shared across formats)
     PNG = "image/png"
     JPEG = "image/jpeg"
@@ -53,6 +56,10 @@ class RT:
     # Shared across formats
     IMAGE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
     THEME = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme"
+    CHART = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"
+    PACKAGE = (
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/package"
+    )
 
 
 # Default content types by extension (shared across formats)

--- a/src/mcp_handley_lab/microsoft/powerpoint/constants.py
+++ b/src/mcp_handley_lab/microsoft/powerpoint/constants.py
@@ -12,6 +12,7 @@ NSMAP = {
     "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
     "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
     "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+    "c": "http://schemas.openxmlformats.org/drawingml/2006/chart",
     "p14": "http://schemas.microsoft.com/office/powerpoint/2010/main",
     "p15": "http://schemas.microsoft.com/office/powerpoint/2012/main",
     "mc": "http://schemas.openxmlformats.org/markup-compatibility/2006",

--- a/src/mcp_handley_lab/microsoft/powerpoint/models.py
+++ b/src/mcp_handley_lab/microsoft/powerpoint/models.py
@@ -161,6 +161,16 @@ class TableInfo(BaseModel):
     cells: list[TableCell] = Field(default_factory=list)
 
 
+class ChartInfo(BaseModel):
+    """Information about a chart on a slide."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    shape_key: str  # slide_num:shape_id
+    type: str  # bar, column, line, pie, scatter, area
+    title: str | None = None
+
+
 class PowerPointReadResult(BaseModel):
     """Result from read() operation."""
 
@@ -175,6 +185,7 @@ class PowerPointReadResult(BaseModel):
     layouts: list[LayoutInfo] | None = None
     images: list[ImageInfo] | None = None
     tables: list[TableInfo] | None = None
+    charts: list[ChartInfo] | None = None
     properties: DocumentProperties | None = None
 
 

--- a/src/mcp_handley_lab/microsoft/powerpoint/ops/charts.py
+++ b/src/mcp_handley_lab/microsoft/powerpoint/ops/charts.py
@@ -1,0 +1,460 @@
+"""Chart operations for PowerPoint presentations.
+
+Inserts DrawingML charts with embedded Excel workbooks as data sources.
+Charts are placed as p:graphicFrame elements on slides.
+"""
+
+from __future__ import annotations
+
+import re
+
+from lxml import etree
+
+from mcp_handley_lab.microsoft.common.charts import (
+    CHART_NSMAP,
+    CT_CHART,
+    CT_XLSX,
+    RT_CHART,
+    RT_PACKAGE,
+    _qn_c,
+    _qn_r,
+    compute_chart_refs,
+    create_chart_xml,
+    validate_chart_data,
+)
+from mcp_handley_lab.microsoft.common.embedding import create_embedded_excel
+from mcp_handley_lab.microsoft.powerpoint.constants import NSMAP, qn
+from mcp_handley_lab.microsoft.powerpoint.models import ChartInfo
+from mcp_handley_lab.microsoft.powerpoint.ops.core import (
+    inches_to_emu,
+    make_shape_key,
+    parse_shape_key,
+)
+from mcp_handley_lab.microsoft.powerpoint.package import PowerPointPackage
+
+
+def _embedding_referenced_elsewhere(
+    pkg: PowerPointPackage, excluding_chart: str, embed_path: str
+) -> bool:
+    """Check if an embedding is referenced by any chart other than the given one."""
+    for partname in pkg.iter_partnames():
+        if not partname.startswith("/ppt/charts/chart") or partname == excluding_chart:
+            continue
+        rels = pkg.get_rels(partname)
+        for _rid, rel in rels.items():
+            if rel.reltype == RT_PACKAGE:
+                resolved = pkg.resolve_rel_target(partname, _rid)
+                if resolved == embed_path:
+                    return True
+    return False
+
+
+def create_chart(
+    pkg: PowerPointPackage,
+    slide_num: int,
+    chart_type: str,
+    data: list[list],
+    x: float = 1.0,
+    y: float = 1.5,
+    width: float = 8.0,
+    height: float = 5.0,
+    title: str | None = None,
+) -> str:
+    """Add a chart to a slide.
+
+    Args:
+        pkg: PowerPoint package
+        slide_num: Target slide number (1-based)
+        chart_type: bar, column, line, pie, scatter, area
+        data: 2D list, e.g. [["Category", "S1", "S2"], ["A", 10, 30], ["B", 20, 40]]
+        x: X position in inches
+        y: Y position in inches
+        width: Chart width in inches
+        height: Chart height in inches
+        title: Optional chart title
+
+    Returns:
+        Shape key (slide_num:shape_id)
+    """
+    validate_chart_data(data)
+
+    slide_partname = pkg.get_slide_partname(slide_num)
+    slide_xml = pkg.get_slide_xml(slide_num)
+    sp_tree = slide_xml.find(qn("p:cSld") + "/" + qn("p:spTree"), NSMAP)
+    if sp_tree is None:
+        raise ValueError(f"Slide {slide_num} has no spTree")
+
+    # 1. Create embedded Excel workbook
+    xlsx_bytes, sheet_name, n_rows, n_cols = create_embedded_excel(data)
+
+    # 2. Store embedding
+    embed_partname = pkg.next_partname(
+        "/ppt/embeddings/Microsoft_Excel_Worksheet", ".xlsx"
+    )
+    pkg.set_bytes(embed_partname, xlsx_bytes, CT_XLSX)
+
+    # 3. Create chart part
+    chart_partname = pkg.next_partname("/ppt/charts/chart", ".xml")
+
+    # 4. Wire chart → embedding relationship (need rId for chart XML)
+    # Relative target from /ppt/charts/ to /ppt/embeddings/
+    embed_basename = embed_partname.split("/")[-1]
+    embed_rid = pkg.relate_to(
+        chart_partname, f"../embeddings/{embed_basename}", RT_PACKAGE
+    )
+
+    # 5. Compute data references and create chart XML
+    cat_range, series_list = compute_chart_refs(sheet_name, n_rows, n_cols)
+    chart_xml = create_chart_xml(
+        chart_type,
+        sheet_name,
+        cat_range,
+        series_list,
+        title=title,
+        external_data_rid=embed_rid,
+    )
+    pkg.set_xml(chart_partname, chart_xml, CT_CHART)
+
+    # 6. Wire slide → chart relationship
+    chart_basename = chart_partname.split("/")[-1]
+    chart_rid = pkg.relate_to(slide_partname, f"../charts/{chart_basename}", RT_CHART)
+
+    # 7. Get next shape ID
+    max_id = 0
+    for cNvPr in sp_tree.findall(".//" + qn("p:cNvPr"), NSMAP):
+        id_str = cNvPr.get("id", "0")
+        if id_str.isdigit():
+            max_id = max(max_id, int(id_str))
+    shape_id = max_id + 1
+
+    # Extract chart number from partname
+    m = re.search(r"chart(\d+)\.xml$", chart_partname)
+    chart_num = m.group(1) if m else str(shape_id)
+
+    # 8. Create graphicFrame
+    graphic_frame = _create_chart_graphic_frame(
+        shape_id,
+        chart_rid,
+        chart_num,
+        x,
+        y,
+        width,
+        height,
+    )
+    sp_tree.append(graphic_frame)
+
+    pkg.mark_xml_dirty(slide_partname)
+    return make_shape_key(slide_num, shape_id)
+
+
+def _create_chart_graphic_frame(
+    shape_id: int,
+    chart_rid: str,
+    chart_num: str,
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+) -> etree._Element:
+    """Create p:graphicFrame element for a chart."""
+    gf = etree.Element(qn("p:graphicFrame"))
+
+    # Non-visual properties
+    nvGfPr = etree.SubElement(gf, qn("p:nvGraphicFramePr"))
+    etree.SubElement(
+        nvGfPr,
+        qn("p:cNvPr"),
+        id=str(shape_id),
+        name=f"Chart {chart_num}",
+    )
+    cNvGfPr = etree.SubElement(nvGfPr, qn("p:cNvGraphicFramePr"))
+    etree.SubElement(cNvGfPr, qn("a:graphicFrameLocks"), noGrp="1")
+    etree.SubElement(nvGfPr, qn("p:nvPr"))
+
+    # Transform
+    xfrm = etree.SubElement(gf, qn("p:xfrm"))
+    etree.SubElement(
+        xfrm, qn("a:off"), x=str(inches_to_emu(x)), y=str(inches_to_emu(y))
+    )
+    etree.SubElement(
+        xfrm, qn("a:ext"), cx=str(inches_to_emu(width)), cy=str(inches_to_emu(height))
+    )
+
+    # Graphic with chart reference
+    graphic = etree.SubElement(gf, qn("a:graphic"))
+    graphic_data = etree.SubElement(
+        graphic,
+        qn("a:graphicData"),
+        uri="http://schemas.openxmlformats.org/drawingml/2006/chart",
+    )
+    chart_ref = etree.SubElement(
+        graphic_data,
+        _qn_c("chart"),
+        nsmap={"c": CHART_NSMAP["c"], "r": CHART_NSMAP["r"]},
+    )
+    chart_ref.set(_qn_r("id"), chart_rid)
+
+    return gf
+
+
+def list_charts(pkg: PowerPointPackage, slide_num: int) -> list[ChartInfo]:
+    """List all charts on a slide."""
+    slide_xml = pkg.get_slide_xml(slide_num)
+    slide_partname = pkg.get_slide_partname(slide_num)
+    sp_tree = slide_xml.find(qn("p:cSld") + "/" + qn("p:spTree"), NSMAP)
+    if sp_tree is None:
+        return []
+
+    charts = []
+    for gf in sp_tree.findall(qn("p:graphicFrame"), NSMAP):
+        chart_ref = gf.find(
+            ".//a:graphicData/c:chart",
+            {"a": NSMAP["a"], "c": NSMAP["c"]},
+        )
+        if chart_ref is None:
+            continue
+
+        chart_rid = chart_ref.get(_qn_r("id"))
+        if not chart_rid:
+            continue
+
+        chart_path = pkg.resolve_rel_target(slide_partname, chart_rid)
+        chart_xml = pkg.get_xml(chart_path)
+
+        # Get shape ID for the shape_key
+        nvGfPr = gf.find(qn("p:nvGraphicFramePr"), NSMAP)
+        cNvPr = nvGfPr.find(qn("p:cNvPr"), NSMAP) if nvGfPr is not None else None
+        shape_id = int(cNvPr.get("id", "0")) if cNvPr is not None else 0
+
+        info = _extract_chart_info(chart_xml, chart_path, slide_num, shape_id)
+        charts.append(info)
+
+    return charts
+
+
+def _extract_chart_info(
+    chart_xml: etree._Element,
+    chart_path: str,
+    slide_num: int,
+    shape_id: int,
+) -> ChartInfo:
+    """Extract ChartInfo from chart XML."""
+    chart = chart_xml.find(_qn_c("chart"))
+    plot_area = chart.find(_qn_c("plotArea")) if chart is not None else None
+
+    chart_type = "unknown"
+    if plot_area is not None:
+        for child in plot_area:
+            tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+            if tag == "barChart":
+                bar_dir = child.find(_qn_c("barDir"))
+                chart_type = (
+                    "bar"
+                    if bar_dir is not None and bar_dir.get("val") == "bar"
+                    else "column"
+                )
+                break
+            elif tag == "lineChart":
+                chart_type = "line"
+                break
+            elif tag == "pieChart":
+                chart_type = "pie"
+                break
+            elif tag == "scatterChart":
+                chart_type = "scatter"
+                break
+            elif tag == "areaChart":
+                chart_type = "area"
+                break
+
+    title_text = None
+    if chart is not None:
+        title_elem = chart.find(_qn_c("title"))
+        if title_elem is not None:
+            tx = title_elem.find(_qn_c("tx"))
+            if tx is not None:
+                rich = tx.find(_qn_c("rich"))
+                if rich is not None:
+                    from mcp_handley_lab.microsoft.common.charts import _qn_a
+
+                    texts = [t.text for t in rich.iter(_qn_a("t")) if t.text]
+                    if texts:
+                        title_text = "".join(texts)
+
+    return ChartInfo(
+        shape_key=make_shape_key(slide_num, shape_id),
+        type=chart_type,
+        title=title_text,
+    )
+
+
+def delete_chart(pkg: PowerPointPackage, slide_num: int, shape_key: str) -> None:
+    """Delete a chart from a slide.
+
+    Removes the graphicFrame, slide→chart relationship,
+    chart part, chart→embedding relationship, and embedded xlsx.
+    """
+    target_slide, target_shape_id = parse_shape_key(shape_key)
+    if target_slide != slide_num:
+        raise ValueError(f"Shape key {shape_key} is not on slide {slide_num}")
+
+    slide_partname = pkg.get_slide_partname(slide_num)
+    slide_xml = pkg.get_slide_xml(slide_num)
+    sp_tree = slide_xml.find(qn("p:cSld") + "/" + qn("p:spTree"), NSMAP)
+    if sp_tree is None:
+        raise ValueError(f"Slide {slide_num} has no spTree")
+
+    for gf in list(sp_tree.findall(qn("p:graphicFrame"), NSMAP)):
+        nvGfPr = gf.find(qn("p:nvGraphicFramePr"), NSMAP)
+        cNvPr = nvGfPr.find(qn("p:cNvPr"), NSMAP) if nvGfPr is not None else None
+        if cNvPr is None:
+            continue
+        sid = int(cNvPr.get("id", "0"))
+        if sid != target_shape_id:
+            continue
+
+        chart_ref = gf.find(
+            ".//a:graphicData/c:chart",
+            {"a": NSMAP["a"], "c": NSMAP["c"]},
+        )
+        if chart_ref is None:
+            raise ValueError(f"Shape {shape_key} is not a chart")
+
+        chart_rid = chart_ref.get(_qn_r("id"))
+        if chart_rid:
+            chart_path = pkg.resolve_rel_target(slide_partname, chart_rid)
+
+            # Remove chart → embedding (only if unreferenced by other charts)
+            chart_rels = pkg.get_rels(chart_path)
+            for rid, rel in chart_rels.items():
+                if rel.reltype == RT_PACKAGE:
+                    embed_path = pkg.resolve_rel_target(chart_path, rid)
+                    if not _embedding_referenced_elsewhere(pkg, chart_path, embed_path):
+                        pkg.drop_part(embed_path)
+                    break
+
+            # Remove chart part and slide→chart relationship
+            pkg.drop_part(chart_path)
+            pkg.remove_rel(slide_partname, chart_rid)
+
+        # Remove graphicFrame from spTree
+        sp_tree.remove(gf)
+        pkg.mark_xml_dirty(slide_partname)
+        return
+
+    raise KeyError(f"Chart not found: {shape_key}")
+
+
+def update_chart_data(
+    pkg: PowerPointPackage,
+    slide_num: int,
+    shape_key: str,
+    data: list[list],
+) -> None:
+    """Update chart data by replacing the embedded workbook and chart references.
+
+    Args:
+        pkg: PowerPoint package
+        slide_num: Slide number
+        shape_key: Shape key of the chart
+        data: New 2D data array
+    """
+    validate_chart_data(data)
+
+    target_slide, target_shape_id = parse_shape_key(shape_key)
+    if target_slide != slide_num:
+        raise ValueError(f"Shape key {shape_key} is not on slide {slide_num}")
+
+    slide_partname = pkg.get_slide_partname(slide_num)
+    slide_xml = pkg.get_slide_xml(slide_num)
+    sp_tree = slide_xml.find(qn("p:cSld") + "/" + qn("p:spTree"), NSMAP)
+    if sp_tree is None:
+        raise ValueError(f"Slide {slide_num} has no spTree")
+
+    for gf in sp_tree.findall(qn("p:graphicFrame"), NSMAP):
+        nvGfPr = gf.find(qn("p:nvGraphicFramePr"), NSMAP)
+        cNvPr = nvGfPr.find(qn("p:cNvPr"), NSMAP) if nvGfPr is not None else None
+        if cNvPr is None:
+            continue
+        sid = int(cNvPr.get("id", "0"))
+        if sid != target_shape_id:
+            continue
+
+        chart_ref = gf.find(
+            ".//a:graphicData/c:chart",
+            {"a": NSMAP["a"], "c": NSMAP["c"]},
+        )
+        if chart_ref is None:
+            raise ValueError(f"Shape {shape_key} is not a chart")
+
+        chart_rid = chart_ref.get(_qn_r("id"))
+        if not chart_rid:
+            raise ValueError("Chart reference has no rId")
+
+        chart_path = pkg.resolve_rel_target(slide_partname, chart_rid)
+
+        # Create new embedded workbook
+        xlsx_bytes, sheet_name, n_rows, n_cols = create_embedded_excel(data)
+
+        # Find and replace the embedded xlsx
+        chart_rels = pkg.get_rels(chart_path)
+        embed_rid = None
+        for rid, rel in chart_rels.items():
+            if rel.reltype == RT_PACKAGE:
+                embed_path = pkg.resolve_rel_target(chart_path, rid)
+                pkg.set_bytes(embed_path, xlsx_bytes, CT_XLSX)
+                embed_rid = rid
+                break
+
+        if embed_rid is None:
+            raise ValueError(f"No embedded workbook found for {shape_key}")
+
+        # Get chart type and title from existing chart
+        old_chart = pkg.get_xml(chart_path)
+        old_chart_elem = old_chart.find(_qn_c("chart"))
+        chart_type = "column"
+        title = None
+
+        if old_chart_elem is not None:
+            pa = old_chart_elem.find(_qn_c("plotArea"))
+            if pa is not None:
+                for child in pa:
+                    tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+                    if tag == "barChart":
+                        bar_dir = child.find(_qn_c("barDir"))
+                        chart_type = (
+                            "bar"
+                            if bar_dir is not None and bar_dir.get("val") == "bar"
+                            else "column"
+                        )
+                        break
+                    elif tag in ("lineChart", "pieChart", "scatterChart", "areaChart"):
+                        chart_type = tag.replace("Chart", "")
+                        break
+
+            title_elem = old_chart_elem.find(_qn_c("title"))
+            if title_elem is not None:
+                tx = title_elem.find(_qn_c("tx"))
+                if tx is not None:
+                    rich = tx.find(_qn_c("rich"))
+                    if rich is not None:
+                        from mcp_handley_lab.microsoft.common.charts import _qn_a
+
+                        texts = [t.text for t in rich.iter(_qn_a("t")) if t.text]
+                        if texts:
+                            title = "".join(texts)
+
+        # Regenerate chart XML
+        cat_range, series_list = compute_chart_refs(sheet_name, n_rows, n_cols)
+        new_chart = create_chart_xml(
+            chart_type,
+            sheet_name,
+            cat_range,
+            series_list,
+            title=title,
+            external_data_rid=embed_rid,
+        )
+        pkg.set_xml(chart_path, new_chart, CT_CHART)
+        return
+
+    raise KeyError(f"Chart not found: {shape_key}")

--- a/src/mcp_handley_lab/microsoft/powerpoint/ops/shapes.py
+++ b/src/mcp_handley_lab/microsoft/powerpoint/ops/shapes.py
@@ -42,7 +42,7 @@ def get_shape_type(shape: etree._Element) -> str:
             return "table"
         chart = shape.find(
             ".//" + qn("c:chart"),
-            {"c": "http://schemas.openxmlformats.org/drawingml/2006/chart"},
+            NSMAP,
         )
         if chart is not None:
             return "chart"

--- a/src/mcp_handley_lab/microsoft/powerpoint/tool.py
+++ b/src/mcp_handley_lab/microsoft/powerpoint/tool.py
@@ -29,6 +29,18 @@ from mcp_handley_lab.microsoft.powerpoint.models import (
     TableCell,
     TableInfo,
 )
+from mcp_handley_lab.microsoft.powerpoint.ops.charts import (
+    create_chart as create_chart_op,
+)
+from mcp_handley_lab.microsoft.powerpoint.ops.charts import (
+    delete_chart as delete_chart_op,
+)
+from mcp_handley_lab.microsoft.powerpoint.ops.charts import (
+    list_charts as list_charts_op,
+)
+from mcp_handley_lab.microsoft.powerpoint.ops.charts import (
+    update_chart_data as update_chart_data_op,
+)
 from mcp_handley_lab.microsoft.powerpoint.ops.images import (
     add_image,
     delete_image,
@@ -89,6 +101,7 @@ ReadScope = Literal[
     "layouts",
     "images",
     "tables",
+    "charts",
     "properties",
 ]
 
@@ -133,6 +146,7 @@ def read(
             - "layouts": List available slide layouts
             - "images": List images (all slides, or specific slide if slide_num given)
             - "tables": List tables with structure (requires slide_num)
+            - "charts": List charts on a slide (requires slide_num)
             - "properties": Document properties (title, author, custom properties)
         slide_num: Slide number (1-based). Required for shapes/text/notes/tables; optional for images (0 = all slides)
 
@@ -172,6 +186,11 @@ def read(
         if not slide_num:
             raise ValueError("slide_num required for tables scope")
         return _read_tables(pkg, slide_num).model_dump(exclude_none=True)
+
+    elif scope == "charts":
+        if not slide_num:
+            raise ValueError("slide_num required for charts scope")
+        return _read_charts(pkg, slide_num).model_dump(exclude_none=True)
 
     elif scope == "properties":
         return _read_properties(pkg).model_dump(exclude_none=True)
@@ -305,6 +324,15 @@ def _read_tables(pkg: PowerPointPackage, slide_num: int) -> PowerPointReadResult
     )
 
 
+def _read_charts(pkg: PowerPointPackage, slide_num: int) -> PowerPointReadResult:
+    """Read charts from a slide."""
+    charts = list_charts_op(pkg, slide_num)
+    return PowerPointReadResult(
+        scope="charts",
+        charts=charts,
+    )
+
+
 def _normalize_text(op: str, params: dict[str, Any]) -> dict[str, Any]:
     """Normalize escaped characters in text fields.
 
@@ -415,6 +443,9 @@ def edit(
         - set_property: Core property {property_name, property_value}
         - set_custom_property: Custom property {property_name, property_value, property_type}
         - delete_custom_property: Delete property {property_name}
+        - add_chart: Add chart {slide_num, chart_type, data, x, y, width, height, title}
+        - delete_chart: Delete chart {slide_num, shape_key}
+        - update_chart_data: Update chart {slide_num, shape_key, data}
 
     $prev chaining:
         Reference results of previous operations using $prev[N] where N is the
@@ -639,6 +670,12 @@ def _apply_op(
         return _op_set_custom_property(pkg, params)
     elif op == "delete_custom_property":
         return _op_delete_custom_property(pkg, params)
+    elif op == "add_chart":
+        return _op_add_chart(pkg, params)
+    elif op == "delete_chart":
+        return _op_delete_chart(pkg, params)
+    elif op == "update_chart_data":
+        return _op_update_chart_data(pkg, params)
     else:
         raise ValueError(f"Unknown operation: {op}")
 
@@ -1083,6 +1120,67 @@ def _op_delete_custom_property(
         }
     else:
         raise ValueError(f"Custom property '{property_name}' not found")
+
+
+def _op_add_chart(pkg: PowerPointPackage, params: dict[str, Any]) -> dict[str, Any]:
+    """Add a chart to a slide."""
+    slide_num = params.get("slide_num")
+    if not slide_num:
+        raise ValueError("slide_num required for add_chart")
+    chart_type = params.get("chart_type", "column")
+    data = params.get("data")
+    if not data:
+        raise ValueError("data required for add_chart (2D list)")
+    title = params.get("title")
+    x = float(params.get("x", 1.0))
+    y = float(params.get("y", 1.5))
+    width = float(params.get("width", 8.0))
+    height = float(params.get("height", 5.0))
+
+    shape_key = create_chart_op(
+        pkg,
+        slide_num,
+        chart_type,
+        data,
+        x=x,
+        y=y,
+        width=width,
+        height=height,
+        title=title,
+    )
+    return {
+        "message": f"Added {chart_type} chart to slide {slide_num}",
+        "element_id": shape_key,
+    }
+
+
+def _op_delete_chart(pkg: PowerPointPackage, params: dict[str, Any]) -> dict[str, Any]:
+    """Delete a chart from a slide."""
+    slide_num = params.get("slide_num")
+    if not slide_num:
+        raise ValueError("slide_num required for delete_chart")
+    shape_key = params.get("shape_key")
+    if not shape_key:
+        raise ValueError("shape_key required for delete_chart")
+    delete_chart_op(pkg, slide_num, shape_key)
+    return {"message": f"Deleted chart {shape_key}", "element_id": ""}
+
+
+def _op_update_chart_data(
+    pkg: PowerPointPackage, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Update chart data."""
+    slide_num = params.get("slide_num")
+    if not slide_num:
+        raise ValueError("slide_num required for update_chart_data")
+    shape_key = params.get("shape_key")
+    if not shape_key:
+        raise ValueError("shape_key required for update_chart_data")
+    data = params.get("data")
+    if not data:
+        raise ValueError("data required for update_chart_data (2D list)")
+    update_chart_data_op(pkg, slide_num, shape_key, data)
+    return {"message": f"Updated chart data for {shape_key}", "element_id": shape_key}
 
 
 # =============================================================================

--- a/src/mcp_handley_lab/microsoft/word/document.py
+++ b/src/mcp_handley_lab/microsoft/word/document.py
@@ -21,6 +21,18 @@ from mcp_handley_lab.microsoft.word.ops.bookmarks import (  # noqa: F401
     insert_caption,
     insert_cross_reference,
 )
+from mcp_handley_lab.microsoft.word.ops.charts import (  # noqa: F401
+    create_chart as create_chart_op,
+)
+from mcp_handley_lab.microsoft.word.ops.charts import (  # noqa: F401
+    delete_chart as delete_chart_op,
+)
+from mcp_handley_lab.microsoft.word.ops.charts import (  # noqa: F401
+    list_charts as list_charts_op,
+)
+from mcp_handley_lab.microsoft.word.ops.charts import (  # noqa: F401
+    update_chart_data as update_chart_data_op,
+)
 from mcp_handley_lab.microsoft.word.ops.comments import (  # noqa: F401
     _COMMENTS_EXT_NS,
     _COMMENTS_EXTENDED_CT,

--- a/src/mcp_handley_lab/microsoft/word/models.py
+++ b/src/mcp_handley_lab/microsoft/word/models.py
@@ -378,6 +378,14 @@ class BibSourceInfo(BaseModel):
     url: str | None = None
 
 
+class ChartInfo(BaseModel):
+    """Information about an embedded chart."""
+
+    id: str  # e.g. "chart_1"
+    type: str  # bar, column, line, pie, scatter, area
+    title: str | None = None
+
+
 class DocumentReadResult(BaseModel):
     """Result from read() tool."""
 
@@ -414,6 +422,7 @@ class DocumentReadResult(BaseModel):
     bibliography_sources: list["BibSourceInfo"] = Field(
         default_factory=list
     )  # For bibliography scope
+    charts: list["ChartInfo"] = Field(default_factory=list)  # For charts scope
 
 
 class OpResult(BaseModel):

--- a/src/mcp_handley_lab/microsoft/word/ops/__init__.py
+++ b/src/mcp_handley_lab/microsoft/word/ops/__init__.py
@@ -15,6 +15,18 @@ from mcp_handley_lab.microsoft.word.ops.bookmarks import (
     insert_caption,
     insert_cross_reference,
 )
+from mcp_handley_lab.microsoft.word.ops.charts import (
+    create_chart as create_chart_op,
+)
+from mcp_handley_lab.microsoft.word.ops.charts import (
+    delete_chart as delete_chart_op,
+)
+from mcp_handley_lab.microsoft.word.ops.charts import (
+    list_charts as list_charts_op,
+)
+from mcp_handley_lab.microsoft.word.ops.charts import (
+    update_chart_data as update_chart_data_op,
+)
 from mcp_handley_lab.microsoft.word.ops.comments import (
     _COMMENTS_EXT_NS,
     _COMMENTS_EXTENDED_CT,
@@ -493,6 +505,11 @@ __all__ = [
     "_get_equation_complexity",
     "_extract_equations_from_paragraph",
     "build_equations",
+    # Charts
+    "create_chart_op",
+    "list_charts_op",
+    "delete_chart_op",
+    "update_chart_data_op",
     # Render
     "render_to_images",
     "render_to_pdf",

--- a/src/mcp_handley_lab/microsoft/word/ops/charts.py
+++ b/src/mcp_handley_lab/microsoft/word/ops/charts.py
@@ -1,0 +1,447 @@
+"""Chart operations for Word documents.
+
+Inserts DrawingML charts with embedded Excel workbooks as data sources.
+Charts are placed inline using wp:inline within w:drawing elements.
+"""
+
+from __future__ import annotations
+
+from lxml import etree
+
+from mcp_handley_lab.microsoft.common.charts import (
+    CHART_NSMAP,
+    CT_CHART,
+    CT_XLSX,
+    RT_CHART,
+    RT_PACKAGE,
+    _qn_c,
+    _qn_r,
+    compute_chart_refs,
+    create_chart_xml,
+    validate_chart_data,
+)
+from mcp_handley_lab.microsoft.common.embedding import create_embedded_excel
+from mcp_handley_lab.microsoft.word.constants import NSMAP, qn
+from mcp_handley_lab.microsoft.word.models import ChartInfo
+from mcp_handley_lab.microsoft.word.ops.core import (
+    mark_dirty,
+    resolve_target,
+)
+from mcp_handley_lab.microsoft.word.package import WordPackage
+
+_EMU_PER_INCH = 914400
+
+
+def _next_chart_number(pkg: WordPackage) -> int:
+    """Find next available chart number."""
+    max_num = 0
+    for partname in pkg.iter_partnames():
+        if partname.startswith("/word/charts/chart") and partname.endswith(".xml"):
+            try:
+                num = int(partname[len("/word/charts/chart") : -4])
+                max_num = max(max_num, num)
+            except ValueError:
+                pass
+    return max_num + 1
+
+
+def _next_embed_number(pkg: WordPackage) -> int:
+    """Find next available embedding number."""
+    max_num = 0
+    for partname in pkg.iter_partnames():
+        if partname.startswith(
+            "/word/embeddings/Microsoft_Excel_Worksheet"
+        ) and partname.endswith(".xlsx"):
+            try:
+                num = int(
+                    partname[len("/word/embeddings/Microsoft_Excel_Worksheet") : -5]
+                )
+                max_num = max(max_num, num)
+            except ValueError:
+                pass
+    return max_num + 1
+
+
+def _next_docPr_id(pkg: WordPackage) -> int:
+    """Find next available docPr id by scanning the document."""
+    doc = pkg.document_xml
+    max_id = 0
+    for elem in doc.iter():
+        tag = elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
+        if tag == "docPr":
+            try:
+                max_id = max(max_id, int(elem.get("id", "0")))
+            except ValueError:
+                pass
+    return max_id + 1
+
+
+def _embedding_referenced_elsewhere(
+    pkg: WordPackage, excluding_chart: str, embed_path: str
+) -> bool:
+    """Check if an embedding is referenced by any chart other than the given one."""
+    for partname in pkg.iter_partnames():
+        if not partname.startswith("/word/charts/chart") or partname == excluding_chart:
+            continue
+        rels = pkg.get_rels(partname)
+        for _rid, rel in rels.items():
+            if rel.reltype == RT_PACKAGE:
+                resolved = pkg.resolve_rel_target(partname, _rid)
+                if resolved == embed_path:
+                    return True
+    return False
+
+
+def create_chart(
+    pkg: WordPackage,
+    target_id: str,
+    chart_type: str,
+    data: list[list],
+    title: str | None = None,
+    width_inches: float = 5.0,
+    height_inches: float = 3.0,
+) -> str:
+    """Insert a chart after the target paragraph.
+
+    Args:
+        pkg: Word package
+        target_id: Block ID of paragraph to insert after
+        chart_type: bar, column, line, pie, scatter, area
+        data: 2D list, e.g. [["Category", "S1", "S2"], ["A", 10, 30], ["B", 20, 40]]
+        title: Optional chart title
+        width_inches: Chart width in inches
+        height_inches: Chart height in inches
+
+    Returns:
+        chart_id string (chart_N)
+    """
+    validate_chart_data(data)
+
+    # 1. Resolve target paragraph
+    target = resolve_target(pkg, target_id)
+
+    # 2. Create embedded Excel workbook
+    xlsx_bytes, sheet_name, n_rows, n_cols = create_embedded_excel(data)
+
+    # 3. Store embedding
+    embed_num = _next_embed_number(pkg)
+    embed_partname = f"/word/embeddings/Microsoft_Excel_Worksheet{embed_num}.xlsx"
+    pkg.set_bytes(embed_partname, xlsx_bytes, CT_XLSX)
+
+    # 4. Create chart part
+    chart_num = _next_chart_number(pkg)
+    chart_partname = f"/word/charts/chart{chart_num}.xml"
+
+    # 5. Wire chart → embedding relationship first (need rId for chart XML)
+    embed_rel_target = f"../embeddings/Microsoft_Excel_Worksheet{embed_num}.xlsx"
+    embed_rid = pkg.relate_to(chart_partname, embed_rel_target, RT_PACKAGE)
+
+    # 6. Compute data references and create chart XML
+    cat_range, series_list = compute_chart_refs(sheet_name, n_rows, n_cols)
+    chart_xml = create_chart_xml(
+        chart_type,
+        sheet_name,
+        cat_range,
+        series_list,
+        title=title,
+        external_data_rid=embed_rid,
+    )
+    pkg.set_xml(chart_partname, chart_xml, CT_CHART)
+
+    # 7. Wire document → chart relationship
+    chart_rel_target = f"charts/chart{chart_num}.xml"
+    chart_rid = pkg.relate_to("/word/document.xml", chart_rel_target, RT_CHART)
+
+    # 8. Create drawing element
+    cx = int(width_inches * _EMU_PER_INCH)
+    cy = int(height_inches * _EMU_PER_INCH)
+    doc_pr_id = _next_docPr_id(pkg)
+
+    drawing = _create_inline_chart_drawing(chart_rid, cx, cy, doc_pr_id, chart_num)
+
+    # 9. Insert drawing into a new paragraph after target
+    new_p = etree.Element(qn("w:p"))
+    r = etree.SubElement(new_p, qn("w:r"))
+    r.append(drawing)
+
+    target_el = target.leaf_el
+    parent = target_el.getparent()
+    idx = list(parent).index(target_el)
+    parent.insert(idx + 1, new_p)
+
+    mark_dirty(pkg)
+
+    return f"chart_{chart_num}"
+
+
+def _create_inline_chart_drawing(
+    chart_rid: str, cx: int, cy: int, doc_pr_id: int, chart_num: int
+) -> etree._Element:
+    """Create w:drawing element with wp:inline containing chart reference."""
+    drawing = etree.Element(qn("w:drawing"))
+
+    inline = etree.SubElement(
+        drawing,
+        qn("wp:inline"),
+        distT="0",
+        distB="0",
+        distL="0",
+        distR="0",
+    )
+
+    etree.SubElement(inline, qn("wp:extent"), cx=str(cx), cy=str(cy))
+    etree.SubElement(inline, qn("wp:effectExtent"), l="0", t="0", r="0", b="0")
+    etree.SubElement(
+        inline,
+        qn("wp:docPr"),
+        id=str(doc_pr_id),
+        name=f"Chart {chart_num}",
+    )
+    etree.SubElement(inline, qn("wp:cNvGraphicFramePr"))
+
+    graphic = etree.SubElement(
+        inline,
+        qn("a:graphic"),
+        nsmap={"a": NSMAP["a"]},
+    )
+    graphic_data = etree.SubElement(
+        graphic,
+        qn("a:graphicData"),
+        uri="http://schemas.openxmlformats.org/drawingml/2006/chart",
+    )
+    chart_ref = etree.SubElement(
+        graphic_data,
+        _qn_c("chart"),
+        nsmap={"c": CHART_NSMAP["c"], "r": CHART_NSMAP["r"]},
+    )
+    chart_ref.set(_qn_r("id"), chart_rid)
+
+    return drawing
+
+
+def list_charts(pkg: WordPackage) -> list[ChartInfo]:
+    """List all charts in the document."""
+    doc = pkg.document_xml
+    charts = []
+
+    for drawing in doc.iter(qn("w:drawing")):
+        chart_ref = drawing.find(
+            ".//a:graphicData/c:chart",
+            {
+                "a": NSMAP["a"],
+                "c": NSMAP["c"],
+            },
+        )
+        if chart_ref is None:
+            continue
+
+        chart_rid = chart_ref.get(_qn_r("id"))
+        if not chart_rid:
+            continue
+
+        chart_path = pkg.resolve_rel_target("/word/document.xml", chart_rid)
+        chart_xml = pkg.get_xml(chart_path)
+
+        chart_info = _extract_chart_info(chart_xml, chart_path)
+        charts.append(chart_info)
+
+    return charts
+
+
+def _extract_chart_info(chart_xml: etree._Element, chart_path: str) -> ChartInfo:
+    """Extract ChartInfo from chart XML."""
+    chart = chart_xml.find(_qn_c("chart"))
+    plot_area = chart.find(_qn_c("plotArea")) if chart is not None else None
+
+    chart_type = "unknown"
+    if plot_area is not None:
+        for child in plot_area:
+            tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+            if tag == "barChart":
+                bar_dir = child.find(_qn_c("barDir"))
+                chart_type = (
+                    "bar"
+                    if bar_dir is not None and bar_dir.get("val") == "bar"
+                    else "column"
+                )
+                break
+            elif tag == "lineChart":
+                chart_type = "line"
+                break
+            elif tag == "pieChart":
+                chart_type = "pie"
+                break
+            elif tag == "scatterChart":
+                chart_type = "scatter"
+                break
+            elif tag == "areaChart":
+                chart_type = "area"
+                break
+
+    # Extract title
+    title_text = None
+    if chart is not None:
+        title_elem = chart.find(_qn_c("title"))
+        if title_elem is not None:
+            tx = title_elem.find(_qn_c("tx"))
+            if tx is not None:
+                rich = tx.find(_qn_c("rich"))
+                if rich is not None:
+                    from mcp_handley_lab.microsoft.common.charts import _qn_a
+
+                    texts = [t.text for t in rich.iter(_qn_a("t")) if t.text]
+                    if texts:
+                        title_text = "".join(texts)
+
+    # Extract chart_id from path: /word/charts/chart1.xml -> chart_1
+    import re
+
+    m = re.search(r"chart(\d+)\.xml$", chart_path)
+    chart_id = f"chart_{m.group(1)}" if m else chart_path
+
+    return ChartInfo(
+        id=chart_id,
+        type=chart_type,
+        title=title_text,
+    )
+
+
+def delete_chart(pkg: WordPackage, chart_id: str) -> None:
+    """Delete a chart by its ID (e.g. 'chart_1').
+
+    Removes the drawing paragraph, document→chart relationship,
+    chart part, chart→embedding relationship, and embedded xlsx.
+    """
+    chart_num = chart_id.split("_")[-1]
+    chart_partname = f"/word/charts/chart{chart_num}.xml"
+
+    if not pkg.has_part(chart_partname):
+        raise KeyError(f"Chart not found: {chart_id}")
+
+    # Find and remove the drawing paragraph containing this chart
+    doc = pkg.document_xml
+    chart_rels = pkg.get_rels("/word/document.xml")
+    target_rid = None
+
+    for rid, rel in chart_rels.items():
+        resolved = pkg.resolve_rel_target("/word/document.xml", rid)
+        if resolved == chart_partname:
+            target_rid = rid
+            break
+
+    if target_rid:
+        # Find drawing referencing this rId
+        for drawing in doc.iter(qn("w:drawing")):
+            chart_ref = drawing.find(
+                ".//a:graphicData/c:chart",
+                {"a": NSMAP["a"], "c": NSMAP["c"]},
+            )
+            if chart_ref is not None and chart_ref.get(_qn_r("id")) == target_rid:
+                # Remove the paragraph containing this drawing
+                p = drawing.getparent()
+                while p is not None and p.tag != qn("w:p"):
+                    p = p.getparent()
+                if p is not None and p.getparent() is not None:
+                    p.getparent().remove(p)
+                break
+
+        # Remove document → chart relationship
+        pkg.remove_rel("/word/document.xml", target_rid)
+
+    # Remove chart → embedding relationship and embedded xlsx (if unreferenced)
+    chart_rels_obj = pkg.get_rels(chart_partname)
+    for rid, rel in chart_rels_obj.items():
+        if rel.reltype == RT_PACKAGE:
+            embed_path = pkg.resolve_rel_target(chart_partname, rid)
+            if not _embedding_referenced_elsewhere(pkg, chart_partname, embed_path):
+                pkg.drop_part(embed_path)
+            break
+
+    # Remove chart part
+    pkg.drop_part(chart_partname)
+    mark_dirty(pkg)
+
+
+def update_chart_data(
+    pkg: WordPackage,
+    chart_id: str,
+    data: list[list],
+) -> None:
+    """Update chart data by replacing the embedded workbook and chart references.
+
+    Args:
+        pkg: Word package
+        chart_id: Chart ID (e.g. 'chart_1')
+        data: New 2D data array
+    """
+    validate_chart_data(data)
+
+    chart_num = chart_id.split("_")[-1]
+    chart_partname = f"/word/charts/chart{chart_num}.xml"
+
+    if not pkg.has_part(chart_partname):
+        raise KeyError(f"Chart not found: {chart_id}")
+
+    # Create new embedded workbook
+    xlsx_bytes, sheet_name, n_rows, n_cols = create_embedded_excel(data)
+
+    # Find and replace the embedded xlsx
+    chart_rels = pkg.get_rels(chart_partname)
+    embed_rid = None
+    for rid, rel in chart_rels.items():
+        if rel.reltype == RT_PACKAGE:
+            embed_path = pkg.resolve_rel_target(chart_partname, rid)
+            pkg.set_bytes(embed_path, xlsx_bytes, CT_XLSX)
+            embed_rid = rid
+            break
+
+    if embed_rid is None:
+        raise ValueError(f"No embedded workbook found for {chart_id}")
+
+    # Get existing chart XML to determine type
+    old_chart = pkg.get_xml(chart_partname)
+    old_plot = old_chart.find(_qn_c("chart"))
+    chart_type = "column"
+    if old_plot is not None:
+        pa = old_plot.find(_qn_c("plotArea"))
+        if pa is not None:
+            for child in pa:
+                tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+                if tag == "barChart":
+                    bar_dir = child.find(_qn_c("barDir"))
+                    chart_type = (
+                        "bar"
+                        if bar_dir is not None and bar_dir.get("val") == "bar"
+                        else "column"
+                    )
+                    break
+                elif tag in ("lineChart", "pieChart", "scatterChart", "areaChart"):
+                    chart_type = tag.replace("Chart", "")
+                    break
+
+    # Extract title from old chart
+    title = None
+    if old_plot is not None:
+        title_elem = old_plot.find(_qn_c("title"))
+        if title_elem is not None:
+            tx = title_elem.find(_qn_c("tx"))
+            if tx is not None:
+                rich = tx.find(_qn_c("rich"))
+                if rich is not None:
+                    from mcp_handley_lab.microsoft.common.charts import _qn_a
+
+                    texts = [t.text for t in rich.iter(_qn_a("t")) if t.text]
+                    if texts:
+                        title = "".join(texts)
+
+    # Regenerate chart XML with new references
+    cat_range, series_list = compute_chart_refs(sheet_name, n_rows, n_cols)
+    new_chart = create_chart_xml(
+        chart_type,
+        sheet_name,
+        cat_range,
+        series_list,
+        title=title,
+        external_data_rid=embed_rid,
+    )
+    pkg.set_xml(chart_partname, new_chart, CT_CHART)

--- a/src/mcp_handley_lab/microsoft/word/shared.py
+++ b/src/mcp_handley_lab/microsoft/word/shared.py
@@ -242,6 +242,9 @@ def read(
         return DocumentReadResult(
             block_count=len(bib_sources), bibliography_sources=bib_sources
         )
+    if scope == "charts":
+        charts = word_ops.list_charts_op(pkg)
+        return DocumentReadResult(block_count=len(charts), charts=charts)
     raise ValueError(f"Unknown scope: {scope}")
 
 

--- a/src/mcp_handley_lab/microsoft/word/tool.py
+++ b/src/mcp_handley_lab/microsoft/word/tool.py
@@ -904,6 +904,32 @@ def _apply_operation(pkg: WordPackage, file_path: str, params: dict) -> OpResult
         element_id = ""
         message = "Inserted bibliography field"
 
+    elif operation == "insert_chart":
+        chart_data = json.loads(content_data)
+        fmt = json.loads(formatting) if formatting else {}
+        chart_id = word_ops.create_chart_op(
+            pkg,
+            target_id,
+            chart_type=chart_data.get("chart_type", "column"),
+            data=chart_data["data"],
+            title=chart_data.get("title"),
+            width_inches=float(fmt.get("width", 5.0)),
+            height_inches=float(fmt.get("height", 3.0)),
+        )
+        element_id = chart_id
+        message = f"Inserted {chart_data.get('chart_type', 'column')} chart"
+
+    elif operation == "delete_chart":
+        word_ops.delete_chart_op(pkg, target_id)
+        element_id = ""
+        message = f"Deleted chart {target_id}"
+
+    elif operation == "update_chart_data":
+        chart_data = json.loads(content_data)
+        word_ops.update_chart_data_op(pkg, target_id, chart_data["data"])
+        element_id = target_id
+        message = f"Updated chart data for {target_id}"
+
     else:
         raise ValueError(f"Unknown operation: {operation}")
 
@@ -916,13 +942,13 @@ def _apply_operation(pkg: WordPackage, file_path: str, params: dict) -> OpResult
 
 
 @mcp.tool(
-    description="Read Word document content. Scopes: 'meta' (doc info), 'outline' (headings only), 'blocks' (all content), 'search' (find text), 'table_cells' (cells of a table), 'table_layout' (table alignment/autofit/row heights), 'runs' (text runs in a paragraph), 'comments' (all comments), 'headers_footers' (headers/footers per section), 'page_setup' (margins, orientation per section), 'images' (embedded inline images), 'hyperlinks' (all hyperlinks with URLs), 'styles' (all document styles), 'style' (detailed formatting for a specific style by name in target_id), 'revisions' (tracked changes/revisions), 'list' (list properties for a paragraph by target_id), 'text_boxes' (all text boxes/floating content), 'text_box_content' (paragraphs inside a text box by target_id), 'bookmarks' (all bookmarks), 'captions' (all captions), 'toc' (table of contents info), 'footnotes' (all footnotes and endnotes), 'content_controls' (all content controls/SDTs), 'equations' (math equations with simplified text), 'bibliography' (bibliography sources). Block IDs are content-addressed (type_hash_occurrence) and CHANGE when content changes or after inserts/deletes shift occurrence index - use element_id from edit response for chaining."
+    description="Read Word document content. Scopes: 'meta' (doc info), 'outline' (headings only), 'blocks' (all content), 'search' (find text), 'table_cells' (cells of a table), 'table_layout' (table alignment/autofit/row heights), 'runs' (text runs in a paragraph), 'comments' (all comments), 'headers_footers' (headers/footers per section), 'page_setup' (margins, orientation per section), 'images' (embedded inline images), 'hyperlinks' (all hyperlinks with URLs), 'styles' (all document styles), 'style' (detailed formatting for a specific style by name in target_id), 'revisions' (tracked changes/revisions), 'list' (list properties for a paragraph by target_id), 'text_boxes' (all text boxes/floating content), 'text_box_content' (paragraphs inside a text box by target_id), 'bookmarks' (all bookmarks), 'captions' (all captions), 'toc' (table of contents info), 'footnotes' (all footnotes and endnotes), 'content_controls' (all content controls/SDTs), 'equations' (math equations with simplified text), 'bibliography' (bibliography sources), 'charts' (embedded charts). Block IDs are content-addressed (type_hash_occurrence) and CHANGE when content changes or after inserts/deletes shift occurrence index - use element_id from edit response for chaining."
 )
 def read(
     file_path: str = Field(..., description="Path to .docx file"),
     scope: str = Field(
         "outline",
-        description="What to read: 'meta', 'outline', 'blocks', 'search', 'table_cells', 'table_layout', 'runs', 'comments', 'headers_footers', 'page_setup', 'images', 'hyperlinks', 'styles', 'style', 'revisions', 'list', 'text_boxes', 'text_box_content', 'bookmarks', 'captions', 'toc', 'footnotes', 'content_controls', 'equations', 'bibliography'",
+        description="What to read: 'meta', 'outline', 'blocks', 'search', 'table_cells', 'table_layout', 'runs', 'comments', 'headers_footers', 'page_setup', 'images', 'hyperlinks', 'styles', 'style', 'revisions', 'list', 'text_boxes', 'text_box_content', 'bookmarks', 'captions', 'toc', 'footnotes', 'content_controls', 'equations', 'bibliography', 'charts'",
     ),
     target_id: str = Field(
         "",
@@ -966,7 +992,7 @@ def render(
 
 
 @mcp.tool(
-    description="Edit Word document with batch operations. Supported ops: 'insert_before', 'insert_after', 'append', 'delete', 'replace', 'style', 'edit_cell', 'edit_run', 'edit_style', 'add_comment', 'reply_comment', 'resolve_comment', 'unresolve_comment', 'set_header', 'set_footer', 'set_first_page_header', 'set_first_page_footer', 'set_even_page_header', 'set_even_page_footer', 'append_header', 'append_footer', 'clear_header', 'clear_footer', 'set_margins', 'set_orientation', 'set_columns', 'set_line_numbering', 'set_page_borders', 'set_custom_property', 'delete_custom_property', 'create_style', 'delete_style', 'insert_image', 'insert_floating_image', 'delete_image', 'add_row', 'add_column', 'delete_row', 'delete_column', 'add_page_break', 'add_break', 'set_meta', 'add_section', 'merge_cells', 'set_table_alignment', 'set_table_autofit', 'set_table_fixed_layout', 'set_row_height', 'set_cell_width', 'set_cell_vertical_alignment', 'set_cell_borders', 'set_cell_shading', 'set_header_row', 'add_tab_stop', 'clear_tab_stops', 'insert_field', 'insert_page_x_of_y', 'accept_change', 'reject_change', 'accept_all_changes', 'reject_all_changes', 'create_list', 'set_list_level', 'promote_list', 'demote_list', 'restart_numbering', 'remove_list', 'add_to_list', 'edit_text_box', 'add_bookmark', 'add_hyperlink', 'insert_cross_ref', 'insert_caption', 'insert_toc', 'update_toc', 'add_footnote', 'delete_footnote', 'set_content_control', 'create_content_control', 'add_source', 'delete_source', 'insert_citation', 'insert_bibliography'. Block IDs are content-addressed and CHANGE when content changes or after inserts/deletes shift occurrence index. Always use element_id from response for chaining operations on modified content. Creates a new file if file_path doesn't exist. 'update_toc' sets dirty flag; Word updates content on open. 'add_to_list' adds a new paragraph to an existing list; content_data: {\"text\": \"...\", \"position\": \"before|after\", \"level\": 0-8 (optional)}. 'add_hyperlink' content_data: {\"text\": \"...\", \"address\"?: \"...\", \"fragment\"?: \"...\", \"replace\"?: true}."
+    description="Edit Word document with batch operations. Supported ops: 'insert_before', 'insert_after', 'append', 'delete', 'replace', 'style', 'edit_cell', 'edit_run', 'edit_style', 'add_comment', 'reply_comment', 'resolve_comment', 'unresolve_comment', 'set_header', 'set_footer', 'set_first_page_header', 'set_first_page_footer', 'set_even_page_header', 'set_even_page_footer', 'append_header', 'append_footer', 'clear_header', 'clear_footer', 'set_margins', 'set_orientation', 'set_columns', 'set_line_numbering', 'set_page_borders', 'set_custom_property', 'delete_custom_property', 'create_style', 'delete_style', 'insert_image', 'insert_floating_image', 'delete_image', 'add_row', 'add_column', 'delete_row', 'delete_column', 'add_page_break', 'add_break', 'set_meta', 'add_section', 'merge_cells', 'set_table_alignment', 'set_table_autofit', 'set_table_fixed_layout', 'set_row_height', 'set_cell_width', 'set_cell_vertical_alignment', 'set_cell_borders', 'set_cell_shading', 'set_header_row', 'add_tab_stop', 'clear_tab_stops', 'insert_field', 'insert_page_x_of_y', 'accept_change', 'reject_change', 'accept_all_changes', 'reject_all_changes', 'create_list', 'set_list_level', 'promote_list', 'demote_list', 'restart_numbering', 'remove_list', 'add_to_list', 'edit_text_box', 'add_bookmark', 'add_hyperlink', 'insert_cross_ref', 'insert_caption', 'insert_toc', 'update_toc', 'add_footnote', 'delete_footnote', 'set_content_control', 'create_content_control', 'add_source', 'delete_source', 'insert_citation', 'insert_bibliography', 'insert_chart', 'delete_chart', 'update_chart_data'. Block IDs are content-addressed and CHANGE when content changes or after inserts/deletes shift occurrence index. Always use element_id from response for chaining operations on modified content. Creates a new file if file_path doesn't exist. 'update_toc' sets dirty flag; Word updates content on open. 'add_to_list' adds a new paragraph to an existing list; content_data: {\"text\": \"...\", \"position\": \"before|after\", \"level\": 0-8 (optional)}. 'add_hyperlink' content_data: {\"text\": \"...\", \"address\"?: \"...\", \"fragment\"?: \"...\", \"replace\"?: true}. 'insert_chart' content_data: {\"chart_type\": \"bar|column|line|pie|scatter|area\", \"data\": [[\"Cat\",\"S1\"],[\"A\",10]], \"title\"?: \"...\"}, formatting: {\"width\"?: 5.0, \"height\"?: 3.0}."
 )
 def edit(
     file_path: str = Field(..., description="Path to .docx file"),

--- a/tests/powerpoint/test_powerpoint_charts.py
+++ b/tests/powerpoint/test_powerpoint_charts.py
@@ -1,0 +1,303 @@
+"""Tests for PowerPoint chart operations (create, list, delete, update)."""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mcp_handley_lab.microsoft.powerpoint.ops.charts import (
+    create_chart,
+    delete_chart,
+    list_charts,
+    update_chart_data,
+)
+from mcp_handley_lab.microsoft.powerpoint.ops.slides import add_slide
+from mcp_handley_lab.microsoft.powerpoint.package import PowerPointPackage
+from mcp_handley_lab.microsoft.powerpoint.tool import mcp
+
+
+def _new_pptx_with_slide() -> PowerPointPackage:
+    """Create a PowerPointPackage with one blank slide."""
+    pkg = PowerPointPackage.new()
+    add_slide(pkg)
+    return pkg
+
+
+SAMPLE_DATA = [["Category", "S1", "S2"], ["A", 10, 30], ["B", 20, 40], ["C", 15, 25]]
+
+
+class TestCreateChart:
+    """Tests for PowerPoint chart creation."""
+
+    def test_create_column_chart(self):
+        pkg = _new_pptx_with_slide()
+        shape_key = create_chart(pkg, 1, "column", SAMPLE_DATA, title="Revenue")
+        assert ":" in shape_key  # slide_num:shape_id format
+
+    def test_create_bar_chart(self):
+        pkg = _new_pptx_with_slide()
+        shape_key = create_chart(pkg, 1, "bar", SAMPLE_DATA)
+        assert shape_key.startswith("1:")
+
+    def test_create_line_chart(self):
+        pkg = _new_pptx_with_slide()
+        shape_key = create_chart(pkg, 1, "line", SAMPLE_DATA)
+        assert shape_key.startswith("1:")
+
+    def test_create_pie_chart(self):
+        pkg = _new_pptx_with_slide()
+        shape_key = create_chart(pkg, 1, "pie", SAMPLE_DATA)
+        assert shape_key.startswith("1:")
+
+    def test_create_scatter_chart(self):
+        pkg = _new_pptx_with_slide()
+        shape_key = create_chart(pkg, 1, "scatter", SAMPLE_DATA)
+        assert shape_key.startswith("1:")
+
+    def test_create_area_chart(self):
+        pkg = _new_pptx_with_slide()
+        shape_key = create_chart(pkg, 1, "area", SAMPLE_DATA)
+        assert shape_key.startswith("1:")
+
+    def test_create_chart_invalid_type(self):
+        pkg = _new_pptx_with_slide()
+        with pytest.raises(ValueError, match="Unsupported"):
+            create_chart(pkg, 1, "radar", SAMPLE_DATA)
+
+    def test_create_multiple_charts(self):
+        pkg = _new_pptx_with_slide()
+        sk1 = create_chart(pkg, 1, "column", SAMPLE_DATA, title="Chart 1")
+        sk2 = create_chart(pkg, 1, "bar", SAMPLE_DATA, title="Chart 2")
+        assert sk1 != sk2
+
+    def test_chart_custom_position(self):
+        pkg = _new_pptx_with_slide()
+        shape_key = create_chart(
+            pkg,
+            1,
+            "column",
+            SAMPLE_DATA,
+            x=2.0,
+            y=3.0,
+            width=6.0,
+            height=4.0,
+        )
+        assert shape_key.startswith("1:")
+
+    def test_chart_has_embedded_workbook(self):
+        pkg = _new_pptx_with_slide()
+        create_chart(pkg, 1, "column", SAMPLE_DATA)
+        found = any(
+            p.startswith("/ppt/embeddings/Microsoft_Excel_Worksheet")
+            for p in pkg.iter_partnames()
+        )
+        assert found
+
+    def test_chart_has_chart_part(self):
+        pkg = _new_pptx_with_slide()
+        create_chart(pkg, 1, "column", SAMPLE_DATA)
+        found = any(p.startswith("/ppt/charts/chart") for p in pkg.iter_partnames())
+        assert found
+
+
+class TestListCharts:
+    """Tests for listing PowerPoint charts."""
+
+    def test_list_empty(self):
+        pkg = _new_pptx_with_slide()
+        charts = list_charts(pkg, 1)
+        assert charts == []
+
+    def test_list_after_create(self):
+        pkg = _new_pptx_with_slide()
+        create_chart(pkg, 1, "column", SAMPLE_DATA, title="Revenue")
+        charts = list_charts(pkg, 1)
+        assert len(charts) == 1
+        assert charts[0].type == "column"
+        assert charts[0].title == "Revenue"
+
+    def test_list_multiple(self):
+        pkg = _new_pptx_with_slide()
+        create_chart(pkg, 1, "bar", SAMPLE_DATA, title="Bar")
+        create_chart(pkg, 1, "line", SAMPLE_DATA, title="Line")
+        charts = list_charts(pkg, 1)
+        assert len(charts) == 2
+        types = {c.type for c in charts}
+        assert types == {"bar", "line"}
+
+    def test_list_chart_types(self):
+        """Each chart type is correctly detected."""
+        for ct in ("bar", "column", "line", "pie", "scatter", "area"):
+            pkg = _new_pptx_with_slide()
+            create_chart(pkg, 1, ct, SAMPLE_DATA)
+            charts = list_charts(pkg, 1)
+            assert charts[0].type == ct, f"Failed for {ct}"
+
+
+class TestDeleteChart:
+    """Tests for PowerPoint chart deletion."""
+
+    def test_delete_chart(self):
+        pkg = _new_pptx_with_slide()
+        shape_key = create_chart(pkg, 1, "column", SAMPLE_DATA)
+        delete_chart(pkg, 1, shape_key)
+        charts = list_charts(pkg, 1)
+        assert len(charts) == 0
+
+    def test_delete_nonexistent_raises(self):
+        pkg = _new_pptx_with_slide()
+        with pytest.raises(KeyError):
+            delete_chart(pkg, 1, "1:999")
+
+    def test_delete_one_of_multiple(self):
+        pkg = _new_pptx_with_slide()
+        create_chart(pkg, 1, "column", SAMPLE_DATA, title="Keep")
+        sk2 = create_chart(pkg, 1, "bar", SAMPLE_DATA, title="Delete")
+        delete_chart(pkg, 1, sk2)
+        charts = list_charts(pkg, 1)
+        assert len(charts) == 1
+        assert charts[0].title == "Keep"
+
+    def test_delete_removes_parts(self):
+        pkg = _new_pptx_with_slide()
+        shape_key = create_chart(pkg, 1, "column", SAMPLE_DATA)
+        chart_parts = [p for p in pkg.iter_partnames() if "/ppt/charts/" in p]
+        embed_parts = [p for p in pkg.iter_partnames() if "/ppt/embeddings/" in p]
+        assert len(chart_parts) >= 1
+        assert len(embed_parts) >= 1
+
+        delete_chart(pkg, 1, shape_key)
+
+        chart_parts_after = [p for p in pkg.iter_partnames() if "/ppt/charts/" in p]
+        embed_parts_after = [p for p in pkg.iter_partnames() if "/ppt/embeddings/" in p]
+        assert len(chart_parts_after) == 0
+        assert len(embed_parts_after) == 0
+
+    def test_wrong_slide_raises(self):
+        pkg = _new_pptx_with_slide()
+        shape_key = create_chart(pkg, 1, "column", SAMPLE_DATA)
+        # Shape key says slide 1, but we pass slide 2
+        with pytest.raises(ValueError, match="not on slide"):
+            delete_chart(pkg, 2, shape_key)
+
+
+class TestUpdateChartData:
+    """Tests for updating PowerPoint chart data."""
+
+    def test_update_data(self):
+        pkg = _new_pptx_with_slide()
+        shape_key = create_chart(pkg, 1, "column", SAMPLE_DATA, title="Original")
+
+        new_data = [["Cat", "Sales"], ["X", 100], ["Y", 200]]
+        update_chart_data(pkg, 1, shape_key, new_data)
+
+        charts = list_charts(pkg, 1)
+        assert len(charts) == 1
+        assert charts[0].title == "Original"
+        assert charts[0].type == "column"
+
+    def test_update_nonexistent_raises(self):
+        pkg = _new_pptx_with_slide()
+        with pytest.raises(KeyError):
+            update_chart_data(pkg, 1, "1:999", SAMPLE_DATA)
+
+
+class TestChartPersistence:
+    """Tests for chart round-trip through save/load."""
+
+    def test_chart_survives_save(self):
+        pkg = _new_pptx_with_slide()
+        create_chart(pkg, 1, "column", SAMPLE_DATA, title="Persist")
+
+        buf = io.BytesIO()
+        pkg.save(buf)
+        buf.seek(0)
+
+        pkg2 = PowerPointPackage.open(buf)
+        charts = list_charts(pkg2, 1)
+        assert len(charts) == 1
+        assert charts[0].type == "column"
+        assert charts[0].title == "Persist"
+
+    def test_full_crud_cycle(self):
+        """Create, list, update, delete cycle."""
+        pkg = _new_pptx_with_slide()
+
+        # Create
+        shape_key = create_chart(pkg, 1, "bar", SAMPLE_DATA, title="Cycle")
+
+        # List
+        charts = list_charts(pkg, 1)
+        assert len(charts) == 1
+
+        # Update
+        new_data = [["Cat", "Revenue"], ["Q1", 500], ["Q2", 600]]
+        update_chart_data(pkg, 1, shape_key, new_data)
+        charts = list_charts(pkg, 1)
+        assert charts[0].title == "Cycle"
+        assert charts[0].type == "bar"
+
+        # Delete
+        delete_chart(pkg, 1, shape_key)
+        assert list_charts(pkg, 1) == []
+
+
+class TestPowerPointChartMcpTool:
+    """Tests for PowerPoint chart operations via MCP tool interface."""
+
+    @pytest.mark.asyncio
+    async def test_add_chart_via_tool(self):
+        with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as f:
+            path = Path(f.name)
+        path.unlink()  # remove so edit() auto-creates
+
+        try:
+            # Create presentation with a slide
+            await mcp.call_tool(
+                "edit",
+                {
+                    "file_path": str(path),
+                    "ops": json.dumps(
+                        [
+                            {"op": "add_slide"},
+                        ]
+                    ),
+                },
+            )
+
+            # Add chart
+            await mcp.call_tool(
+                "edit",
+                {
+                    "file_path": str(path),
+                    "ops": json.dumps(
+                        [
+                            {
+                                "op": "add_chart",
+                                "slide_num": 1,
+                                "chart_type": "column",
+                                "data": [["Cat", "Sales"], ["A", 10], ["B", 20]],
+                                "title": "Test Chart",
+                            },
+                        ]
+                    ),
+                },
+            )
+
+            # Verify via read charts scope
+            result = await mcp.call_tool(
+                "read",
+                {"file_path": str(path), "scope": "charts", "slide_num": 1},
+            )
+            # Handle both tuple (content_list, extra) and list returns
+            content_list = result[0] if isinstance(result, tuple) else result
+            data = json.loads(content_list[0].text)
+            assert len(data["charts"]) == 1
+            assert data["charts"][0]["type"] == "column"
+            assert data["charts"][0]["title"] == "Test Chart"
+        finally:
+            path.unlink(missing_ok=True)

--- a/tests/test_common_charts.py
+++ b/tests/test_common_charts.py
@@ -1,0 +1,534 @@
+"""Tests for shared chart XML builders and embedding utilities."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from lxml import etree
+
+from mcp_handley_lab.microsoft.common.charts import (
+    CHART_NSMAP,
+    _col_letter,
+    compute_chart_refs,
+    create_chart_xml,
+    validate_chart_data,
+)
+from mcp_handley_lab.microsoft.common.embedding import create_embedded_excel
+from mcp_handley_lab.microsoft.excel.package import ExcelPackage
+
+
+class TestColLetter:
+    """Tests for _col_letter column index conversion."""
+
+    def test_single_letters(self):
+        assert _col_letter(0) == "A"
+        assert _col_letter(1) == "B"
+        assert _col_letter(25) == "Z"
+
+    def test_double_letters(self):
+        assert _col_letter(26) == "AA"
+        assert _col_letter(27) == "AB"
+        assert _col_letter(51) == "AZ"
+        assert _col_letter(52) == "BA"
+
+
+class TestComputeChartRefs:
+    """Tests for compute_chart_refs dimension-to-range conversion."""
+
+    def test_single_series(self):
+        cat_range, series = compute_chart_refs("Sheet1", n_rows=4, n_cols=2)
+        assert cat_range == "'Sheet1'!$A$2:$A$4"
+        assert len(series) == 1
+        name_ref, name_text, val_range = series[0]
+        assert name_ref == "'Sheet1'!$B$1"
+        assert val_range == "'Sheet1'!$B$2:$B$4"
+
+    def test_multi_series(self):
+        cat_range, series = compute_chart_refs("Data", n_rows=5, n_cols=4)
+        assert cat_range == "'Data'!$A$2:$A$5"
+        assert len(series) == 3
+        # Series B, C, D
+        assert series[0][0] == "'Data'!$B$1"
+        assert series[0][2] == "'Data'!$B$2:$B$5"
+        assert series[1][0] == "'Data'!$C$1"
+        assert series[2][0] == "'Data'!$D$1"
+
+    def test_single_data_row(self):
+        cat_range, series = compute_chart_refs("S", n_rows=2, n_cols=2)
+        assert cat_range == "'S'!$A$2:$A$2"
+        assert len(series) == 1
+        assert series[0][2] == "'S'!$B$2:$B$2"
+
+
+class TestCreateChartXml:
+    """Tests for the shared chart XML builder."""
+
+    def _ns(self, tag: str) -> str:
+        return f"{{{CHART_NSMAP['c']}}}{tag}"
+
+    def test_bar_chart(self):
+        xml = create_chart_xml(
+            "bar",
+            "Sheet1",
+            "'S'!$A$2:$A$3",
+            [("'S'!$B$1", "S1", "'S'!$B$2:$B$3")],
+            title="Sales",
+        )
+        chart = xml.find(self._ns("chart"))
+        assert chart is not None
+        plot = chart.find(self._ns("plotArea"))
+        bar = plot.find(self._ns("barChart"))
+        assert bar is not None
+        bar_dir = bar.find(self._ns("barDir"))
+        assert bar_dir.get("val") == "bar"
+
+    def test_column_chart(self):
+        xml = create_chart_xml(
+            "column",
+            "Sheet1",
+            "'S'!$A$2:$A$3",
+            [("'S'!$B$1", "S1", "'S'!$B$2:$B$3")],
+        )
+        chart = xml.find(self._ns("chart"))
+        plot = chart.find(self._ns("plotArea"))
+        bar = plot.find(self._ns("barChart"))
+        assert bar is not None
+        bar_dir = bar.find(self._ns("barDir"))
+        assert bar_dir.get("val") == "col"
+
+    def test_line_chart(self):
+        xml = create_chart_xml(
+            "line",
+            "Sheet1",
+            "'S'!$A$2:$A$3",
+            [("'S'!$B$1", "S1", "'S'!$B$2:$B$3")],
+        )
+        chart = xml.find(self._ns("chart"))
+        plot = chart.find(self._ns("plotArea"))
+        assert plot.find(self._ns("lineChart")) is not None
+
+    def test_pie_chart(self):
+        xml = create_chart_xml(
+            "pie",
+            "Sheet1",
+            "'S'!$A$2:$A$3",
+            [("'S'!$B$1", "S1", "'S'!$B$2:$B$3")],
+        )
+        chart = xml.find(self._ns("chart"))
+        plot = chart.find(self._ns("plotArea"))
+        assert plot.find(self._ns("pieChart")) is not None
+
+    def test_scatter_chart_has_xval_yval(self):
+        xml = create_chart_xml(
+            "scatter",
+            "Sheet1",
+            "'S'!$A$2:$A$3",
+            [("'S'!$B$1", "S1", "'S'!$B$2:$B$3")],
+        )
+        chart = xml.find(self._ns("chart"))
+        plot = chart.find(self._ns("plotArea"))
+        scatter = plot.find(self._ns("scatterChart"))
+        assert scatter is not None
+        ser = scatter.find(self._ns("ser"))
+        assert ser.find(self._ns("xVal")) is not None
+        assert ser.find(self._ns("yVal")) is not None
+
+    def test_area_chart(self):
+        xml = create_chart_xml(
+            "area",
+            "Sheet1",
+            "'S'!$A$2:$A$3",
+            [("'S'!$B$1", "S1", "'S'!$B$2:$B$3")],
+        )
+        chart = xml.find(self._ns("chart"))
+        plot = chart.find(self._ns("plotArea"))
+        assert plot.find(self._ns("areaChart")) is not None
+
+    def test_invalid_chart_type(self):
+        with pytest.raises(ValueError, match="Unsupported chart type"):
+            create_chart_xml("radar", "S", "r", [("", "", "r")])
+
+    def test_title_present(self):
+        xml = create_chart_xml(
+            "column",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+            title="Revenue",
+        )
+        chart = xml.find(self._ns("chart"))
+        title_elem = chart.find(self._ns("title"))
+        assert title_elem is not None
+        # autoTitleDeleted should be 0
+        atd = chart.find(self._ns("autoTitleDeleted"))
+        assert atd.get("val") == "0"
+
+    def test_no_title_sets_autotitledeleted(self):
+        xml = create_chart_xml(
+            "column",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+        )
+        chart = xml.find(self._ns("chart"))
+        title_elem = chart.find(self._ns("title"))
+        assert title_elem is None
+        atd = chart.find(self._ns("autoTitleDeleted"))
+        assert atd.get("val") == "1"
+
+    def test_external_data_rid(self):
+        xml = create_chart_xml(
+            "column",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+            external_data_rid="rId1",
+        )
+        ext_data = xml.find(self._ns("externalData"))
+        assert ext_data is not None
+        r_ns = CHART_NSMAP["r"]
+        assert ext_data.get(f"{{{r_ns}}}id") == "rId1"
+        auto = ext_data.find(self._ns("autoUpdate"))
+        assert auto.get("val") == "0"
+
+    def test_no_external_data_without_rid(self):
+        xml = create_chart_xml(
+            "column",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+        )
+        assert xml.find(self._ns("externalData")) is None
+
+    def test_multi_series(self):
+        xml = create_chart_xml(
+            "bar",
+            "S",
+            "'S'!$A$2:$A$3",
+            [
+                ("'S'!$B$1", "S1", "'S'!$B$2:$B$3"),
+                ("'S'!$C$1", "S2", "'S'!$C$2:$C$3"),
+            ],
+        )
+        chart = xml.find(self._ns("chart"))
+        plot = chart.find(self._ns("plotArea"))
+        bar = plot.find(self._ns("barChart"))
+        sers = bar.findall(self._ns("ser"))
+        assert len(sers) == 2
+        # Check idx/order
+        assert sers[0].find(self._ns("idx")).get("val") == "0"
+        assert sers[1].find(self._ns("idx")).get("val") == "1"
+
+    def test_categories_none_skips_cat(self):
+        """Excel simple mode: no categories_range, no c:cat elements."""
+        xml = create_chart_xml(
+            "column",
+            "S",
+            categories_range=None,
+            series=[("", "", "'S'!$A$1:$A$5")],
+        )
+        chart = xml.find(self._ns("chart"))
+        plot = chart.find(self._ns("plotArea"))
+        bar = plot.find(self._ns("barChart"))
+        ser = bar.find(self._ns("ser"))
+        # Should have val but NOT cat
+        assert ser.find(self._ns("val")) is not None
+        assert ser.find(self._ns("cat")) is None
+
+    def test_scatter_no_categories_skips_xval(self):
+        """Excel simple scatter: no xVal, only yVal."""
+        xml = create_chart_xml(
+            "scatter",
+            "S",
+            categories_range=None,
+            series=[("", "", "'S'!$A$1:$A$5")],
+        )
+        chart = xml.find(self._ns("chart"))
+        scatter = chart.find(self._ns("plotArea")).find(self._ns("scatterChart"))
+        ser = scatter.find(self._ns("ser"))
+        assert ser.find(self._ns("xVal")) is None
+        assert ser.find(self._ns("yVal")) is not None
+
+    def test_series_name_ref_creates_sertx(self):
+        """When name_ref is provided, c:serTx is emitted."""
+        xml = create_chart_xml(
+            "line",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("'S'!$B$1", "Revenue", "'S'!$B$2:$B$3")],
+        )
+        chart = xml.find(self._ns("chart"))
+        line = chart.find(self._ns("plotArea")).find(self._ns("lineChart"))
+        ser = line.find(self._ns("ser"))
+        tx = ser.find(self._ns("tx"))
+        assert tx is not None
+
+    def test_empty_name_ref_no_sertx(self):
+        """When name_ref is empty string, c:serTx is NOT emitted."""
+        xml = create_chart_xml(
+            "line",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+        )
+        chart = xml.find(self._ns("chart"))
+        line = chart.find(self._ns("plotArea")).find(self._ns("lineChart"))
+        ser = line.find(self._ns("ser"))
+        tx = ser.find(self._ns("tx"))
+        assert tx is None
+
+    def test_pie_chart_no_axes(self):
+        """Pie charts have no axes."""
+        xml = create_chart_xml(
+            "pie",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+        )
+        chart = xml.find(self._ns("chart"))
+        plot = chart.find(self._ns("plotArea"))
+        assert plot.find(self._ns("catAx")) is None
+        assert plot.find(self._ns("valAx")) is None
+
+    def test_non_pie_chart_has_axes(self):
+        """Non-pie charts have category and value axes."""
+        xml = create_chart_xml(
+            "column",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+        )
+        chart = xml.find(self._ns("chart"))
+        plot = chart.find(self._ns("plotArea"))
+        assert plot.find(self._ns("catAx")) is not None
+        assert plot.find(self._ns("valAx")) is not None
+
+    def test_scatter_has_two_valax(self):
+        """Scatter charts use valAx for both axes."""
+        xml = create_chart_xml(
+            "scatter",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+        )
+        chart = xml.find(self._ns("chart"))
+        plot = chart.find(self._ns("plotArea"))
+        val_axes = plot.findall(self._ns("valAx"))
+        assert len(val_axes) == 2
+        assert plot.find(self._ns("catAx")) is None
+
+    def test_print_settings_present(self):
+        xml = create_chart_xml(
+            "column",
+            "S",
+            None,
+            [("", "", "'S'!$A$1:$A$5")],
+        )
+        assert xml.find(self._ns("printSettings")) is not None
+
+    def test_legend_present(self):
+        xml = create_chart_xml(
+            "column",
+            "S",
+            None,
+            [("", "", "'S'!$A$1:$A$5")],
+        )
+        chart = xml.find(self._ns("chart"))
+        assert chart.find(self._ns("legend")) is not None
+
+
+class TestCreateEmbeddedExcel:
+    """Tests for the embedded Excel workbook creation utility."""
+
+    def test_basic_creation(self):
+        data = [["Cat", "S1", "S2"], ["A", 10, 30], ["B", 20, 40]]
+        xlsx_bytes, sheet_name, n_rows, n_cols = create_embedded_excel(data)
+        assert isinstance(xlsx_bytes, bytes)
+        assert len(xlsx_bytes) > 0
+        assert sheet_name == "Sheet1"
+        assert n_rows == 3
+        assert n_cols == 3
+
+    def test_single_column(self):
+        data = [["Value"], [100], [200], [300]]
+        xlsx_bytes, sheet_name, n_rows, n_cols = create_embedded_excel(data)
+        assert n_rows == 4
+        assert n_cols == 1
+
+    def test_default_sheet_name(self):
+        data = [["X"], [1]]
+        xlsx_bytes, sheet_name, n_rows, n_cols = create_embedded_excel(data)
+        assert sheet_name == "Sheet1"
+
+    def test_valid_xlsx(self):
+        """The returned bytes can be opened as a valid Excel package."""
+        data = [["Cat", "S1"], ["A", 10], ["B", 20]]
+        xlsx_bytes, sheet_name, n_rows, n_cols = create_embedded_excel(data)
+
+        pkg = ExcelPackage.open(io.BytesIO(xlsx_bytes))
+        sheet_names = [name for name, _rId, _path in pkg.get_sheet_paths()]
+        assert sheet_name in sheet_names
+
+    def test_data_roundtrip(self):
+        """Values written are readable from the resulting workbook."""
+        data = [["Name", "Score"], ["Alice", 95], ["Bob", 87]]
+        xlsx_bytes, sheet_name, n_rows, n_cols = create_embedded_excel(data)
+
+        from mcp_handley_lab.microsoft.excel.ops.cells import get_cell_value
+
+        pkg = ExcelPackage.open(io.BytesIO(xlsx_bytes))
+        assert get_cell_value(pkg, sheet_name, "A1") == "Name"
+        assert get_cell_value(pkg, sheet_name, "B1") == "Score"
+        assert get_cell_value(pkg, sheet_name, "A2") == "Alice"
+        assert get_cell_value(pkg, sheet_name, "B2") == 95
+
+
+class TestValidateChartData:
+    """Tests for validate_chart_data input validation."""
+
+    def test_empty_data(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            validate_chart_data([])
+
+    def test_single_row(self):
+        with pytest.raises(ValueError, match="at least 2 rows"):
+            validate_chart_data([["Cat", "S1"]])
+
+    def test_single_column(self):
+        with pytest.raises(ValueError, match="at least 2 columns"):
+            validate_chart_data([["Cat"], ["A"]])
+
+    def test_jagged_rows(self):
+        with pytest.raises(ValueError, match="rectangular"):
+            validate_chart_data([["Cat", "S1"], ["A"]])
+
+    def test_valid_data(self):
+        # Should not raise
+        validate_chart_data([["Cat", "S1"], ["A", 10]])
+
+    def test_valid_multi_series(self):
+        # Should not raise
+        validate_chart_data([["Cat", "S1", "S2"], ["A", 10, 20], ["B", 30, 40]])
+
+
+class TestCreateChartXmlValidation:
+    """Tests for input validation in create_chart_xml."""
+
+    def test_invalid_chart_type(self):
+        with pytest.raises(ValueError, match="Unsupported chart type"):
+            create_chart_xml("radar", "S", "r", [("", "", "r")])
+
+    def test_empty_series(self):
+        with pytest.raises(ValueError, match="At least one data series"):
+            create_chart_xml("column", "S", "'S'!$A$2:$A$3", [])
+
+
+class TestScatterAxes:
+    """Tests for scatter chart axes (two valAx, no catAx properties)."""
+
+    def _ns(self, tag: str) -> str:
+        return f"{{{CHART_NSMAP['c']}}}{tag}"
+
+    def test_scatter_no_catax(self):
+        xml = create_chart_xml(
+            "scatter",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+        )
+        plot = xml.find(self._ns("chart")).find(self._ns("plotArea"))
+        assert plot.find(self._ns("catAx")) is None
+
+    def test_scatter_two_valax(self):
+        xml = create_chart_xml(
+            "scatter",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+        )
+        plot = xml.find(self._ns("chart")).find(self._ns("plotArea"))
+        val_axes = plot.findall(self._ns("valAx"))
+        assert len(val_axes) == 2
+
+    def test_scatter_x_axis_position_bottom(self):
+        xml = create_chart_xml(
+            "scatter",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+        )
+        plot = xml.find(self._ns("chart")).find(self._ns("plotArea"))
+        val_axes = plot.findall(self._ns("valAx"))
+        # First valAx (X axis) should be at bottom
+        ax_pos = val_axes[0].find(self._ns("axPos"))
+        assert ax_pos.get("val") == "b"
+
+    def test_scatter_y_axis_position_left(self):
+        xml = create_chart_xml(
+            "scatter",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+        )
+        plot = xml.find(self._ns("chart")).find(self._ns("plotArea"))
+        val_axes = plot.findall(self._ns("valAx"))
+        # Second valAx (Y axis) should be at left
+        ax_pos = val_axes[1].find(self._ns("axPos"))
+        assert ax_pos.get("val") == "l"
+
+    def test_scatter_axes_no_catax_properties(self):
+        """Scatter valAx should NOT have catAx-only properties: auto, lblAlgn, lblOffset."""
+        xml = create_chart_xml(
+            "scatter",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+        )
+        plot = xml.find(self._ns("chart")).find(self._ns("plotArea"))
+        for val_ax in plot.findall(self._ns("valAx")):
+            assert val_ax.find(self._ns("auto")) is None
+            assert val_ax.find(self._ns("lblAlgn")) is None
+            assert val_ax.find(self._ns("lblOffset")) is None
+
+    def test_scatter_axes_have_numfmt(self):
+        """Both scatter valAx should have numFmt (value axis property)."""
+        xml = create_chart_xml(
+            "scatter",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+        )
+        plot = xml.find(self._ns("chart")).find(self._ns("plotArea"))
+        for val_ax in plot.findall(self._ns("valAx")):
+            assert val_ax.find(self._ns("numFmt")) is not None
+
+    def test_non_scatter_catax_has_catax_properties(self):
+        """Non-scatter catAx should have auto, lblAlgn, lblOffset."""
+        xml = create_chart_xml(
+            "column",
+            "S",
+            "'S'!$A$2:$A$3",
+            [("", "", "'S'!$B$2:$B$3")],
+        )
+        plot = xml.find(self._ns("chart")).find(self._ns("plotArea"))
+        cat_ax = plot.find(self._ns("catAx"))
+        assert cat_ax.find(self._ns("auto")) is not None
+        assert cat_ax.find(self._ns("lblAlgn")) is not None
+        assert cat_ax.find(self._ns("lblOffset")) is not None
+
+
+class TestChartSpaceNamespace:
+    """Test that chartSpace uses prefixed 'c:' namespace."""
+
+    def test_chartspace_uses_c_prefix(self):
+        xml = create_chart_xml(
+            "column",
+            "S",
+            None,
+            [("", "", "'S'!$A$1:$A$5")],
+        )
+        serialized = etree.tostring(xml, encoding="unicode")
+        # Should use c: prefix, not default namespace
+        assert "c:chartSpace" in serialized
+        assert "c:chart" in serialized

--- a/tests/word/test_word_charts.py
+++ b/tests/word/test_word_charts.py
@@ -1,0 +1,348 @@
+"""Tests for Word chart operations (create, list, delete, update)."""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mcp_handley_lab.microsoft.word.ops.charts import (
+    create_chart,
+    delete_chart,
+    list_charts,
+    update_chart_data,
+)
+from mcp_handley_lab.microsoft.word.package import WordPackage
+from mcp_handley_lab.microsoft.word.tool import mcp
+
+SAMPLE_DATA = [["Category", "S1", "S2"], ["A", 10, 30], ["B", 20, 40], ["C", 15, 25]]
+
+
+def _make_doc_with_paragraph() -> WordPackage:
+    """Create a WordPackage with a single paragraph for testing."""
+    pkg = WordPackage.new()
+    from mcp_handley_lab.microsoft.word.ops.core import append_paragraph_ooxml
+
+    append_paragraph_ooxml(pkg, "Test paragraph")
+    return pkg
+
+
+def _get_first_para_id(pkg: WordPackage) -> str:
+    """Get block ID of first paragraph with text."""
+    from mcp_handley_lab.microsoft.word.ops.core import build_blocks
+
+    blocks, _total = build_blocks(pkg)
+    # Find first paragraph with text (skip empty default paragraph)
+    for b in blocks:
+        if b.text:
+            return b.id
+    return blocks[0].id
+
+
+class TestCreateChart:
+    """Tests for Word chart creation."""
+
+    def test_create_column_chart(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        chart_id = create_chart(pkg, target, "column", SAMPLE_DATA, title="Revenue")
+        assert chart_id.startswith("chart_")
+
+    def test_create_bar_chart(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        chart_id = create_chart(pkg, target, "bar", SAMPLE_DATA)
+        assert chart_id.startswith("chart_")
+
+    def test_create_line_chart(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        chart_id = create_chart(pkg, target, "line", SAMPLE_DATA)
+        assert chart_id.startswith("chart_")
+
+    def test_create_pie_chart(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        chart_id = create_chart(pkg, target, "pie", SAMPLE_DATA)
+        assert chart_id.startswith("chart_")
+
+    def test_create_scatter_chart(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        chart_id = create_chart(pkg, target, "scatter", SAMPLE_DATA)
+        assert chart_id.startswith("chart_")
+
+    def test_create_area_chart(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        chart_id = create_chart(pkg, target, "area", SAMPLE_DATA)
+        assert chart_id.startswith("chart_")
+
+    def test_create_chart_invalid_type(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        with pytest.raises(ValueError, match="Unsupported"):
+            create_chart(pkg, target, "radar", SAMPLE_DATA)
+
+    def test_create_multiple_charts(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        id1 = create_chart(pkg, target, "column", SAMPLE_DATA, title="Chart 1")
+        id2 = create_chart(pkg, target, "bar", SAMPLE_DATA, title="Chart 2")
+        assert id1 != id2
+
+    def test_chart_has_embedded_workbook(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        create_chart(pkg, target, "column", SAMPLE_DATA)
+        # Check that embedding part exists
+        found = any(
+            p.startswith("/word/embeddings/Microsoft_Excel_Worksheet")
+            for p in pkg.iter_partnames()
+        )
+        assert found
+
+    def test_chart_has_chart_part(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        create_chart(pkg, target, "column", SAMPLE_DATA)
+        found = any(p.startswith("/word/charts/chart") for p in pkg.iter_partnames())
+        assert found
+
+    def test_chart_custom_size(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        chart_id = create_chart(
+            pkg,
+            target,
+            "column",
+            SAMPLE_DATA,
+            width_inches=8.0,
+            height_inches=4.0,
+        )
+        assert chart_id.startswith("chart_")
+
+
+class TestListCharts:
+    """Tests for listing Word charts."""
+
+    def test_list_empty(self):
+        pkg = _make_doc_with_paragraph()
+        charts = list_charts(pkg)
+        assert charts == []
+
+    def test_list_after_create(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        create_chart(pkg, target, "column", SAMPLE_DATA, title="Revenue")
+        charts = list_charts(pkg)
+        assert len(charts) == 1
+        assert charts[0].type == "column"
+        assert charts[0].title == "Revenue"
+
+    def test_list_multiple(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        create_chart(pkg, target, "bar", SAMPLE_DATA, title="Bar")
+        create_chart(pkg, target, "line", SAMPLE_DATA, title="Line")
+        charts = list_charts(pkg)
+        assert len(charts) == 2
+        types = {c.type for c in charts}
+        assert types == {"bar", "line"}
+
+    def test_list_chart_types(self):
+        """Each chart type is correctly detected."""
+        for ct in ("bar", "column", "line", "pie", "scatter", "area"):
+            pkg = _make_doc_with_paragraph()
+            target = _get_first_para_id(pkg)
+            create_chart(pkg, target, ct, SAMPLE_DATA)
+            charts = list_charts(pkg)
+            assert charts[0].type == ct, f"Failed for {ct}"
+
+
+class TestDeleteChart:
+    """Tests for Word chart deletion."""
+
+    def test_delete_chart(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        chart_id = create_chart(pkg, target, "column", SAMPLE_DATA)
+        delete_chart(pkg, chart_id)
+        charts = list_charts(pkg)
+        assert len(charts) == 0
+
+    def test_delete_nonexistent_raises(self):
+        pkg = _make_doc_with_paragraph()
+        with pytest.raises(KeyError):
+            delete_chart(pkg, "chart_999")
+
+    def test_delete_one_of_multiple(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        create_chart(pkg, target, "column", SAMPLE_DATA, title="Keep")
+        id2 = create_chart(pkg, target, "bar", SAMPLE_DATA, title="Delete")
+        delete_chart(pkg, id2)
+        charts = list_charts(pkg)
+        assert len(charts) == 1
+        assert charts[0].title == "Keep"
+
+    def test_delete_removes_parts(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        chart_id = create_chart(pkg, target, "column", SAMPLE_DATA)
+        # Confirm parts exist before deletion
+        chart_parts = [p for p in pkg.iter_partnames() if "/word/charts/" in p]
+        embed_parts = [p for p in pkg.iter_partnames() if "/word/embeddings/" in p]
+        assert len(chart_parts) >= 1
+        assert len(embed_parts) >= 1
+
+        delete_chart(pkg, chart_id)
+
+        # Parts should be removed
+        chart_parts_after = [p for p in pkg.iter_partnames() if "/word/charts/" in p]
+        embed_parts_after = [
+            p for p in pkg.iter_partnames() if "/word/embeddings/" in p
+        ]
+        assert len(chart_parts_after) == 0
+        assert len(embed_parts_after) == 0
+
+
+class TestUpdateChartData:
+    """Tests for updating Word chart data."""
+
+    def test_update_data(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        chart_id = create_chart(pkg, target, "column", SAMPLE_DATA, title="Original")
+
+        new_data = [["Cat", "Sales"], ["X", 100], ["Y", 200]]
+        update_chart_data(pkg, chart_id, new_data)
+
+        charts = list_charts(pkg)
+        assert len(charts) == 1
+        # Title should be preserved
+        assert charts[0].title == "Original"
+        # Type should be preserved
+        assert charts[0].type == "column"
+
+    def test_update_nonexistent_raises(self):
+        pkg = _make_doc_with_paragraph()
+        with pytest.raises(KeyError):
+            update_chart_data(pkg, "chart_999", SAMPLE_DATA)
+
+
+class TestChartPersistence:
+    """Tests for chart round-trip through save/load."""
+
+    def test_chart_survives_save(self):
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+        create_chart(pkg, target, "column", SAMPLE_DATA, title="Persist")
+
+        buf = io.BytesIO()
+        pkg.save(buf)
+        buf.seek(0)
+
+        pkg2 = WordPackage.open(buf)
+        charts = list_charts(pkg2)
+        assert len(charts) == 1
+        assert charts[0].type == "column"
+        assert charts[0].title == "Persist"
+
+    def test_full_crud_cycle(self):
+        """Create, list, update, delete cycle."""
+        pkg = _make_doc_with_paragraph()
+        target = _get_first_para_id(pkg)
+
+        # Create
+        chart_id = create_chart(pkg, target, "bar", SAMPLE_DATA, title="Cycle")
+
+        # List
+        charts = list_charts(pkg)
+        assert len(charts) == 1
+
+        # Update
+        new_data = [["Cat", "Revenue"], ["Q1", 500], ["Q2", 600]]
+        update_chart_data(pkg, chart_id, new_data)
+        charts = list_charts(pkg)
+        assert charts[0].title == "Cycle"
+        assert charts[0].type == "bar"
+
+        # Delete
+        delete_chart(pkg, chart_id)
+        assert list_charts(pkg) == []
+
+
+class TestWordChartMcpTool:
+    """Tests for Word chart operations via MCP tool interface."""
+
+    @pytest.mark.asyncio
+    async def test_insert_chart_via_tool(self):
+        with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as f:
+            path = Path(f.name)
+        path.unlink()
+
+        try:
+            # Create document with a paragraph
+            await mcp.call_tool(
+                "edit",
+                {
+                    "file_path": str(path),
+                    "ops": json.dumps(
+                        [
+                            {"op": "append", "content_data": "Before chart"},
+                        ]
+                    ),
+                },
+            )
+
+            # Read to get block IDs
+            content_list, _err = await mcp.call_tool(
+                "read",
+                {"file_path": str(path), "scope": "blocks"},
+            )
+            result_data = json.loads(content_list[0].text)
+            blocks = result_data["blocks"]
+            # Find a block with text
+            target_id = blocks[0]["id"]
+            for b in blocks:
+                if b.get("text"):
+                    target_id = b["id"]
+                    break
+
+            # Insert chart
+            chart_data = {
+                "chart_type": "column",
+                "data": [["Cat", "Sales"], ["A", 10], ["B", 20]],
+                "title": "Test Chart",
+            }
+            await mcp.call_tool(
+                "edit",
+                {
+                    "file_path": str(path),
+                    "ops": json.dumps(
+                        [
+                            {
+                                "op": "insert_chart",
+                                "target_id": target_id,
+                                "content_data": json.dumps(chart_data),
+                            },
+                        ]
+                    ),
+                },
+            )
+
+            # Verify via read charts scope
+            content_list, _err = await mcp.call_tool(
+                "read",
+                {"file_path": str(path), "scope": "charts"},
+            )
+            data = json.loads(content_list[0].text)
+            assert len(data["charts"]) == 1
+            assert data["charts"][0]["type"] == "column"
+            assert data["charts"][0]["title"] == "Test Chart"
+        finally:
+            path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- Add chart CRUD operations (create, list, delete, update data) for **Word** and **PowerPoint** documents with shared DrawingML infrastructure
- Shared chart XML builders (`common/charts.py`) support bar, column, line, pie, scatter, and area chart types with proper category/series semantics and embedded Excel workbooks as data sources
- Refactored Excel chart module to use shared builders, removing ~300 lines of duplicate code
- Input validation, safe embedding deletion (checks cross-references), correct scatter axes (two `valAx`, no `catAx` properties), prefixed `c:` namespace

## Test plan

- [x] 565 chart-related tests passing (96 new: 31 common, 26 Word, 23 PowerPoint, 16 validation/axes)
- [x] All 22 existing Excel chart tests pass after refactoring
- [x] All 95 existing PowerPoint tests pass
- [x] All 315 existing Word tests pass
- [x] Full suite: 1318 passed, 1 pre-existing failure (LibreOffice render)
- [ ] Manual verification: open created .docx/.pptx in Word/LibreOffice

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)