### PR TITLE
fix: restore unified mcp-llm entry point reverted by bad merge

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.11
+pkgver=0.25.12
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ uv tool install -e .
 ```
 
 Alternatively:
-- `uv sync` for a local venv (run tools with `uv run mcp-llm-chat` or `source .venv/bin/activate`)
+- `uv sync` for a local venv (run tools with `uv run mcp-llm` or `source .venv/bin/activate`)
 - Traditional pip: `python3 -m venv venv && source venv/bin/activate && pip install -e .`
 
 ## Configuration
@@ -95,9 +95,7 @@ Register only the tools you need to avoid context bloat:
 
 ```bash
 # Unified LLM tools (one tool handles all providers via model inference)
-claude mcp add llm-chat --scope user mcp-llm-chat      # Chat with any LLM
-claude mcp add llm-image --scope user mcp-llm-image    # Image generation
-claude mcp add llm-models --scope user mcp-llm-models  # List available models
+claude mcp add llm --scope user mcp-llm                # Chat, vision, image gen, transcribe, OCR, models
 
 # Other essential tools
 claude mcp add arxiv --scope user mcp-arxiv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.11"
+version = "0.25.12"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -65,14 +65,9 @@ dev = [
 
 [project.scripts]
 # Unified LLM tools
-mcp-llm-chat = "mcp_handley_lab.llm.chat.tool:mcp.run"
-mcp-llm-image = "mcp_handley_lab.llm.image.tool:mcp.run"
+mcp-llm = "mcp_handley_lab.llm.tool:mcp.run"
 mcp-llm-embeddings = "mcp_handley_lab.llm.embeddings.tool:mcp.run"
-mcp-llm-ocr = "mcp_handley_lab.llm.ocr.tool:mcp.run"
-mcp-llm-audio = "mcp_handley_lab.llm.audio.tool:mcp.run"
-mcp-llm-models = "mcp_handley_lab.llm.models.tool:mcp.run"
 # Other tools
-mcp-vim = "mcp_handley_lab.vim.tool:mcp.run"
 mcp-code2prompt = "mcp_handley_lab.code2prompt.tool:mcp.run"
 mcp-arxiv = "mcp_handley_lab.arxiv.tool:mcp.run"
 mcp-google-calendar = "mcp_handley_lab.google_calendar.tool:mcp.run"


### PR DESCRIPTION
## Summary

- Restore unified `mcp-llm` entry point that was reverted by a bad merge conflict resolution in #191
- Remove stale `mcp-vim` entry point similarly re-added despite intentional removal in #192
- Update README.md references from old individual tool names to unified `mcp-llm`

PR #189 unified 6 LLM MCP servers into a single `mcp-llm` entry point. PR #191 (search improvements) was branched before #189 merged, and the merge conflict on `pyproject.toml` was resolved incorrectly, silently reverting the unification.

## Test plan

- [x] No old entry points (`mcp-llm-chat`, `mcp-llm-image`, `mcp-llm-ocr`, `mcp-llm-audio`, `mcp-llm-models`, `mcp-vim`) remain in pyproject.toml, README.md, or other files
- [x] Unified `mcp-llm` entry point points to `mcp_handley_lab.llm.tool:mcp.run`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)