### PR TITLE
fix(gemini): guard against None parts in response content

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.18
+pkgver=0.25.19
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.18"
+version = "0.25.19"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/providers/gemini/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/gemini/adapter.py
@@ -230,7 +230,11 @@ def generation_adapter(
     # Extract text, separating thinking from answer
     text_parts = []
     thinking_parts = []
-    if response.candidates and response.candidates[0].content:
+    if (
+        response.candidates
+        and response.candidates[0].content
+        and response.candidates[0].content.parts
+    ):
         for part in response.candidates[0].content.parts:
             if getattr(part, "thought", None):
                 # Thought parts contain reasoning content - extract the text
@@ -437,7 +441,11 @@ def _generate_with_nano_banana(prompt: str, model: str, **kwargs) -> dict:
     text_response = ""
     mime_type = "image/png"
 
-    if response.candidates and response.candidates[0].content:
+    if (
+        response.candidates
+        and response.candidates[0].content
+        and response.candidates[0].content.parts
+    ):
         for part in response.candidates[0].content.parts:
             if hasattr(part, "inline_data") and part.inline_data:
                 # SDK returns data as bytes or base64 string depending on version


### PR DESCRIPTION
## Summary

- Guard against `content.parts` being `None` in Gemini adapter
- Prevents `TypeError: 'NoneType' object is not iterable` when Gemini returns error finish_reasons like `MALFORMED_FUNCTION_CALL`

Fixes #206

## Test plan

- [x] Verified SDK allows `Content(parts=None)` which crashes on iteration
- [x] Import test passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)