### PR TITLE
fix(config): ignore unrelated env vars in Settings

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.17
+pkgver=0.25.18
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.17"
+version = "0.25.18"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/common/config.py
+++ b/src/mcp_handley_lab/common/config.py
@@ -9,7 +9,9 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     """Global settings for MCP Framework."""
 
-    model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = ConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
 
     # API Keys
     gemini_api_key: str = Field(


### PR DESCRIPTION
## Summary
- Add `extra="ignore"` to Settings ConfigDict to prevent validation errors when unrelated environment variables are present
- Fixes crash when `WHATSAPP_*` or other unrelated env vars are set

Closes #210

## Test plan
- [x] Verified MCP LLM tool loads with WHATSAPP_TEST env var set
- [x] Verified chat tool works after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)