### PR TITLE
feat(loop): add cwd and prompt params to spawn chain

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.25b10
+pkgver=0.25.25b11
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.25b10"
+version = "0.25.25b11"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Wire `cwd` and `prompt` through the full spawn chain: protocol → daemon → backends → tool → client
- `ClaudeBackend` uses both: `cwd` sets working directory, `prompt` passes `--system-prompt` to Claude CLI
- Fix `args.split()` → `shlex.split(args)` for correct quoting of CLI flags with spaces

## Test plan
- [ ] Verify daemon starts and accepts spawn requests with new params
- [ ] Test ClaudeBackend spawn with `cwd` and `prompt` set
- [ ] Test that existing spawns (without cwd/prompt) still work (backward compatible)
- [ ] Test shlex.split handles quoted args like `--permission-mode acceptEdits`

🤖 Generated with [Claude Code](https://claude.com/claude-code)