### PR TITLE
fix(repl): strip venv from tmux window environment

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.16
+pkgver=0.25.17
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.16"
+version = "0.25.17"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/repl/manager.py
+++ b/src/mcp_handley_lab/repl/manager.py
@@ -1,5 +1,7 @@
+import os
 import re
 import subprocess
+import sys
 from datetime import datetime
 
 from mcp_handley_lab.repl.backends import BACKENDS
@@ -37,7 +39,23 @@ def create(backend, name=None, args=None):
 
     cfg = BACKENDS[backend]
     extra_args = args or cfg.default_args
-    command = cfg.command + (extra_args.split() if extra_args else [])
+    base_command = cfg.command + (extra_args.split() if extra_args else [])
+
+    # Strip venv from environment so tmux windows start clean
+    clean_path = os.pathsep.join(
+        p
+        for p in os.environ.get("PATH", "").split(os.pathsep)
+        if not p.startswith(sys.prefix)
+    )
+    command = [
+        "env",
+        "-u",
+        "VIRTUAL_ENV",
+        "-u",
+        "PYTHONPATH",
+        f"PATH={clean_path}",
+    ] + base_command
+
     name = f"{backend}-{name or datetime.now().strftime('%H%M%S')}"
     res = _run(
         ["new-window", "-t", TMUX, "-n", name, "-P", "-F", "#{pane_id}", *command]


### PR DESCRIPTION
## Summary

- When Claude Code runs inside a venv, tmux windows inherited `VIRTUAL_ENV`, `PYTHONPATH`, and venv paths in `PATH`
- This caused REPL sessions to use the venv's Python instead of the system Python
- Wrap backend commands with `env -u VIRTUAL_ENV -u PYTHONPATH PATH=...` to start clean

## Test plan

- [x] Create Python REPL session from Claude Code running in venv
- [x] Verify `sys.executable` is `/usr/bin/python3` (not venv python)
- [x] Verify `VIRTUAL_ENV` env var is not set
- [x] Verify no venv paths in `PATH`
- [x] Verify system packages (numpy, mcp_handley_lab) accessible

🤖 Generated with [Claude Code](https://claude.ai/code)