### PR TITLE
feat(llm): convert LLM tools to async for non-blocking API calls

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.24
+pkgver=0.25.25
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.24"
+version = "0.25.25"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/embeddings/tool.py
+++ b/src/mcp_handley_lab/llm/embeddings/tool.py
@@ -35,13 +35,13 @@ def _resolve_embedding_provider(model: str) -> str:
     )
 
 
-def _get_embeddings(texts: list[str], model: str) -> list[list[float]]:
+async def _get_embeddings(texts: list[str], model: str) -> list[list[float]]:
     """Get embeddings using the appropriate provider via registry."""
     from mcp_handley_lab.llm.registry import get_adapter
 
     provider = _resolve_embedding_provider(model)
     adapter = get_adapter(provider, "embeddings")
-    return adapter(texts, model)
+    return await adapter(texts, model)
 
 
 def _cosine_similarity(vec1: list[float], vec2: list[float]) -> float:
@@ -61,7 +61,7 @@ def _cosine_similarity(vec1: list[float], vec2: list[float]) -> float:
     "Related: index_documents, search_documents, calculate_similarity. "
     "Returns: {embeddings: [[float]], model, provider, dimensions, count}."
 )
-def get_embeddings(
+async def get_embeddings(
     texts: list[str] = Field(
         ...,
         description="Text strings to embed. Max 16 for Mistral.",
@@ -82,7 +82,7 @@ def get_embeddings(
     if provider == "mistral" and len(texts) > 16:
         raise ValueError(f"Mistral: maximum 16 texts per request (got {len(texts)})")
 
-    embeddings = _get_embeddings(texts, model)
+    embeddings = await _get_embeddings(texts, model)
 
     result = {
         "embeddings": embeddings,
@@ -105,7 +105,7 @@ def get_embeddings(
     "Related: get_embeddings, index_documents, search_documents. "
     "Returns: {similarity: float (-1.0 to 1.0), model, provider}."
 )
-def calculate_similarity(
+async def calculate_similarity(
     text1: str = Field(
         ...,
         description="First text for comparison.",
@@ -120,7 +120,7 @@ def calculate_similarity(
     ),
 ) -> dict[str, Any]:
     """Calculate cosine similarity between two texts."""
-    embeddings = _get_embeddings([text1, text2], model)
+    embeddings = await _get_embeddings([text1, text2], model)
 
     similarity = _cosine_similarity(embeddings[0], embeddings[1])
 
@@ -137,7 +137,7 @@ def calculate_similarity(
     "Use search_documents to query the index. "
     "Returns: {message, index_path, model, document_count}."
 )
-def index_documents(
+async def index_documents(
     document_paths: list[str] = Field(
         ...,
         description="File paths to text documents to index.",
@@ -161,7 +161,7 @@ def index_documents(
 
     # Get embeddings for all documents
     texts = [doc["content"] for doc in documents]
-    embeddings = _get_embeddings(texts, model)
+    embeddings = await _get_embeddings(texts, model)
 
     # Build index
     index = {
@@ -191,7 +191,7 @@ def index_documents(
     "Returns: {query, model, results: [{path, similarity}]}. "
     "Model defaults to index model if not specified."
 )
-def search_documents(
+async def search_documents(
     query: str = Field(
         ...,
         description="Search query.",
@@ -226,7 +226,7 @@ def search_documents(
         )
 
     # Get query embedding
-    query_embedding = _get_embeddings([query], search_model)[0]
+    query_embedding = (await _get_embeddings([query], search_model))[0]
 
     # Calculate similarities
     results = []

--- a/src/mcp_handley_lab/llm/providers/claude/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/claude/adapter.py
@@ -4,10 +4,9 @@ Contains provider-specific generation functions that implement the Anthropic API
 These adapters are used by the unified mcp-chat tool.
 """
 
-import threading
 from typing import Any
 
-from anthropic import Anthropic
+from anthropic import AsyncAnthropic
 
 from mcp_handley_lab.common.config import settings
 from mcp_handley_lab.llm.common import (
@@ -16,20 +15,15 @@ from mcp_handley_lab.llm.common import (
     resolve_images_for_multimodal_prompt,
 )
 
-# Lazy initialization of Claude client
-_client: Anthropic | None = None
-_client_lock = threading.Lock()
+# Lazy initialization of async Claude client
+_client: AsyncAnthropic | None = None
 
 
-def get_client() -> Anthropic:
-    """Get or create the global Claude client with thread safety."""
+def get_client() -> AsyncAnthropic:
+    """Get or create the global async Claude client."""
     global _client
-    with _client_lock:
-        if _client is None:
-            try:
-                _client = Anthropic(api_key=settings.anthropic_api_key)
-            except Exception as e:
-                raise RuntimeError(f"Failed to initialize Claude client: {e}") from e
+    if _client is None:
+        _client = AsyncAnthropic(api_key=settings.anthropic_api_key)
     return _client
 
 
@@ -124,7 +118,7 @@ def resolve_images_to_content_blocks(
     return claude_image_blocks
 
 
-def generation_adapter(
+async def generation_adapter(
     prompt: str,
     model: str,
     history: list[dict[str, str]],
@@ -180,10 +174,7 @@ def generation_adapter(
         request_params["system"] = system_instruction
 
     # Make API call
-    try:
-        response = get_client().messages.create(**request_params)
-    except Exception as e:
-        raise ValueError(f"Claude API error: {str(e)}") from e
+    response = await get_client().messages.create(**request_params)
 
     # Extract text and thinking from response content blocks
     text_parts = []
@@ -249,7 +240,7 @@ def generation_adapter(
     }
 
 
-def image_analysis_adapter(
+async def image_analysis_adapter(
     prompt: str,
     model: str,
     history: list[dict[str, str]],
@@ -293,10 +284,7 @@ def image_analysis_adapter(
     if system_instruction:
         request_params["system"] = system_instruction
 
-    try:
-        response = get_client().messages.create(**request_params)
-    except Exception as e:
-        raise ValueError(f"Claude API error: {str(e)}") from e
+    response = await get_client().messages.create(**request_params)
 
     # Extract citations from content blocks
     citations = []

--- a/src/mcp_handley_lab/llm/providers/gemini/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/gemini/adapter.py
@@ -4,9 +4,10 @@ Contains provider-specific generation functions that implement the Gemini API ca
 These adapters are used by the unified mcp-chat tool.
 """
 
+import asyncio
 import base64
+import functools
 import io
-import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -40,26 +41,20 @@ GEMINI_INLINE_FILE_LIMIT_BYTES = 20 * 1024 * 1024  # 20MB
 
 # Lazy initialization of Gemini client
 _client: google_genai.Client | None = None
-_client_lock = threading.Lock()
 
 
 def get_client() -> google_genai.Client:
-    """Get or create the global Gemini client with thread safety."""
+    """Get or create the global Gemini client."""
     global _client
-    with _client_lock:
-        if _client is None:
-            try:
-                _client = google_genai.Client(api_key=settings.gemini_api_key)
-            except Exception as e:
-                raise RuntimeError(f"Failed to initialize Gemini client: {e}") from e
+    if _client is None:
+        _client = google_genai.Client(api_key=settings.gemini_api_key)
     return _client
 
 
 def reset_client() -> None:
     """Reset the global client. Used by tests to ensure VCR can intercept requests."""
     global _client
-    with _client_lock:
-        _client = None
+    _client = None
 
 
 # Load model configurations using shared loader
@@ -134,14 +129,14 @@ def resolve_images(images: list[str] | None = None) -> list[Image.Image]:
     return image_list
 
 
-def generation_adapter(
+def _sync_generation_adapter(
     prompt: str,
     model: str,
     history: list[dict[str, str]],
     system_instruction: str,
     **kwargs,
 ) -> dict[str, Any]:
-    """Gemini-specific text generation function for the shared processor."""
+    """Sync Gemini text generation (internal)."""
     # Extract Gemini-specific parameters from options dict
     options = kwargs.get("options", {})
     temperature = kwargs.get("temperature", 1.0)
@@ -343,14 +338,34 @@ def generation_adapter(
     }
 
 
-def image_analysis_adapter(
+async def generation_adapter(
     prompt: str,
     model: str,
     history: list[dict[str, str]],
     system_instruction: str,
     **kwargs,
 ) -> dict[str, Any]:
-    """Gemini-specific image analysis function for the shared processor."""
+    """Gemini text generation wrapped for async."""
+    return await asyncio.to_thread(
+        functools.partial(
+            _sync_generation_adapter,
+            prompt,
+            model,
+            history,
+            system_instruction,
+            **kwargs,
+        )
+    )
+
+
+def _sync_image_analysis_adapter(
+    prompt: str,
+    model: str,
+    history: list[dict[str, str]],
+    system_instruction: str,
+    **kwargs,
+) -> dict[str, Any]:
+    """Sync Gemini image analysis (internal)."""
     # Extract image analysis specific parameters
     images = kwargs.get("images", [])
 
@@ -388,6 +403,26 @@ def image_analysis_adapter(
         "output_tokens": response.usage_metadata.candidates_token_count,
         "total_tokens": getattr(response.usage_metadata, "total_token_count", 0) or 0,
     }
+
+
+async def image_analysis_adapter(
+    prompt: str,
+    model: str,
+    history: list[dict[str, str]],
+    system_instruction: str,
+    **kwargs,
+) -> dict[str, Any]:
+    """Gemini image analysis wrapped for async."""
+    return await asyncio.to_thread(
+        functools.partial(
+            _sync_image_analysis_adapter,
+            prompt,
+            model,
+            history,
+            system_instruction,
+            **kwargs,
+        )
+    )
 
 
 def _is_nano_banana_model(model: str) -> bool:
@@ -533,36 +568,49 @@ def _generate_with_imagen(prompt: str, model: str, **kwargs) -> dict:
     }
 
 
-def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
-    """Gemini-specific image generation function.
-
-    Routes to appropriate API based on model type:
-    - Nano Banana models (gemini-*-image*): uses generate_content API
-    - Imagen models: uses generate_images API
-    """
+def _sync_image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
+    """Sync Gemini image generation (internal)."""
     if _is_nano_banana_model(model):
         return _generate_with_nano_banana(prompt, model, **kwargs)
     else:
         return _generate_with_imagen(prompt, model, **kwargs)
 
 
-def list_api_models() -> set[str]:
-    """List model names available from the Gemini API."""
+async def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
+    """Gemini image generation wrapped for async."""
+    return await asyncio.to_thread(
+        functools.partial(_sync_image_generation_adapter, prompt, model, **kwargs)
+    )
+
+
+def _sync_list_api_models() -> set[str]:
+    """Sync list models (internal)."""
     models_response = get_client().models.list()
     return {model.name.split("/")[-1] for model in models_response}
 
 
-def embeddings_adapter(texts: list[str], model: str) -> list[list[float]]:
-    """Generate embeddings for a list of texts."""
+async def list_api_models() -> set[str]:
+    """List model names available from the Gemini API."""
+    return await asyncio.to_thread(_sync_list_api_models)
+
+
+def _sync_embeddings_adapter(texts: list[str], model: str) -> list[list[float]]:
+    """Sync embeddings (internal)."""
     result = []
     for text in texts:
         response = get_client().models.embed_content(model=model, contents=text)
-        # response.embeddings is a list of ContentEmbedding, each has .values
         result.append(response.embeddings[0].values)
     return result
 
 
-def deep_research_adapter(
+async def embeddings_adapter(texts: list[str], model: str) -> list[list[float]]:
+    """Generate embeddings for a list of texts."""
+    return await asyncio.to_thread(
+        functools.partial(_sync_embeddings_adapter, texts, model)
+    )
+
+
+def _sync_deep_research_adapter(
     prompt: str,
     model: str,
     history: list[dict[str, str]],
@@ -668,3 +716,23 @@ def deep_research_adapter(
         "response_id": interaction_id,
         "grounding_metadata": grounding_metadata,
     }
+
+
+async def deep_research_adapter(
+    prompt: str,
+    model: str,
+    history: list[dict[str, str]],
+    system_instruction: str,
+    **kwargs,
+) -> dict[str, Any]:
+    """Gemini Deep Research wrapped for async."""
+    return await asyncio.to_thread(
+        functools.partial(
+            _sync_deep_research_adapter,
+            prompt,
+            model,
+            history,
+            system_instruction,
+            **kwargs,
+        )
+    )

--- a/src/mcp_handley_lab/llm/providers/grok/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/grok/adapter.py
@@ -4,7 +4,8 @@ Contains provider-specific generation functions that implement the Grok API call
 These adapters are used by the unified mcp-chat tool.
 """
 
-import threading
+import asyncio
+import functools
 from typing import Any
 
 from xai_sdk import Client
@@ -18,18 +19,13 @@ from mcp_handley_lab.llm.common import (
 
 # Lazy initialization of Grok client
 _client: Client | None = None
-_client_lock = threading.Lock()
 
 
 def get_client() -> Client:
-    """Get or create the global Grok client with thread safety."""
+    """Get or create the global Grok client."""
     global _client
-    with _client_lock:
-        if _client is None:
-            try:
-                _client = Client(api_key=settings.xai_api_key)
-            except Exception as e:
-                raise RuntimeError(f"Failed to initialize Grok client: {e}") from e
+    if _client is None:
+        _client = Client(api_key=settings.xai_api_key)
     return _client
 
 
@@ -42,14 +38,14 @@ def get_model_config(model: str) -> dict:
     return MODEL_CONFIGS.get(model, MODEL_CONFIGS[DEFAULT_MODEL])
 
 
-def generation_adapter(
+def _sync_generation_adapter(
     prompt: str,
     model: str,
     history: list[dict[str, str]],
     system_instruction: str,
     **kwargs,
 ) -> dict[str, Any]:
-    """Grok-specific text generation function for the shared processor."""
+    """Sync Grok text generation (internal)."""
     from xai_sdk import chat
 
     # Extract Grok-specific parameters
@@ -169,14 +165,34 @@ def generation_adapter(
     }
 
 
-def image_analysis_adapter(
+async def generation_adapter(
     prompt: str,
     model: str,
     history: list[dict[str, str]],
     system_instruction: str,
     **kwargs,
 ) -> dict[str, Any]:
-    """Grok-specific image analysis function for the shared processor."""
+    """Grok text generation wrapped for async."""
+    return await asyncio.to_thread(
+        functools.partial(
+            _sync_generation_adapter,
+            prompt,
+            model,
+            history,
+            system_instruction,
+            **kwargs,
+        )
+    )
+
+
+def _sync_image_analysis_adapter(
+    prompt: str,
+    model: str,
+    history: list[dict[str, str]],
+    system_instruction: str,
+    **kwargs,
+) -> dict[str, Any]:
+    """Sync Grok image analysis (internal)."""
     from xai_sdk import chat
 
     # Extract image analysis specific parameters
@@ -256,8 +272,28 @@ def image_analysis_adapter(
     }
 
 
-def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
-    """Grok-specific image generation function with comprehensive metadata extraction."""
+async def image_analysis_adapter(
+    prompt: str,
+    model: str,
+    history: list[dict[str, str]],
+    system_instruction: str,
+    **kwargs,
+) -> dict[str, Any]:
+    """Grok image analysis wrapped for async."""
+    return await asyncio.to_thread(
+        functools.partial(
+            _sync_image_analysis_adapter,
+            prompt,
+            model,
+            history,
+            system_instruction,
+            **kwargs,
+        )
+    )
+
+
+def _sync_image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
+    """Sync Grok image generation (internal)."""
     # Use xai-sdk's image.sample method
     # image_format="base64" returns raw bytes via response.image
     response = get_client().image.sample(
@@ -287,8 +323,15 @@ def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
     }
 
 
-def list_api_models() -> set[str]:
-    """List model names available from the Grok API."""
+async def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
+    """Grok image generation wrapped for async."""
+    return await asyncio.to_thread(
+        functools.partial(_sync_image_generation_adapter, prompt, model, **kwargs)
+    )
+
+
+def _sync_list_api_models() -> set[str]:
+    """Sync list models (internal)."""
     language_models = get_client().models.list_language_models()
     api_model_ids = {m.name for m in language_models}
 
@@ -297,3 +340,8 @@ def list_api_models() -> set[str]:
     api_model_ids.update({m.name for m in image_models})
 
     return api_model_ids
+
+
+async def list_api_models() -> set[str]:
+    """List model names available from the Grok API."""
+    return await asyncio.to_thread(_sync_list_api_models)

--- a/src/mcp_handley_lab/llm/providers/groq/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/groq/adapter.py
@@ -5,10 +5,9 @@ These adapters are used by the unified mcp-chat tool.
 """
 
 import os
-import threading
 from typing import Any
 
-from openai import BadRequestError, OpenAI
+from openai import AsyncOpenAI, BadRequestError
 
 from mcp_handley_lab.common.config import settings
 from mcp_handley_lab.llm.common import (
@@ -16,22 +15,19 @@ from mcp_handley_lab.llm.common import (
     resolve_files_for_llm,
 )
 
-# Lazy initialization of Groq client
-_client: OpenAI | None = None
-_client_lock = threading.Lock()
+# Lazy initialization of async Groq client
+_client: AsyncOpenAI | None = None
 
 
-def get_client() -> OpenAI:
-    """Get or create the global Groq client with thread safety."""
+def get_client() -> AsyncOpenAI:
+    """Get or create the global async Groq client."""
     global _client
-    with _client_lock:
-        if _client is None:
-            # Check env var directly (for tests) or fall back to settings
-            api_key = os.environ.get("GROQ_API_KEY") or settings.groq_api_key
-            _client = OpenAI(
-                api_key=api_key,
-                base_url="https://api.groq.com/openai/v1",
-            )
+    if _client is None:
+        api_key = os.environ.get("GROQ_API_KEY") or settings.groq_api_key
+        _client = AsyncOpenAI(
+            api_key=api_key,
+            base_url="https://api.groq.com/openai/v1",
+        )
     return _client
 
 
@@ -44,7 +40,7 @@ def get_model_config(model: str) -> dict:
     return MODEL_CONFIGS.get(model, MODEL_CONFIGS[DEFAULT_MODEL])
 
 
-def generation_adapter(
+async def generation_adapter(
     prompt: str,
     model: str,
     history: list[dict[str, str]],
@@ -84,10 +80,8 @@ def generation_adapter(
     }
 
     try:
-        response = get_client().chat.completions.create(**request_params)
+        response = await get_client().chat.completions.create(**request_params)
     except BadRequestError as e:
-        raise ValueError(f"Groq API error: {str(e)}") from e
-    except Exception as e:
         raise ValueError(f"Groq API error: {str(e)}") from e
 
     # Extract timing information from usage (Groq-specific latency breakdown)
@@ -126,7 +120,7 @@ def generation_adapter(
     }
 
 
-def list_api_models() -> set[str]:
+async def list_api_models() -> set[str]:
     """List model IDs available from the Groq API."""
-    api_models = get_client().models.list()
+    api_models = await get_client().models.list()
     return {m.id for m in api_models.data}

--- a/src/mcp_handley_lab/llm/providers/mistral/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/mistral/adapter.py
@@ -4,8 +4,9 @@ Contains provider-specific generation functions that implement the Mistral API c
 These adapters are used by the unified mcp-chat tool.
 """
 
+import asyncio
 import base64
-import threading
+import functools
 from pathlib import Path
 from typing import Any
 
@@ -21,18 +22,13 @@ from mcp_handley_lab.llm.common import (
 
 # Lazy initialization of Mistral client
 _client: Mistral | None = None
-_client_lock = threading.Lock()
 
 
 def get_client() -> Mistral:
-    """Get or create the global Mistral client with thread safety."""
+    """Get or create the global Mistral client."""
     global _client
-    with _client_lock:
-        if _client is None:
-            try:
-                _client = Mistral(api_key=settings.mistral_api_key)
-            except Exception as e:
-                raise RuntimeError(f"Failed to initialize Mistral client: {e}") from e
+    if _client is None:
+        _client = Mistral(api_key=settings.mistral_api_key)
     return _client
 
 
@@ -113,14 +109,14 @@ def resolve_files(files: list[str]) -> list[dict[str, Any]]:
     return content_parts
 
 
-def generation_adapter(
+def _sync_generation_adapter(
     prompt: str,
     model: str,
     history: list[dict[str, str]],
     system_instruction: str,
     **kwargs,
 ) -> dict[str, Any]:
-    """Mistral-specific text generation function for the shared processor."""
+    """Sync Mistral text generation (internal)."""
     # Extract Mistral-specific parameters from options dict
     options = kwargs.get("options", {})
     temperature = kwargs.get("temperature", 1.0)
@@ -188,14 +184,34 @@ def generation_adapter(
     }
 
 
-def image_analysis_adapter(
+async def generation_adapter(
     prompt: str,
     model: str,
     history: list[dict[str, str]],
     system_instruction: str,
     **kwargs,
 ) -> dict[str, Any]:
-    """Mistral-specific image analysis function for the shared processor."""
+    """Mistral text generation wrapped for async."""
+    return await asyncio.to_thread(
+        functools.partial(
+            _sync_generation_adapter,
+            prompt,
+            model,
+            history,
+            system_instruction,
+            **kwargs,
+        )
+    )
+
+
+def _sync_image_analysis_adapter(
+    prompt: str,
+    model: str,
+    history: list[dict[str, str]],
+    system_instruction: str,
+    **kwargs,
+) -> dict[str, Any]:
+    """Sync Mistral image analysis (internal)."""
     # Extract image analysis specific parameters
     images = kwargs.get("images", [])
     focus = kwargs.get("focus", "general")
@@ -268,8 +284,30 @@ def image_analysis_adapter(
     }
 
 
-def ocr_adapter(document_path: str, include_images: bool = True) -> dict[str, Any]:
-    """Mistral-specific OCR function for document processing."""
+async def image_analysis_adapter(
+    prompt: str,
+    model: str,
+    history: list[dict[str, str]],
+    system_instruction: str,
+    **kwargs,
+) -> dict[str, Any]:
+    """Mistral image analysis wrapped for async."""
+    return await asyncio.to_thread(
+        functools.partial(
+            _sync_image_analysis_adapter,
+            prompt,
+            model,
+            history,
+            system_instruction,
+            **kwargs,
+        )
+    )
+
+
+def _sync_ocr_adapter(
+    document_path: str, include_images: bool = True
+) -> dict[str, Any]:
+    """Sync Mistral OCR (internal)."""
     # Determine input type and format
     document_input = {}
 
@@ -341,12 +379,21 @@ def ocr_adapter(document_path: str, include_images: bool = True) -> dict[str, An
     }
 
 
-def audio_transcription_adapter(
+async def ocr_adapter(
+    document_path: str, include_images: bool = True
+) -> dict[str, Any]:
+    """Mistral OCR wrapped for async."""
+    return await asyncio.to_thread(
+        functools.partial(_sync_ocr_adapter, document_path, include_images)
+    )
+
+
+def _sync_audio_transcription_adapter(
     audio_path: str,
     language: str = "",
     include_timestamps: bool = False,
 ) -> dict[str, Any]:
-    """Mistral-specific audio transcription function."""
+    """Sync Mistral audio transcription (internal)."""
     # Prepare transcription request
     transcription_params = {
         "model": "voxtral-mini-latest",
@@ -393,14 +440,34 @@ def audio_transcription_adapter(
     return result
 
 
-def embeddings_adapter(texts: list[str], model: str) -> list[list[float]]:
-    """Generate embeddings for a list of texts."""
+async def audio_transcription_adapter(
+    audio_path: str,
+    language: str = "",
+    include_timestamps: bool = False,
+) -> dict[str, Any]:
+    """Mistral audio transcription wrapped for async."""
+    return await asyncio.to_thread(
+        functools.partial(
+            _sync_audio_transcription_adapter, audio_path, language, include_timestamps
+        )
+    )
+
+
+def _sync_embeddings_adapter(texts: list[str], model: str) -> list[list[float]]:
+    """Sync embeddings (internal)."""
     response = get_client().embeddings.create(model=model, inputs=texts)
     return [item.embedding for item in response.data]
 
 
-def moderation_adapter(text: str) -> dict[str, Any]:
-    """Mistral-specific content moderation function."""
+async def embeddings_adapter(texts: list[str], model: str) -> list[list[float]]:
+    """Generate embeddings for a list of texts."""
+    return await asyncio.to_thread(
+        functools.partial(_sync_embeddings_adapter, texts, model)
+    )
+
+
+def _sync_moderation_adapter(text: str) -> dict[str, Any]:
+    """Sync moderation (internal)."""
     # Call Mistral moderation API
     response = get_client().classifiers.moderate_chat(
         model="mistral-moderation-latest",
@@ -443,7 +510,12 @@ def moderation_adapter(text: str) -> dict[str, Any]:
     }
 
 
-def fill_in_middle_adapter(
+async def moderation_adapter(text: str) -> dict[str, Any]:
+    """Mistral moderation wrapped for async."""
+    return await asyncio.to_thread(functools.partial(_sync_moderation_adapter, text))
+
+
+def _sync_fill_in_middle_adapter(
     prefix: str,
     suffix: str = "",
     model: str = "codestral-latest",
@@ -451,7 +523,7 @@ def fill_in_middle_adapter(
     temperature: float = 0.0,
     stop: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Mistral-specific fill-in-the-middle code completion."""
+    """Sync FIM (internal)."""
     # Build FIM request
     fim_params = {
         "model": model,
@@ -485,7 +557,34 @@ def fill_in_middle_adapter(
     }
 
 
-def list_api_models() -> set[str]:
-    """List model IDs available from the Mistral API."""
+async def fill_in_middle_adapter(
+    prefix: str,
+    suffix: str = "",
+    model: str = "codestral-latest",
+    max_tokens: int = 256,
+    temperature: float = 0.0,
+    stop: list[str] | None = None,
+) -> dict[str, Any]:
+    """Mistral FIM wrapped for async."""
+    return await asyncio.to_thread(
+        functools.partial(
+            _sync_fill_in_middle_adapter,
+            prefix,
+            suffix,
+            model,
+            max_tokens,
+            temperature,
+            stop,
+        )
+    )
+
+
+def _sync_list_api_models() -> set[str]:
+    """Sync list models (internal)."""
     models_response = get_client().models.list()
     return {model.id for model in models_response.data}
+
+
+async def list_api_models() -> set[str]:
+    """List model IDs available from the Mistral API."""
+    return await asyncio.to_thread(_sync_list_api_models)

--- a/src/mcp_handley_lab/llm/providers/openai/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/openai/adapter.py
@@ -5,12 +5,11 @@ These adapters are used by the unified mcp-chat tool.
 """
 
 import base64
-import threading
 from typing import Any
 
 import httpx
 import openai
-from openai import OpenAI
+from openai import AsyncOpenAI
 
 from mcp_handley_lab.common.config import settings
 from mcp_handley_lab.llm.common import (
@@ -19,20 +18,15 @@ from mcp_handley_lab.llm.common import (
     resolve_images_for_multimodal_prompt,
 )
 
-# Lazy initialization of OpenAI client
-_client: OpenAI | None = None
-_client_lock = threading.Lock()
+# Lazy initialization of async OpenAI client
+_client: AsyncOpenAI | None = None
 
 
-def get_client() -> OpenAI:
-    """Get or create the global OpenAI client with thread safety."""
+def get_client() -> AsyncOpenAI:
+    """Get or create the global async OpenAI client."""
     global _client
-    with _client_lock:
-        if _client is None:
-            try:
-                _client = OpenAI(api_key=settings.openai_api_key)
-            except Exception as e:
-                raise RuntimeError(f"Failed to initialize OpenAI client: {e}") from e
+    if _client is None:
+        _client = AsyncOpenAI(api_key=settings.openai_api_key)
     return _client
 
 
@@ -45,7 +39,7 @@ def get_model_config(model: str) -> dict:
     return MODEL_CONFIGS.get(model, MODEL_CONFIGS[DEFAULT_MODEL])
 
 
-def generation_adapter(
+async def generation_adapter(
     prompt: str,
     model: str,
     history: list[dict[str, str]],
@@ -125,7 +119,7 @@ def generation_adapter(
         request_params["tools"] = [{"type": "web_search_preview"}]
 
     # Make Responses API call
-    response = get_client().responses.create(**request_params)
+    response = await get_client().responses.create(**request_params)
 
     # Extract primary output text via helper property
     text = getattr(response, "output_text", None)
@@ -200,7 +194,7 @@ def generation_adapter(
     }
 
 
-def image_analysis_adapter(
+async def image_analysis_adapter(
     prompt: str,
     model: str,
     history: list[dict[str, str]],
@@ -273,7 +267,7 @@ def image_analysis_adapter(
 
     request_params["max_output_tokens"] = default_tokens
 
-    response = get_client().responses.create(**request_params)
+    response = await get_client().responses.create(**request_params)
 
     text = getattr(response, "output_text", None)
     if text is None:
@@ -315,7 +309,7 @@ def image_analysis_adapter(
     }
 
 
-def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
+async def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
     """OpenAI-specific image generation function with comprehensive metadata extraction."""
     size = kwargs.get("size", "1024x1024")
     quality = kwargs.get("quality", "standard")
@@ -328,23 +322,20 @@ def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
         params["quality"] = quality
 
     try:
-        response = get_client().images.generate(**params)
+        response = await get_client().images.generate(**params)
     except openai.BadRequestError as e:
-        raise ValueError(f"OpenAI image generation error: {str(e)}") from e
-    except Exception as e:
         raise ValueError(f"OpenAI image generation error: {str(e)}") from e
 
     image = response.data[0]
 
     # Get image bytes based on response format
     if is_gpt_image or getattr(image, "b64_json", None):
-        # Decode base64 response
         image_bytes = base64.b64decode(image.b64_json)
         original_url = None
     else:
-        # Download from URL
-        with httpx.Client() as http_client:
-            image_response = http_client.get(image.url)
+        # Download from URL using async httpx
+        async with httpx.AsyncClient() as http_client:
+            image_response = await http_client.get(image.url)
             image_response.raise_for_status()
             image_bytes = image_response.content
         original_url = image.url
@@ -371,13 +362,13 @@ def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
     }
 
 
-def list_api_models() -> set[str]:
+async def list_api_models() -> set[str]:
     """List model IDs available from the OpenAI API."""
-    api_models = get_client().models.list()
+    api_models = await get_client().models.list()
     return {m.id for m in api_models.data}
 
 
-def embeddings_adapter(texts: list[str], model: str) -> list[list[float]]:
+async def embeddings_adapter(texts: list[str], model: str) -> list[list[float]]:
     """Generate embeddings for a list of texts."""
-    response = get_client().embeddings.create(model=model, input=texts)
+    response = await get_client().embeddings.create(model=model, input=texts)
     return [item.embedding for item in response.data]

--- a/src/mcp_handley_lab/llm/shared.py
+++ b/src/mcp_handley_lab/llm/shared.py
@@ -257,7 +257,7 @@ def _save_conversation_turn(
     return memory.write_conversation(project_dir, branch, content, commit_message)
 
 
-def process_llm_request(
+async def process_llm_request(
     prompt: str | None,
     output_file: str,
     branch: str,
@@ -275,7 +275,7 @@ def process_llm_request(
         branch: Already resolved branch name (callers handle "session" resolution)
         model: Model identifier
         provider: Provider name
-        generation_func: Provider-specific generation function
+        generation_func: Provider-specific async generation function
         from_ref: Optional ref to fork from when creating new branch
         **kwargs: Additional arguments for the generation function
     """
@@ -311,8 +311,8 @@ def process_llm_request(
         final_prompt, user_prompt, kwargs
     )
 
-    # Call provider-specific generation function
-    response_data = generation_func(
+    # Call provider-specific async generation function
+    response_data = await generation_func(
         prompt=final_prompt,
         model=model,
         history=history,
@@ -392,7 +392,7 @@ def process_llm_request(
 # =============================================================================
 
 
-def chat(
+async def chat(
     prompt: str | None = None,
     prompt_file: str | None = None,
     prompt_vars: dict[str, str] | None = None,
@@ -454,7 +454,7 @@ def chat(
         kwargs["images"] = images
         kwargs["focus"] = focus
 
-    return process_llm_request(
+    return await process_llm_request(
         prompt=prompt,
         output_file=output_file,
         branch=actual_branch,

--- a/src/mcp_handley_lab/llm/tool.py
+++ b/src/mcp_handley_lab/llm/tool.py
@@ -66,7 +66,7 @@ def _detect_image_format(data: bytes) -> str:
     "For vision/image analysis, provide images parameter with local paths or data URIs. "
     "Returns: {content, usage: {input_tokens, output_tokens, cost, model_used}, branch, commit_sha}."
 )
-def chat(
+async def chat(
     prompt: str = Field(
         default="",
         description="The message to send to the LLM.",
@@ -160,7 +160,7 @@ def chat(
         kwargs["images"] = images
         kwargs["focus"] = focus
 
-    return process_llm_request(
+    return await process_llm_request(
         prompt=prompt or None,
         output_file=output_file,
         branch=resolved_branch,
@@ -225,7 +225,7 @@ def conversation(
     "Returns: [TextContent(JSON metadata), Image(preview)]. "
     "Metadata includes: file_path, file_size_bytes, model, provider, cost, detected_format, enhanced_prompt, original_prompt."
 )
-def generate_image(
+async def generate_image(
     prompt: str = Field(
         default="",
         description="Text description of the image to generate.",
@@ -292,7 +292,7 @@ def generate_image(
     if input_images:
         kwargs["input_images"] = input_images
 
-    response_data = generation_func(
+    response_data = await generation_func(
         prompt=final_prompt, model=canonical_model, **kwargs
     )
 
@@ -358,7 +358,7 @@ def generate_image(
     "Supports MP3, WAV, FLAC, OGG, M4A. Use model://list resource to discover audio models. "
     "Returns: {text, segments?: [{start, end, text}]}. Segments included if include_timestamps=true."
 )
-def transcribe(
+async def transcribe(
     audio_path: str = Field(
         ...,
         description="Path to audio file or URL.",
@@ -378,7 +378,7 @@ def transcribe(
 ) -> dict[str, Any]:
     """Transcribe audio using Mistral Voxtral model."""
     adapter = get_adapter("mistral", "audio_transcription")
-    result = adapter(
+    result = await adapter(
         audio_path=audio_path,
         language=language,
         include_timestamps=include_timestamps,
@@ -397,7 +397,7 @@ def transcribe(
     "Supports PDFs, images (PNG, JPG), PPTX, and DOCX. Use model://list resource to discover OCR models. "
     "Returns: {status, pages, output_file?, message}. Full OCR JSON saved to output_file if provided."
 )
-def ocr(
+async def ocr(
     document_path: str = Field(
         ...,
         description="Path to document file or URL. Supports PDF, images, PPTX, DOCX.",
@@ -413,7 +413,7 @@ def ocr(
 ) -> dict[str, Any]:
     """Process document with Mistral OCR for text extraction."""
     adapter = get_adapter("mistral", "ocr")
-    result = adapter(document_path, include_images)
+    result = await adapter(document_path, include_images)
 
     pages = result.get("pages", [])
     response: dict[str, Any] = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,17 +4,12 @@ import re
 import tempfile
 from pathlib import Path
 
-import nest_asyncio
 import pytest
-
-# Apply nest_asyncio to allow nested event loops.
-# Required for VCR 8.0.0's httpcore stubs compatibility with pytest-asyncio.
-nest_asyncio.apply()
 
 
 # Patch VCR 8.0.0's broken _run_async_function.
 # The original uses ensure_future() which returns a Future without awaiting it.
-# This patch uses asyncio.run() with nest_asyncio to properly execute the coroutine.
+# This patch uses asyncio.run() to properly execute the coroutine from sync context.
 def _fixed_run_async_function(sync_func, *args, **kwargs):
     """Fixed version that properly runs async code from sync context."""
     return asyncio.run(sync_func(*args, **kwargs))

--- a/tests/integration/cassettes/TestAsyncConcurrency.test_concurrent_native_async_providers.yaml
+++ b/tests/integration/cassettes/TestAsyncConcurrency.test_concurrent_native_async_providers.yaml
@@ -1,0 +1,216 @@
+interactions:
+- request:
+    body: '{"max_tokens": 64000, "messages": [{"role": "user", "content": "What is
+      3+3? Answer with just the number."}], "model": "claude-haiku-4-5-20251001",
+      "temperature": 0.0}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '157'
+      Content-Type:
+      - application/json
+      Host:
+      - api.anthropic.com
+      User-Agent:
+      - AsyncAnthropic/Python 0.76.0
+      X-Stainless-Arch:
+      - x64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - Linux
+      X-Stainless-Package-Version:
+      - 0.76.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.2
+      anthropic-version:
+      - '2023-06-01'
+      x-stainless-read-timeout:
+      - '599'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-timeout:
+      - '599'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/3WQTUvEMBCG/8ucW2iL3UPvogcVPAQUkRCSoQ2bJt1kIqul/93J4vqJp4T3eWaG
+        mRXmYNDBANqpbLCelN3n+qLu667p+rZpWqjAGhbmNMqmfezGLO5vhLi8uj0Kca3fDne7B3bodcFi
+        YUpqRA5icCVQKdlEyhNHOnhC/g1P69knPBZyegbYwfZcQaKwyIgqBc8ZeiMpRw8fIOEho9dc7LNz
+        FeTTvGEF65dMksIefYKha3ie0hNKza3IBi9/Cp+csfmPnWtLf1wmnDEqJ/v5r/9F2+k33SoImb5H
+        PS+D8cVqlGQx8prlRkZFA9v2DtHXE3yVAQAA
+    headers:
+      CF-RAY:
+      - 9c895bd33c1df547-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 04 Feb 2026 10:07:02 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 2c171920-9bc8-49f3-a3b0-ec271bf76c62
+      anthropic-ratelimit-input-tokens-limit:
+      - '4000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '4000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2026-02-04T10:07:02Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '800000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '800000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2026-02-04T10:07:02Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-02-04T10:07:01Z'
+      anthropic-ratelimit-tokens-limit:
+      - '4800000'
+      anthropic-ratelimit-tokens-remaining:
+      - '4800000'
+      anthropic-ratelimit-tokens-reset:
+      - '2026-02-04T10:07:02Z'
+      cf-cache-status:
+      - DYNAMIC
+      request-id:
+      - req_011CXnqr5UcgufKQMHzYUjMm
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-envoy-upstream-service-time:
+      - '473'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"input": "What is 2+2? Answer with just the number.", "max_output_tokens":
+      16384, "model": "gpt-4o-mini", "temperature": 0.0}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '119'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - AsyncOpenAI/Python 2.16.0
+      X-Stainless-Arch:
+      - x64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - Linux
+      X-Stainless-Package-Version:
+      - 2.16.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dFTRjqMwDHzvV6A8b09AKdv2V1YnZILp5jbEucSptlr1308JhcJe9w08
+        9sSecfK1yTKhOnHKhENvm7wv873EvKrLHUKLeV4fD7sCqn0Le3kojvu26vdlvevqoiqKQ12Jl0hB
+        7R+UPNGQ8TjGpUNg7BqIWPH6mhfHY10WCfMMHHyskTRYjYzdWNSC/Dg7Cib21YP2OIaV1sqcxSn7
+        2mRZlgkLV3SxvsMLarLoxCbLbuPBE+W3o8uEonMUK03QOgV6h38DGnltLBrQfBWnLP+VJ0yZiazp
+        kEFpv6xUxrMLkhWZVXyAz4YC28AN0wcmsKh3h2pGmUg3EvSab6AOdRzqbHlb0XZQRm3LvKy2+eu2
+        ONzlTsTilL0lJUY9ZicHf/7ZyLqquzwaCVjJA7RQI6Isy31iTix8tZh40Hs44wP4ybEESjKM5tHU
+        srEV7aQKfvJcnRLAGGKYlHz7vQI1na2j9gmSiE6ZqMQcvd2/5kThSKfDwXvlGQyPyTExJQkLDrRG
+        vbaFXRiXzzr0aCQ+2Q/r8KIo+GZa/SbZMDtqHQ2WGwnyHZsPvP6IOYwCKjLLDIfgyaz2HvueHC+S
+        ojVhGMBN3PM18NAjXxvVReJe4WrpPbqLktiwmq5RD0GPpgjP5HCpAONg0QGHFJ6Gv4t/76wnN8Dj
+        f2F6yhslv3d8QdeSV0lKMWCnwvC4vqMJ76Tk6FpgEjPw2AHBZJvFZuRz0MbrNvXogpFwF1Z0ykOr
+        p7cmpA2fB1BmdWHL/OX/+OIVmMdMBnaPwnw16vd3oHwWf0Y7m/8TMxODXhCXs4LBr80ekKEDhkh/
+        29z+AQAA//8DADb37J/5BQAA
+    headers:
+      CF-RAY:
+      - 9c895bd34b127a91-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 04 Feb 2026 10:07:02 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=Rglr30312IDxwzP48moasE45iCQdH59sHfopE7y18Oc-1770199622-1.0.1.1-_E1MlvsqF0MRBhwupQrOb.4r_zXG378NlLOnLJTyI1a5xXD_NlFDi8T.zTGATRBFfp66nIGydb5ScziKTxquGVzpnVsSe069L_JzLRcP_9I;
+        path=/; expires=Wed, 04-Feb-26 10:37:02 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=48OFzjf7oAsVlbT9zWJHMFXpf3RYwEoJ9t.J5NHVtIo-1770199622510-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - handley-8bq6ws
+      openai-processing-ms:
+      - '719'
+      openai-project:
+      - proj_kbC53WfwHWl267JuvHfOY149
+      openai-version:
+      - '2020-10-01'
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999960'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_309c330edc3e4eb8a3698c9359d1e192
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/cassettes/TestAsyncConcurrency.test_mixed_async_and_threaded_providers.yaml
+++ b/tests/integration/cassettes/TestAsyncConcurrency.test_mixed_async_and_threaded_providers.yaml
@@ -1,0 +1,163 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "What is 7+7? Answer with just the number."}],
+      "role": "user"}], "generationConfig": {"temperature": 0.0, "maxOutputTokens":
+      65536}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '166'
+      Content-Type:
+      - application/json
+      Host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.60.0 gl-python/3.14.2
+      x-goog-api-client:
+      - google-genai-sdk/1.60.0 gl-python/3.14.2
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/2WQQWvDMAyF7/kVQed2tCUbY7ex7lBoaddmYzB6MLOSmDp2GiuQEfLfZydL6jAf
+        jNF7fpK+JghD+GaKC84IDTyFX7YShk13O00rQkVWGEq2WLCSbt7+NN7bWghr9wmWEXhCO77Ps1tc
+        qSU6b645ysHeDgZIhBImOyIzWjnbKd4fYFSF4ljb8iIYGnTRUBmW4g6J2cXYOD4Upc4LivUF1Yuu
+        usWWUR/mcZjoqz+ZNDE5UR4Ws3+pZm17Cunj8cjZFZkU9OP2iF8/Y/Aw0HSogUPg4QLKdJVmNB0w
+        ct6OV4/wA0sjelYp5pbefHV3P08kM1nXD0o0hVYGN9x5jvV1zZI4e3486Qt/Pwi+317fdhC0wS80
+        Y6zBHwIAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 04 Feb 2026 10:07:03 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=513
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"input": "What is 5+5? Answer with just the number.", "max_output_tokens":
+      16384, "model": "gpt-4o-mini", "temperature": 0.0}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '119'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - AsyncOpenAI/Python 2.16.0
+      X-Stainless-Arch:
+      - x64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - Linux
+      X-Stainless-Package-Version:
+      - 2.16.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dFTbjqMwDH3vV6A8T1eBXij9ldEKucF0shPibOJUU4367ytCoTDbvoGP
+        fWKf4+R7lWVCN+KYCY/B1VI2ZSkBZbnZq6JVUu6rwyaH7R4OW3XIK3nYbcpiJ1WJkON+14q3noJO
+        f1DxSEM24BBXHoGxqaHH8rKUeVXtiyJhgYFj6GsUdc4gYzMUnUB9nj1F2/fVggk4hLUx2p7FMfte
+        ZVmWCQdX9H19gxc05NCLVZbdhoNHyh9HbxKK3lNfaaMxKdB6/BvRqmvt0ILhqzhm8pdMmLYjWd0g
+        gzZhXqltYB8Va7KLeAdfNUV2kWumT0xgvt8cthPKRKZWYJZ8HTVo+qHOjtdbWnfa6nUhi+1aluv8
+        cJc7EYtj9p6UGPSYnOzC+bWRpSxwm4ysmryo9lW5aYqNPKnEnFj46jDxYAhwxgfwyrEEKrKM9tHU
+        vLEF7agKfvFUnRLAWmIYlXz/vQANnZ2n0xMkER0zkUsxhW/3rylTeDLpdAhBBwbLQ3KfmJKEAw/G
+        oFn6wj4O2+c8BrQKnyyI83jRFEM97n6dfJgsdZ46x7UC9YH1J15fYh57BTXZeYZHCGQXi49tS55n
+        Sb03sevAj9zTPQjQIl9r3fTErcbF1gf0F62wZj3eoxaiGVwRgcnjXAHGzqEHjik8Dn9X/95ZS76D
+        x//M9ZQ3SH7v+IL+REEnKUWHjY7d4/4OJnyQVoNrkUlMwGMJBJOrZ6shp6Dr79vYo49WwV1Y0egA
+        JzM+NjGt+DSAtosbW8i3/+OzZ2AaMxnYPArlYtSfD0HxLP6MdjL/FTMTg5kRF5OCMSzN7pChAYae
+        /ra6/QMAAP//AwDxHqMf+gUAAA==
+    headers:
+      CF-RAY:
+      - 9c895bd919318e0d-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 04 Feb 2026 10:07:03 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - handley-8bq6ws
+      openai-processing-ms:
+      - '458'
+      openai-project:
+      - proj_kbC53WfwHWl267JuvHfOY149
+      openai-version:
+      - '2020-10-01'
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999960'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_7a57399ef5494950bd98c597e5d7b387
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/cassettes/test_llm_chat_basic[openai].yaml
+++ b/tests/integration/cassettes/test_llm_chat_basic[openai].yaml
@@ -16,17 +16,17 @@ interactions:
       Host:
       - api.openai.com
       User-Agent:
-      - OpenAI/Python 2.15.0
+      - AsyncOpenAI/Python 2.16.0
       X-Stainless-Arch:
       - x64
       X-Stainless-Async:
-      - 'false'
+      - async:asyncio
       X-Stainless-Lang:
       - python
       X-Stainless-OS:
       - Linux
       X-Stainless-Package-Version:
-      - 2.15.0
+      - 2.16.0
       X-Stainless-Runtime:
       - CPython
       X-Stainless-Runtime-Version:
@@ -40,21 +40,21 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RU0Y6jMAx871egPG9PQCnQ/srqhExiurkNSS5xqkWr/vuJUCjstW/gsSf2jJPv
-        XZIwKdg5YQ69bdKy7jAv0vRYgKizNk3LU1V02BVClLzOTocWD2WVCiyrQ52VcGBvI4Vp/yCnmcZo
-        j1OcOwRC0cCIZVV5yqtjlhcR8wQU/FjDTW8VEoqpqAX+eXEm6LGvDpTHKSyVkvrCzsn3LkmShFkY
-        0I31Aq+ojEXHdklymw6eKX8cfYwoOmfGSh2UioHO4d+Amg+NRQ2KBnZO0l9pxKSeyRqBBFL5daXU
-        nlzgJI3exHv4akwgG6gh84kRzMpDXSwoGaMaDmrL1xuBahzqYmlfmH0vtdznaV7s02qf1Xe5IzE7
-        J+9RiUmPxcneX14beRTZZGTNs6w+HSGtWlFV9aR9ZKHBYuRB7+GCD+CVYxHkRhPqR1Prxja0syr4
-        RUt1TACtDcGs5PvvDajMxTrTPkEi0TlhBVuit/vXksicUfFw8F56Ak1T8pgYk5gFB0qh2tpCLkzL
-        Zx161Byf7Id1eJUm+GZe/SbasDhqnektNRz4BzafOLzEHI4CSqPXGQ7BG73Ze+w642iVNFoT+h7c
-        zL1cAw8d0tBIMRJ3EjdL79FdJceG5HyNOghqMoV5Mg7XChD2Fh1QiOF5+Lv4984643p4/K9Mj3mT
-        5PeOr+ha42WUkvUoZOgf13cy4cNIPrkWyLAFeOwAI2Ob1WakS9CO123u0QXN4S4sE9JDq+a3JsQN
-        XwaQenNh8/Tt//jqFVjGjAaKR2G6GfXnO5A/iz+jXcx/xUyGQK2I80XB4Ldm90gggGCkv+1u/wAA
-        AP//AwBLNK8w+QUAAA==
+        H4sIAAAAAAAAAwAAAP//dFTRjuIwDHznK6o8L6cWChR+ZXWq3MRlc5vGucRBi1b8+6kpLe0evLUe
+        e2LPOPleZZnQSpwy4TG4Ot/DNq+acidLta8azPP9sdoWsCnhcJBVcdwCwA7Vvt3K/FiVh1a89RTU
+        /EHJIw3ZgENcegRGVUOPFYdDXhyPu6pKWGDgGPoaSZ0zyKiGogbk59lTtH1fLZiAQ1gbo+1ZnLLv
+        VZZlmXBwRd/XK7ygIYderLLsNhw8Uv44+phQ9J76ShuNSYHW49+IVl5rhxYMX8Upy3/lCdN2JKsV
+        MmgT5pXaBvZRsia7iHfwVVNkF7lm+sQEFvttVU4oE5laglnydaTQ9EOdHa9LWnfa6vUm35Tr/LAu
+        qrvciVicsvekxKDH5GQXzq+N3FWbJhlZHaHdqUJVDeybYt8k5sTCV4eJB0OAMz6AV44lUJJltI+m
+        5o0taEdV8Iun6pQA1hLDqOT77wVo6Ow8NU+QRHTKRCmm6O3+NSUKTyYdDiHowGB5SO4TU5Jw4MEY
+        NEtb2Mdh+ZzHgFbik/1wHi+aYqjH1a+TDZOjzlPnuJYgP7D+xOtLzGMvoCY7z/AIgexi77FtyfMs
+        qbcmdh34kXu6BgFa5GutVU/calwsfUB/0RJr1uM1aiGawRQRmDzOFWDsHHrgmMLj8Hfx75215Dt4
+        /M9MT3mD5PeOL+gbCjpJKTpUOnaP6zuY8EFaDq5FJjEBjx0QTK6ebUY+BV1/3cYefbQS7sIKpQM0
+        ZnxrYtrwaQBtFxd2k7/9H5+9AtOYyUD1KMwXo/58BzbP4s9oJ/NfMTMxmBnxZlIwhqXZHTIoYOjp
+        b6vbPwAAAP//AwCUoSOs+QUAAA==
     headers:
       CF-RAY:
-      - 9c3131172e631ddf-LHR
+      - 9c895b048f939a57-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -62,14 +62,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 24 Jan 2026 17:18:46 GMT
+      - Wed, 04 Feb 2026 10:06:29 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=W24wPQMpJmyjGV4XOTdNY_xtAirQZY8_f3YrujspyCI-1769275126-1.0.1.1-xLwWyCDenF8Tft98mvm7pxiKSk.qRxTqb4aTLSWWnTKiNvr_VNfefLc1OpEziPFdneXwvn7BJDcWrGFGpwSE2_RiWUG0YpQLQIJ18Oo5ui4;
-        path=/; expires=Sat, 24-Jan-26 17:48:46 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=WvCmr_zzaIJJ5fsKrgdAL.75yM_ED9QrogP6u91sYeU-1770199589-1.0.1.1-IxcocTp.8502neX0PLOWtMAQ6Bsvtap0xQ679_mVmxXk38re1UuTPQB3LMJiwMUMiYoLc16JcS0EgPWNAhzWrnhZvpm2Ww.EBgO_kup5mKM;
+        path=/; expires=Wed, 04-Feb-26 10:36:29 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=Foy7hdJ3a8fVq.DrGJsWxsbHA0tSM9EbD142PD3FKsI-1769275126017-0.0.1.1-604800000;
+      - _cfuvid=f5gbqXJDhTpU68EmVn9gc.pAdnmlZ6FafYSWIvWT1lI-1770199589731-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
@@ -84,13 +84,11 @@ interactions:
       openai-organization:
       - handley-8bq6ws
       openai-processing-ms:
-      - '1092'
+      - '1015'
       openai-project:
       - proj_kbC53WfwHWl267JuvHfOY149
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '1096'
       x-ratelimit-limit-requests:
       - '30000'
       x-ratelimit-limit-tokens:
@@ -104,7 +102,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 0s
       x-request-id:
-      - req_af48d50fc6084302877a9bd8629339f1
+      - req_4eeb61d99c7f4546aa7795e65384af4c
     status:
       code: 200
       message: OK

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -914,3 +914,131 @@ async def test_llm_prompt_file_xor_validation(
     with pytest.raises(ToolError) as exc_info:
         await mcp.call_tool("chat", base_params)
     assert "exactly one of 'prompt' or 'prompt_file'" in str(exc_info.value).lower()
+
+
+class TestAsyncConcurrency:
+    """Test async concurrency behavior - verify event loop isn't blocked."""
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    async def test_concurrent_native_async_providers(
+        self, skip_if_no_api_key, test_output_file, tmp_path
+    ):
+        """Test concurrent requests to native async providers (OpenAI + Claude)."""
+        skip_if_no_api_key("OPENAI_API_KEY")
+        skip_if_no_api_key("ANTHROPIC_API_KEY")
+
+        import asyncio
+
+        output1 = tmp_path / "openai.txt"
+        output2 = tmp_path / "claude.txt"
+
+        # Both providers use native async - should run truly concurrently
+        tasks = [
+            mcp.call_tool(
+                "chat",
+                {
+                    "prompt": "What is 2+2? Answer with just the number.",
+                    "output_file": str(output1),
+                    "model": "gpt-4o-mini",
+                    "branch": "",
+                    "temperature": 0.0,
+                },
+            ),
+            mcp.call_tool(
+                "chat",
+                {
+                    "prompt": "What is 3+3? Answer with just the number.",
+                    "output_file": str(output2),
+                    "model": "claude-haiku-4-5-20251001",
+                    "branch": "",
+                    "temperature": 0.0,
+                },
+            ),
+        ]
+        results = await asyncio.gather(*tasks)
+
+        # Both should succeed
+        for _, response in results:
+            assert "error" not in response, response.get("error")
+            assert response["content"] is not None
+
+        # Verify outputs
+        assert "4" in output1.read_text()
+        assert "6" in output2.read_text()
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    async def test_mixed_async_and_threaded_providers(
+        self, skip_if_no_api_key, test_output_file, tmp_path
+    ):
+        """Test native async (OpenAI) alongside thread-wrapped (Gemini)."""
+        skip_if_no_api_key("OPENAI_API_KEY")
+        skip_if_no_api_key("GEMINI_API_KEY")
+
+        import asyncio
+
+        output1 = tmp_path / "openai.txt"
+        output2 = tmp_path / "gemini.txt"
+
+        # OpenAI is native async, Gemini uses anyio.to_thread wrapping
+        tasks = [
+            mcp.call_tool(
+                "chat",
+                {
+                    "prompt": "What is 5+5? Answer with just the number.",
+                    "output_file": str(output1),
+                    "model": "gpt-4o-mini",
+                    "branch": "",
+                    "temperature": 0.0,
+                },
+            ),
+            mcp.call_tool(
+                "chat",
+                {
+                    "prompt": "What is 7+7? Answer with just the number.",
+                    "output_file": str(output2),
+                    "model": "gemini-2.5-flash",
+                    "branch": "",
+                    "temperature": 0.0,
+                },
+            ),
+        ]
+        results = await asyncio.gather(*tasks)
+
+        # Both should succeed
+        for _, response in results:
+            assert "error" not in response, response.get("error")
+            assert response["content"] is not None
+
+        # Verify outputs
+        assert "10" in output1.read_text()
+        assert "14" in output2.read_text()
+
+    @pytest.mark.asyncio
+    async def test_concurrency_not_blocked(self):
+        """Deterministic test: verify event loop isn't blocked (no external APIs).
+
+        Two "slow" operations using asyncio.to_thread should complete
+        in ~0.2s, not ~0.4s (sequential would take ~0.4s).
+        """
+        import asyncio
+        import time
+
+        async def slow_operation():
+            """Simulate a slow blocking operation wrapped for async."""
+            await asyncio.to_thread(time.sleep, 0.2)
+            return "done"
+
+        start = time.monotonic()
+        results = await asyncio.gather(slow_operation(), slow_operation())
+        elapsed = time.monotonic() - start
+
+        # Both should complete
+        assert results == ["done", "done"]
+
+        # Should complete in parallel (~0.2s) not sequentially (~0.4s)
+        # Use 0.35s threshold to allow some overhead
+        assert elapsed < 0.35, (
+            f"Expected ~0.2s for parallel execution, got {elapsed:.2f}s"
+        )

--- a/tests/unit/test_llm_shared_unit.py
+++ b/tests/unit/test_llm_shared_unit.py
@@ -11,9 +11,10 @@ from mcp_handley_lab.llm.shared import process_llm_request
 class TestProcessLLMRequestPromptResolution:
     """Test prompt resolution logic in process_llm_request."""
 
+    @pytest.mark.asyncio
     @patch("mcp_handley_lab.llm.shared.memory")
     @patch("mcp_handley_lab.common.pricing.calculate_cost", return_value=0.001)
-    def test_resolves_prompt_file_and_vars(
+    async def test_resolves_prompt_file_and_vars(
         self, mock_calculate_cost, mock_memory, tmp_path
     ):
         """Test that prompt_file and prompt_vars are resolved correctly."""
@@ -21,8 +22,8 @@ class TestProcessLLMRequestPromptResolution:
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("Solve ${problem} and answer with ${format}")
 
-        # Mock generation function
-        def mock_generation_func(prompt, system_instruction, **kwargs):
+        # Mock async generation function
+        async def mock_generation_func(prompt, system_instruction, **kwargs):
             return {
                 "text": f"Received: {prompt}",
                 "input_tokens": 10,
@@ -36,7 +37,7 @@ class TestProcessLLMRequestPromptResolution:
         mock_context.client_id = "test_client"
         mock_mcp.get_context.return_value = mock_context
 
-        result = process_llm_request(
+        result = await process_llm_request(
             prompt="",
             output_file="",
             branch="",
@@ -55,9 +56,10 @@ class TestProcessLLMRequestPromptResolution:
         assert result.usage.input_tokens == 10
         assert result.usage.output_tokens == 5
 
+    @pytest.mark.asyncio
     @patch("mcp_handley_lab.llm.shared.memory")
     @patch("mcp_handley_lab.common.pricing.calculate_cost", return_value=0.001)
-    def test_resolves_system_prompt_file_and_vars(
+    async def test_resolves_system_prompt_file_and_vars(
         self, mock_calculate_cost, mock_memory, tmp_path
     ):
         """Test that system_prompt_file and system_prompt_vars are resolved correctly."""
@@ -65,8 +67,8 @@ class TestProcessLLMRequestPromptResolution:
         system_prompt_file = tmp_path / "system.txt"
         system_prompt_file.write_text("You are a ${role} assistant. Be ${style}.")
 
-        # Mock generation function
-        def mock_generation_func(prompt, system_instruction, **kwargs):
+        # Mock async generation function
+        async def mock_generation_func(prompt, system_instruction, **kwargs):
             return {
                 "text": "Response",
                 "input_tokens": 10,
@@ -81,7 +83,7 @@ class TestProcessLLMRequestPromptResolution:
         mock_context.client_id = "test_client"
         mock_mcp.get_context.return_value = mock_context
 
-        result = process_llm_request(
+        result = await process_llm_request(
             prompt="Test prompt",
             output_file="",
             branch="",
@@ -100,15 +102,19 @@ class TestProcessLLMRequestPromptResolution:
         # since it's passed internally to the generation function
         assert result.content == "Response"
 
-    def test_xor_validation_prompt_raises_both(self):
+    @pytest.mark.asyncio
+    async def test_xor_validation_prompt_raises_both(self):
         """Test that ValueError is raised when both prompt and prompt_file are provided."""
-        mock_generation_func = Mock()
+
+        async def mock_generation_func(prompt, system_instruction, **kwargs):
+            return {}
+
         mock_mcp = Mock()
 
         with pytest.raises(
             ValueError, match="Provide exactly one of 'prompt' or 'prompt_file'"
         ):
-            process_llm_request(
+            await process_llm_request(
                 prompt="Direct prompt",
                 output_file="",
                 branch="",
@@ -123,15 +129,19 @@ class TestProcessLLMRequestPromptResolution:
                 system_prompt_vars={},
             )
 
-    def test_xor_validation_prompt_raises_neither(self):
+    @pytest.mark.asyncio
+    async def test_xor_validation_prompt_raises_neither(self):
         """Test that ValueError is raised when neither prompt nor prompt_file is provided."""
-        mock_generation_func = Mock()
+
+        async def mock_generation_func(prompt, system_instruction, **kwargs):
+            return {}
+
         mock_mcp = Mock()
 
         with pytest.raises(
             ValueError, match="Provide exactly one of 'prompt' or 'prompt_file'"
         ):
-            process_llm_request(
+            await process_llm_request(
                 prompt="",
                 output_file="",
                 branch="",
@@ -146,15 +156,19 @@ class TestProcessLLMRequestPromptResolution:
                 system_prompt_vars={},
             )
 
-    def test_xor_validation_system_prompt_raises_both(self):
+    @pytest.mark.asyncio
+    async def test_xor_validation_system_prompt_raises_both(self):
         """Test that ValueError is raised when both system_prompt and system_prompt_file are provided."""
-        mock_generation_func = Mock()
+
+        async def mock_generation_func(prompt, system_instruction, **kwargs):
+            return {}
+
         mock_mcp = Mock()
 
         with pytest.raises(
             ValueError, match="Provide exactly one of 'prompt' or 'prompt_file'"
         ):
-            process_llm_request(
+            await process_llm_request(
                 prompt="Test prompt",
                 output_file="",
                 branch="",
@@ -169,16 +183,19 @@ class TestProcessLLMRequestPromptResolution:
                 system_prompt_vars={},
             )
 
-    def test_missing_prompt_var_raises_keyerror(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_missing_prompt_var_raises_keyerror(self, tmp_path):
         """Test that KeyError is raised when prompt template variable is missing."""
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("Hello ${missing_var}")
 
-        mock_generation_func = Mock()
+        async def mock_generation_func(prompt, system_instruction, **kwargs):
+            return {}
+
         mock_mcp = Mock()
 
         with pytest.raises(KeyError):
-            process_llm_request(
+            await process_llm_request(
                 prompt="",
                 output_file="",
                 branch="",
@@ -193,16 +210,19 @@ class TestProcessLLMRequestPromptResolution:
                 system_prompt_vars={},
             )
 
-    def test_missing_system_prompt_var_raises_keyerror(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_missing_system_prompt_var_raises_keyerror(self, tmp_path):
         """Test that KeyError is raised when system prompt template variable is missing."""
         system_prompt_file = tmp_path / "system.txt"
         system_prompt_file.write_text("You are ${missing_var}")
 
-        mock_generation_func = Mock()
+        async def mock_generation_func(prompt, system_instruction, **kwargs):
+            return {}
+
         mock_mcp = Mock()
 
         with pytest.raises(KeyError):
-            process_llm_request(
+            await process_llm_request(
                 prompt="Test prompt",
                 output_file="",
                 branch="",
@@ -217,9 +237,10 @@ class TestProcessLLMRequestPromptResolution:
                 system_prompt_vars={"wrong_key": "value"},
             )
 
+    @pytest.mark.asyncio
     @patch("mcp_handley_lab.llm.shared.memory")
     @patch("mcp_handley_lab.common.pricing.calculate_cost", return_value=0.001)
-    def test_system_prompt_passed_to_llm_for_new_branch(
+    async def test_system_prompt_passed_to_llm_for_new_branch(
         self, mock_calculate_cost, mock_memory, tmp_path
     ):
         """Test that system prompt is passed to LLM for new branches."""
@@ -240,8 +261,8 @@ class TestProcessLLMRequestPromptResolution:
 
         received_system_instruction = None
 
-        # Mock generation function that captures system_instruction
-        def mock_generation_func(prompt, system_instruction, **kwargs):
+        # Mock async generation function that captures system_instruction
+        async def mock_generation_func(prompt, system_instruction, **kwargs):
             nonlocal received_system_instruction
             received_system_instruction = system_instruction
             return {
@@ -257,7 +278,7 @@ class TestProcessLLMRequestPromptResolution:
         mock_context.client_id = "test_client"
         mock_mcp.get_context.return_value = mock_context
 
-        process_llm_request(
+        await process_llm_request(
             prompt="Test prompt",
             output_file="",
             branch="test_branch",


### PR DESCRIPTION
## Summary

- Convert all LLM provider adapters and MCP tools from synchronous to asynchronous
- Prevents event loop blocking during API calls (3-60s latency)
- Enables concurrent operations within tools

## Changes

**Provider adapters:**
- OpenAI/Claude: Use AsyncOpenAI and AsyncAnthropic native async clients
- Gemini/Mistral/Grok: Wrap sync calls with `asyncio.to_thread()`
- Groq: Use async OpenAI client (OpenAI-compatible API)

**Core:**
- `shared.py`: Make `process_llm_request()` async
- `tool.py`: Convert all `@mcp.tool` functions to `async def`
- `embeddings/tool.py`: Convert `index_documents` and `search_documents` to async

**Tests:**
- Remove nest_asyncio from conftest (caused httpx/anyio compatibility issues)
- Add concurrency tests verifying event loop isn't blocked
- Convert unit tests to async

## Test plan

- [x] All 38 integration tests pass
- [x] All 8 unit tests in test_llm_shared_unit.py pass
- [x] New concurrency tests verify parallel execution works
- [x] VCR cassettes updated for async client behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)