### PR TITLE
feat(loop): tag loop-generated messages with mcp_meta HTML comment

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.25.40
+pkgver=0.25.41
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.25.40"
+version = "0.25.41"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/loop/backends.py
+++ b/src/mcp_handley_lab/loop/backends.py
@@ -553,8 +553,10 @@ class ClaudeBackend:
         if proc.poll() is not None:
             raise RuntimeError(f"Claude process has exited (code {proc.returncode})")
 
-        # Send user message
-        msg = {"type": "user", "message": {"role": "user", "content": code}}
+        # Tag message as loop-generated (persists in JSONL for search filtering)
+        meta = json.dumps({"source": "mcp_loop", "loop_id": pane_id})
+        tagged = f"{code}\n\n<!-- mcp_meta: {meta} -->"
+        msg = {"type": "user", "message": {"role": "user", "content": tagged}}
         proc.stdin.write(json.dumps(msg) + "\n")
         proc.stdin.flush()
 


### PR DESCRIPTION
## Summary
- Appends `<!-- mcp_meta: {"source": "mcp_loop", "loop_id": "..."} -->` to messages sent via `ClaudeBackend.eval`
- Enables distinguishing human-authored from loop-generated messages in JSONL conversation logs
- Verified experimentally: tag survives Claude Code's stream-json input and persists in JSONL

## Context
With loop, Claude Code sessions can act as "users" to other sessions. The `type: "user"` / `userType: "external"` fields in JSONL don't distinguish human from machine. This HTML comment tag provides that signal for transcript search/filtering.

## Test plan
- [x] Spawn a child Claude session via loop, send a message
- [x] Inspect child's JSONL — `mcp_meta` tag present in user message content
- [x] Child responds normally (tag is invisible to Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)