### PR TITLE
fix(calendar): show all calendars in tool description

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.22
+pkgver=0.25.23
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.22"
+version = "0.25.23"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/google_calendar/tool.py
+++ b/src/mcp_handley_lab/google_calendar/tool.py
@@ -198,7 +198,7 @@ def _fetch_calendars_text() -> str:
             break
 
     lines = []
-    for c in items[:10]:
+    for c in items:
         cid = c.get("id")
         if not cid:
             continue
@@ -208,8 +208,6 @@ def _fetch_calendars_text() -> str:
     if not lines:
         return "(No calendars found; use 'primary' or read calendar://list resource)"
 
-    if len(items) > 10:
-        lines.append("... and more (read calendar://list resource for full list)")
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary
- Remove the 10-calendar limit from tool description injection
- All calendars now shown in the tool description at startup

## Test plan
- [x] Restart Claude Code and verify all calendars appear in tool description
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)