### PR TITLE
fix: ignore extra environment variables in Settings

### DIFF
--- a/src/mcp_handley_lab/common/config.py
+++ b/src/mcp_handley_lab/common/config.py
@@ -9,7 +9,9 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     """Global settings for MCP Framework."""
 
-    model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = ConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
 
     # API Keys
     gemini_api_key: str = Field(


### PR DESCRIPTION
Fixes #210

The Settings model was crashing when unrelated environment variables (e.g., `WHATSAPP_*`) were present, due to Pydantic's default behavior of forbidding extra fields in BaseSettings.

## Changes
- Added `extra="ignore"` to the `model_config` in `Settings` class to allow the model to ignore environment variables that aren't defined as fields

## Testing
Verified that Settings loads successfully with `WHATSAPP_VERIFY_TOKEN`, `WHATSAPP_ACCESS_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, and `WHATSAPP_APP_SECRET` environment variables present.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>