### PR TITLE
fix: restore unified mcp-llm entry point (again)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.12b4
+pkgver=0.25.13
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.12b4"
+version = "0.25.13"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -65,14 +65,9 @@ dev = [
 
 [project.scripts]
 # Unified LLM tools
-mcp-llm-chat = "mcp_handley_lab.llm.chat.tool:mcp.run"
-mcp-llm-image = "mcp_handley_lab.llm.image.tool:mcp.run"
+mcp-llm = "mcp_handley_lab.llm.tool:mcp.run"
 mcp-llm-embeddings = "mcp_handley_lab.llm.embeddings.tool:mcp.run"
-mcp-llm-ocr = "mcp_handley_lab.llm.ocr.tool:mcp.run"
-mcp-llm-audio = "mcp_handley_lab.llm.audio.tool:mcp.run"
-mcp-llm-models = "mcp_handley_lab.llm.models.tool:mcp.run"
 # Other tools
-mcp-vim = "mcp_handley_lab.vim.tool:mcp.run"
 mcp-code2prompt = "mcp_handley_lab.code2prompt.tool:mcp.run"
 mcp-arxiv = "mcp_handley_lab.arxiv.tool:mcp.run"
 mcp-google-calendar = "mcp_handley_lab.google_calendar.tool:mcp.run"


### PR DESCRIPTION
## Summary
- Restores unified `mcp-llm` entry point (replaces `mcp-llm-{chat,image,ocr,audio,models}`)
- Removes stale `mcp-vim` entry point (was deleted in #192)

## Background
PR #207 re-introduced the old separate LLM entry points via bad merge conflict resolution, reverting the unification done in #189 and the subsequent fix in #208.

This is the **third time** this has been reverted by bad merges. The pattern:
1. #189 unified 6 LLM servers into `mcp-llm`
2. #191 reverted it (bad merge)
3. #208 fixed it
4. #207 reverted it again (bad merge)

## Test plan
- [ ] Verify `mcp-llm` entry point works after install
- [ ] Verify old entry points (`mcp-llm-chat` etc.) are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)