### PR TITLE
feat(loop): add orphan detection and prune action

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.27.0
+pkgver=0.27.1
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.27.0"
+version = "0.27.1"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/loop/daemon.py
+++ b/src/mcp_handley_lab/loop/daemon.py
@@ -11,6 +11,7 @@ import os
 import re
 import signal
 import socket
+import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -142,6 +143,32 @@ class LoopDaemon:
             result.extend(self._get_descendants(child.loop_id, _visited))
         return result
 
+    def _is_session_alive(self, session_id: str) -> bool:
+        """Check if a Claude Code session is still running via its task lock file."""
+        lock_path = Path.home() / ".claude" / "tasks" / session_id / ".lock"
+        if not lock_path.exists():
+            return False
+        try:
+            result = subprocess.run(["lsof", str(lock_path)], capture_output=True)
+        except FileNotFoundError:
+            return True  # lsof not available — assume alive (conservative)
+        return result.returncode == 0
+
+    def _is_orphaned(
+        self, loop: LoopState, session_cache: dict[str, bool] | None = None
+    ) -> bool:
+        """Check if a loop's parent is dead."""
+        pid = loop.parent_id
+        if not pid:
+            return False  # intentionally parentless
+        if pid in self.loops:
+            return False  # parent is a living loop
+        if session_cache is not None:
+            if pid not in session_cache:
+                session_cache[pid] = self._is_session_alive(pid)
+            return not session_cache[pid]
+        return not self._is_session_alive(pid)
+
     async def handle_request(self, request: Request) -> Response:
         """Handle a single request."""
         self.last_activity = time.time()
@@ -166,6 +193,8 @@ class LoopDaemon:
             return await self._terminate(request)
         elif action == "kill":
             return await self._kill(request)
+        elif action == "prune":
+            return await self._prune(request)
         else:
             return Response.error_response(f"unknown action: {action}")
 
@@ -338,6 +367,7 @@ class LoopDaemon:
             # Show all loops
             loops_to_show = list(self.loops.values())
 
+        session_cache: dict[str, bool] = {}
         for loop in loops_to_show:
             visible.append(
                 {
@@ -345,6 +375,7 @@ class LoopDaemon:
                     "backend": loop.backend,
                     "parent_id": loop.parent_id,
                     "label": loop.label,
+                    "orphaned": self._is_orphaned(loop, session_cache),
                 }
             )
         # Echo caller's session_id back for context (daemon is stateless re: sessions)
@@ -408,6 +439,19 @@ class LoopDaemon:
         del self.loops[request.loop_id]
         self.save_state()
         return Response(ok=True)
+
+    async def _prune(self, request: Request) -> Response:
+        """Kill a loop, but only if it's orphaned."""
+        loop = self._get_loop(request.loop_id)
+        if not loop:
+            return Response.error_response(
+                f"loop not found: {request.loop_id}", ERROR_NOT_FOUND
+            )
+        if not self._is_orphaned(loop):
+            return Response.error_response(
+                f"loop {request.loop_id} is not orphaned", ERROR_INVALID_REQUEST
+            )
+        return await self._kill(request)
 
     def _get_backend(self, name: str) -> Any:
         """Get or create backend instance."""

--- a/src/mcp_handley_lab/loop/protocol.py
+++ b/src/mcp_handley_lab/loop/protocol.py
@@ -18,7 +18,7 @@ ERROR_CANCELLED = "cancelled"
 class Request:
     """Request to the loop daemon."""
 
-    action: str  # spawn, run, read, read_raw, list, status, terminate, kill
+    action: str  # spawn, run, read, read_raw, list, status, terminate, kill, prune
     loop_id: str = ""  # for operations on existing loops
     parent_id: str = ""  # for spawn: session_id or parent loop_id
     label: str = ""  # for spawn: optional human-readable tag for tmux window

--- a/src/mcp_handley_lab/loop/tool.py
+++ b/src/mcp_handley_lab/loop/tool.py
@@ -28,6 +28,7 @@ class LoopInfo(BaseModel):
     backend: str
     parent_id: str
     label: str
+    orphaned: bool = False
 
 
 class Cell(BaseModel):
@@ -142,7 +143,7 @@ mcp = FastMCP("Loop Tool")
 @mcp.tool()
 def manage(params: ManageArgs) -> ManageResult:
     """
-    Manage loops: spawn, list, read, read_raw, status, terminate, kill.
+    Manage loops: spawn, list, read, read_raw, status, terminate, kill, prune.
 
     Loops are persistent REPL sessions (Python, Bash, Julia, etc.) that run in tmux.
     Uses Unix process model: each loop has loop_id (like PID) and parent_id (like PPID).
@@ -150,12 +151,13 @@ def manage(params: ManageArgs) -> ManageResult:
 
     Actions:
     - spawn: Create new loop. Params: backend (required), parent_id (optional), label (optional)
-    - list: List loops. Params: parent_id (direct children), descendants_of (subtree)
+    - list: List loops. Params: parent_id (direct children), descendants_of (subtree). Each loop includes orphaned flag.
     - read: Get cells from loop. Params: loop_id
     - read_raw: Get raw terminal capture. Params: loop_id
     - status: Check if run is in progress. Params: loop_id
     - terminate: Send Ctrl-C to interrupt. Params: loop_id
     - kill: Force-kill loop. Params: loop_id
+    - prune: Kill a loop only if orphaned (safe kill). Params: loop_id
 
     Available backends: bash, zsh, python, ipython, julia, R, clojure, apl, maple, ollama, mathematica, claude, gemini, openai
 


### PR DESCRIPTION
## Summary

- Detect orphaned loops by checking if the parent Claude Code session still holds its task lock file (`~/.claude/tasks/<session-id>/.lock` via `lsof`)
- `list` action now includes an `orphaned` flag on each loop
- New `prune` action: safe kill that refuses unless the target loop is orphaned
- Session liveness cached per list/prune call to avoid repeated `lsof` subprocess spawns

## Orphan classification

- **Session UUID parent**: check if lock file is held → orphaned if not
- **Loop parent**: check if parent exists in daemon state → not orphaned
- **Empty parent_id**: intentionally parentless → never orphaned
- **Missing `lsof`**: conservatively assume alive (avoid false pruning)

## Test plan

- [ ] `list` → current session's loops show `orphaned: false`
- [ ] `list` → old dead session loops show `orphaned: true`
- [ ] Messenger loops (empty parent_id) → `orphaned: false`
- [ ] `prune` on orphaned loop → kills it
- [ ] `prune` on non-orphaned loop → returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)