### PR TITLE
feat(email): inject tags/folders into tool descriptions

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.23b2
+pkgver=0.25.24
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.23b2"
+version = "0.25.24"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/email/common.py
+++ b/src/mcp_handley_lab/email/common.py
@@ -1,7 +1,78 @@
-"""Shared MCP instance for unified email tool."""
+"""Shared MCP instance for unified email tool with dynamic description injection."""
+
+import asyncio
+import logging
+from collections.abc import Callable
+from contextlib import asynccontextmanager
+from typing import Any, TypedDict
 
 from mcp.server.fastmcp import FastMCP
 
+logger = logging.getLogger(__name__)
+
+
+class ToolConfig(TypedDict):
+    fn: Callable[..., Any]
+    description: str
+
+
+# Tool configs for lifespan-based description injection.
+# Populated by provider modules (notmuch, mutt, offlineimap) before mcp.run().
+_TOOL_CONFIGS: dict[str, ToolConfig] = {}
+
+
+def _fetch_email_context() -> tuple[list[str], list[str]]:
+    """Fetch tags and folders for injection into tool descriptions."""
+    from mcp_handley_lab.email.notmuch.tool import _list_folders, _list_tags
+
+    return _list_tags(), _list_folders()
+
+
+@asynccontextmanager
+async def _lifespan(app: FastMCP):
+    """Inject tags/folders into tool descriptions at startup."""
+    try:
+        tags, folders = await asyncio.wait_for(
+            asyncio.to_thread(_fetch_email_context),
+            timeout=5.0,
+        )
+    except Exception:
+        logger.warning("Failed to fetch email context for injection", exc_info=True)
+        yield
+        return
+
+    # Format for injection (cap tags at 50 to avoid huge descriptions)
+    tags_text = "\n".join(f"- {t}" for t in sorted(tags)[:50])
+    if len(tags) > 50:
+        tags_text += f"\n... and {len(tags) - 50} more tags"
+    folders_text = "\n".join(f"- {f}" for f in sorted(folders))
+
+    # Tool-specific injection content
+    # read: tags only (for query building)
+    # update: tags + folders (for move/archive operations)
+    injection_map = {
+        "read": f"\n\nAvailable tags:\n{tags_text}",
+        "update": f"\n\nAvailable tags:\n{tags_text}\n\nAvailable folders:\n{folders_text}",
+    }
+
+    # Re-register tools with injected descriptions
+    for tool_name, injection_text in injection_map.items():
+        if tool_name not in _TOOL_CONFIGS:
+            continue
+        config = _TOOL_CONFIGS[tool_name]
+        try:
+            app.remove_tool(tool_name)
+            app.add_tool(
+                config["fn"],
+                name=tool_name,
+                description=config["description"] + injection_text,
+            )
+        except Exception:
+            logger.warning(f"Failed to inject into {tool_name}", exc_info=True)
+
+    yield
+
+
 # Single, shared MCP instance for the entire email tool.
 # All provider modules will import and use this instance.
-mcp = FastMCP("Email")
+mcp = FastMCP("Email", lifespan=_lifespan)

--- a/src/mcp_handley_lab/email/notmuch/shared.py
+++ b/src/mcp_handley_lab/email/notmuch/shared.py
@@ -81,21 +81,11 @@ def read(
     if "id:" in query or "mid:" in query:
         query = _resolve_id_in_query(query)
 
-    # For headers/summary mode, use lightweight search
-    if mode in ("headers", "summary"):
-        results = _search_emails(query, limit, offset, include_excluded)
-        if mode == "headers":
-            return results
-        # For summary, get truncated content
-        return _show_email(
-            query,
-            mode="summary",
-            limit=limit,
-            include_excluded=include_excluded,
-            save_to=save_attachments_to,
-        )
+    # Headers mode: lightweight search (no body parsing)
+    if mode == "headers":
+        return _search_emails(query, limit, offset, include_excluded)
 
-    # Full content display
+    # Summary and full modes: parse email content
     return _show_email(
         query,
         mode=mode,

--- a/src/mcp_handley_lab/email/notmuch/tool.py
+++ b/src/mcp_handley_lab/email/notmuch/tool.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from pydantic import BaseModel, Field
 
 from mcp_handley_lab.common.process import run_command
-from mcp_handley_lab.email.common import mcp
+from mcp_handley_lab.email.common import _TOOL_CONFIGS, mcp
 from mcp_handley_lab.email.extraction import (
     EmailBodySegment,
     EmailPartInfo,
@@ -877,13 +877,15 @@ def email_accounts() -> list[str]:
 
 
 # ============================================================================
-# Unified Tools
+# Unified Tools (registered via _TOOL_CONFIGS for lifespan injection)
 # ============================================================================
 
+# Base descriptions (will have tags/folders appended at startup)
+_READ_DESCRIPTION = """Search and read emails. Returns message IDs needed by send (for replies) and update (for tagging/moving). Use email://tags, email://folders, email://accounts resources to discover available options. Supports notmuch query language: sender, subject, date ranges, tags, attachments, and body content filtering with boolean operators."""
 
-@mcp.tool(
-    description="""Search and read emails. Returns message IDs needed by send (for replies) and update (for tagging/moving). Use email://tags, email://folders, email://accounts resources to discover available options. Supports notmuch query language: sender, subject, date ranges, tags, attachments, and body content filtering with boolean operators."""
-)
+_UPDATE_DESCRIPTION = """Update email metadata. Requires message_ids from the read tool. Actions: 'tag' (add/remove tags), 'move' (relocate to folder), 'archive' (move to Archive folder)."""
+
+
 def read(
     query: str = Field(
         default="",
@@ -941,9 +943,6 @@ def read(
     )
 
 
-@mcp.tool(
-    description="""Update email metadata. Requires message_ids from the read tool. Actions: 'tag' (add/remove tags), 'move' (relocate to folder), 'archive' (move to Archive folder)."""
-)
 def update(
     message_ids: list[str] = Field(
         default_factory=list,
@@ -976,3 +975,17 @@ def update(
         remove_tags=remove_tags or None,
         destination_folder=destination_folder,
     )
+
+
+# =============================================================================
+# Tool Registration (explicit for lifespan-based description injection)
+# =============================================================================
+
+_TOOL_CONFIGS["read"] = {"fn": read, "description": _READ_DESCRIPTION}
+_TOOL_CONFIGS["update"] = {"fn": update, "description": _UPDATE_DESCRIPTION}
+
+for _name, _config in [
+    ("read", _TOOL_CONFIGS["read"]),
+    ("update", _TOOL_CONFIGS["update"]),
+]:
+    mcp.add_tool(_config["fn"], name=_name, description=_config["description"])

--- a/src/mcp_handley_lab/llm/registry.py
+++ b/src/mcp_handley_lab/llm/registry.py
@@ -45,6 +45,8 @@ MODEL_ALIASES = {
     "opus": "claude-opus-4-5-20251101",
     "sonnet": "claude-sonnet-4-5-20250929",
     "haiku": "claude-haiku-4-5-20251001",
+    # Gemini shorthand aliases
+    "deep-research": "gemini-deep-research",
 }
 
 # Provider name aliases are added dynamically from YAML defaults


### PR DESCRIPTION
## Summary
- Inject available tags into `read` tool description at server startup
- Inject tags + folders into `update` tool description
- Add `deep-research` alias for `gemini-deep-research` model
- Fix performance bug in summary mode (redundant notmuch search)

## Implementation
Follows the same lifespan injection pattern used in `google_calendar/tool.py`:
1. At startup, fetch tags via `_list_tags()` and folders via `_list_folders()`
2. Re-register `read` and `update` tools with augmented descriptions
3. Tags capped at 50 to avoid oversized descriptions

## Test plan
- [ ] Verify email tool imports correctly
- [ ] Verify `deep-research` alias resolves to `gemini-deep-research`
- [ ] Restart Claude Code and check tool descriptions include tags/folders

🤖 Generated with [Claude Code](https://claude.com/claude-code)