### PR TITLE
fix(word): handle pdftoppm zero-padded page numbers in PNG render

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.15
+pkgver=0.25.16
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.15"
+version = "0.25.16"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/microsoft/common/render.py
+++ b/src/mcp_handley_lab/microsoft/common/render.py
@@ -141,14 +141,15 @@ def render_pages_to_images(
             except subprocess.TimeoutExpired as e:
                 raise RuntimeError(f"Page {page_num} render timed out") from e
 
-            # pdftoppm creates files like page1-1.png, page2-2.png
-            expected_png = tmp / f"page{page_num}-{page_num}.png"
-            if not expected_png.exists():
+            # pdftoppm creates files with zero-padded page numbers based on total
+            # page count: page1-1.png (1-9 pages), page1-01.png (10-99 pages), etc.
+            # Use glob to find the actual output file.
+            png_files = list(tmp.glob(f"page{page_num}-*.png"))
+            if not png_files:
                 raise ValueError(
-                    f"Page {page_num} not found in rendered output. "
-                    "The document may have fewer pages than expected, "
-                    "or PDF conversion may have partially failed."
+                    f"Page {page_num} out of bounds. "
+                    "The document may have fewer pages than requested."
                 )
-            result.append((page_num, expected_png.read_bytes()))
+            result.append((page_num, png_files[0].read_bytes()))
 
         return result

--- a/tests/common/test_render_errors.py
+++ b/tests/common/test_render_errors.py
@@ -149,9 +149,8 @@ class TestRenderPagesToImagesErrors:
                     render_pages_to_images(str(doc_path), pages=[1], dpi=150)
 
                 msg = str(exc_info.value)
-                assert "Page 1 not found" in msg
-                assert "fewer pages than expected" in msg
-                assert "partially failed" in msg
+                assert "Page 1 out of bounds" in msg
+                assert "fewer pages than requested" in msg
 
     def test_pdftoppm_failure(self, tmp_path):
         """pdftoppm failure gives clear error message."""

--- a/tests/word/test_render.py
+++ b/tests/word/test_render.py
@@ -168,6 +168,66 @@ async def test_render_missing_page_error(sample_docx):
         render_to_images(str(sample_docx), pages=[999])
 
 
+@pytest.fixture
+async def ten_plus_page_docx():
+    """Create a Word document with 12 pages for zero-padding test.
+
+    pdftoppm uses zero-padded page numbers based on total page count:
+    - 1-9 pages: page1-1.png
+    - 10-99 pages: page1-01.png
+    This fixture ensures we test the >9 pages case.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as f:
+        path = Path(f.name)
+
+    WordPackage.new().save(str(path))
+
+    # Create 12 pages with page breaks
+    ops = [
+        {
+            "op": "append",
+            "content_type": "heading",
+            "content_data": "Page 1 Content",
+            "heading_level": 1,
+        }
+    ]
+    for i in range(2, 13):
+        ops.append({"op": "add_page_break"})
+        ops.append(
+            {
+                "op": "append",
+                "content_type": "heading",
+                "content_data": f"Page {i} Content",
+                "heading_level": 1,
+            }
+        )
+
+    await mcp.call_tool("edit", {"file_path": str(path), "ops": _ops(ops)})
+
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@requires_libreoffice
+@requires_pdftoppm
+@pytest.mark.asyncio
+async def test_render_ten_plus_pages(ten_plus_page_docx):
+    """Test rendering pages from a 10+ page document works correctly.
+
+    Regression test for #224: pdftoppm uses zero-padded page numbers
+    (page1-01.png instead of page1-1.png) when total pages > 9.
+    """
+    result = render_to_images(str(ten_plus_page_docx), pages=[1, 5])
+    assert len(result) == 2
+    page1_num, page1_bytes = result[0]
+    page5_num, page5_bytes = result[1]
+    assert page1_num == 1
+    assert page5_num == 5
+    # Verify valid PNG headers
+    assert page1_bytes[:8] == b"\x89PNG\r\n\x1a\n"
+    assert page5_bytes[:8] == b"\x89PNG\r\n\x1a\n"
+
+
 # PDF rendering tests - only require libreoffice
 @requires_libreoffice
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fix PNG rendering for documents with 10+ pages
- pdftoppm uses zero-padded page numbers based on total page count (e.g., `page1-01.png` for 10-99 page documents instead of `page1-1.png`)
- Use glob to find the actual output file instead of hardcoding the expected filename

## Test plan
- [x] Added regression test `test_render_ten_plus_pages` that creates a 12-page document
- [x] All 11 render tests pass
- [x] Verified fix works via MCP tool on restarted Claude Code session

Fixes #224

🤖 Generated with [Claude Code](https://claude.ai/code)