### PR TITLE
fix(llm): reframe conversation tool description for retrieval

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.21
+pkgver=0.25.22
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.21"
+version = "0.25.22"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/tool.py
+++ b/src/mcp_handley_lab/llm/tool.py
@@ -173,8 +173,9 @@ def chat(
 
 
 @mcp.tool(
-    description="Manage conversation branches created by chat. Actions: "
-    "'list' (all branches), 'log' (history with hashes), 'show' (content at ref), "
+    description="Retrieve past LLM responses and manage conversation history. "
+    "Use 'response' to get a previous assistant message from a branch (the primary way to retrieve results from chat). "
+    "Actions: 'list' (all branches), 'log' (history with hashes), 'show' (content at ref), "
     "'response' (get assistant message by index), "
     "'edit' (start editing session with worktree), 'done' (end editing session)."
 )


### PR DESCRIPTION
## Summary
- Reframes the `conversation` tool description to lead with "Retrieve past LLM responses" instead of "Manage conversation branches"
- Explicitly calls out `response` action as the primary way to retrieve results from `chat`

## Motivation
The previous description framed the tool as administrative, making it non-obvious that it's the retrieval path for past LLM outputs. This led to Claude Code attempting to parse raw JSONL transcript files instead of using the purpose-built conversation tool.

## Test plan
- [ ] Verify tool description appears correctly in MCP tool listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)