### PR TITLE
fix(llm): expand tildes in file paths

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.12b3
+pkgver=0.25.12b4
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.12b3"
+version = "0.25.12b4"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/common.py
+++ b/src/mcp_handley_lab/llm/common.py
@@ -82,7 +82,7 @@ def load_prompt_text(
 
     # Load prompt text
     if prompt_file:
-        final_prompt = Path(prompt_file).read_text(encoding="utf-8")
+        final_prompt = Path(prompt_file).expanduser().read_text(encoding="utf-8")
     else:
         final_prompt = prompt  # type: ignore[assignment]  # XOR ensures non-None
 
@@ -202,12 +202,12 @@ def resolve_image_data(image_item: str | dict[str, str]) -> bytes:
             header, encoded = image_item.split(",", 1)
             return base64.b64decode(encoded)
         else:
-            return Path(image_item).read_bytes()
+            return Path(image_item).expanduser().read_bytes()
     elif isinstance(image_item, dict):
         if "data" in image_item:
             return base64.b64decode(image_item["data"])
         elif "path" in image_item:
-            return Path(image_item["path"]).read_bytes()
+            return Path(image_item["path"]).expanduser().read_bytes()
 
     raise ValueError(f"Invalid image format: {image_item}")
 
@@ -233,7 +233,7 @@ def resolve_images_for_multimodal_prompt(
         if isinstance(image_path, str) and image_path.startswith("data:image"):
             mime_type = image_path.split(";")[0].split(":")[1]
         else:
-            mime_type = determine_mime_type(Path(image_path))
+            mime_type = determine_mime_type(Path(image_path).expanduser())
             if not mime_type.startswith("image/"):
                 mime_type = "image/jpeg"
 
@@ -268,7 +268,7 @@ def resolve_files_for_llm(
 
     inline_content = []
     for file_path_str in files:
-        file_path = Path(file_path_str)
+        file_path = Path(file_path_str).expanduser()
         # Fail-fast: let ValueError propagate for files too large
         content, is_text = read_file_smart(file_path, max_file_size)
         inline_content.append(content)

--- a/src/mcp_handley_lab/llm/providers/gemini/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/gemini/adapter.py
@@ -82,9 +82,9 @@ def resolve_files(files: list[str]) -> tuple[list[Part], bool]:
     for file_item in files:
         # Handle unified format: strings or {"path": "..."} dicts
         if isinstance(file_item, str):
-            file_path = Path(file_item)
+            file_path = Path(file_item).expanduser()
         elif isinstance(file_item, dict) and "path" in file_item:
-            file_path = Path(file_item["path"])
+            file_path = Path(file_item["path"]).expanduser()
         else:
             raise ValueError(f"Invalid file item format: {file_item}")
         file_size = file_path.stat().st_size

--- a/src/mcp_handley_lab/llm/providers/mistral/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/mistral/adapter.py
@@ -81,9 +81,9 @@ def resolve_files(files: list[str]) -> list[dict[str, Any]]:
     for file_item in files:
         # Handle unified format: strings or {"path": "..."} dicts
         if isinstance(file_item, str):
-            file_path = Path(file_item)
+            file_path = Path(file_item).expanduser()
         elif isinstance(file_item, dict) and "path" in file_item:
-            file_path = Path(file_item["path"])
+            file_path = Path(file_item["path"]).expanduser()
         else:
             raise ValueError(f"Invalid file item format: {file_item}")
 
@@ -218,7 +218,7 @@ def image_analysis_adapter(
         # Detect MIME type from path or default to jpeg
         mime_type = "image/jpeg"
         if isinstance(image_item, str) and not image_item.startswith("data:"):
-            guessed_type = determine_mime_type(Path(image_item))
+            guessed_type = determine_mime_type(Path(image_item).expanduser())
             if guessed_type.startswith("image/"):
                 mime_type = guessed_type
         content.append(
@@ -281,7 +281,7 @@ def ocr_adapter(document_path: str, include_images: bool = True) -> dict[str, An
         document_input = {"type": "document_url", "document_url": document_path}
     else:
         # Local file - convert to base64 data URI
-        file_path = Path(document_path)
+        file_path = Path(document_path).expanduser()
 
         # Read file and encode
         file_content = file_path.read_bytes()
@@ -357,7 +357,7 @@ def audio_transcription_adapter(
         transcription_params["file_url"] = audio_path
     else:
         # Local file
-        file_path = Path(audio_path)
+        file_path = Path(audio_path).expanduser()
         with open(file_path, "rb") as f:
             transcription_params["file"] = {
                 "content": f,


### PR DESCRIPTION
## Summary
- Apply `Path.expanduser()` to file paths before reading them
- Fixes file-not-found errors when paths like `~/foo/bar.txt` are passed to file path parameters

## Changes (9 locations)

**common.py:**
- `load_prompt_text()` - prompt_file paths
- `resolve_image_data()` - image file paths (2 locations)
- `resolve_images_for_multimodal_prompt()` - MIME type detection
- `resolve_files_for_llm()` - context file paths

**gemini/adapter.py:**
- `resolve_files()` - file paths (2 locations)

**mistral/adapter.py:**
- `resolve_files()` - file paths (2 locations)
- `image_analysis_adapter()` - MIME type detection
- `ocr_adapter()` - document_path
- `audio_transcription_adapter()` - audio_path

## Test plan
- [x] 155 LLM unit tests pass
- [x] Lint clean
- [x] Gemini iterative review: APPROVED
- [x] OpenAI iterative review: APPROVED

Fixes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)