### PR TITLE
fix(sandbox): preserve locked mount flags on ro remount

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.26.0
+pkgver=0.26.1
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.26.0"
+version = "0.26.1"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/loop/sandbox.py
+++ b/src/mcp_handley_lab/loop/sandbox.py
@@ -158,7 +158,8 @@ def main():
             os.makedirs(target, exist_ok=True)
         _mount(host, target, None, MS_BIND | MS_REC)
         if mode == "ro":
-            _mount(host, target, None, MS_REMOUNT | MS_BIND | MS_REC | MS_RDONLY)
+            current = os.statvfs(target).f_flag
+            _mount(host, target, None, MS_REMOUNT | MS_BIND | MS_REC | current | MS_RDONLY)
 
     # 6. Essential mounts under new_root
     for d in ("proc", "dev", "tmp"):

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -252,6 +252,21 @@ class TestSandboxIntegration:
         # Verify it appeared on the host
         assert Path(self.host_dir, "new.txt").read_text().strip() == "test"
 
+    def test_user_defined_ro_mount(self):
+        """User-defined ro mounts from tmpfs paths must work (issue #259)."""
+        extra = tempfile.mkdtemp(prefix="sandbox-extra-")
+        with open(os.path.join(extra, "data.txt"), "w") as f:
+            f.write("readonly content")
+        cmd, _ = sandbox_cmd(
+            ["bash", "-c", "cat /extra/data.txt && touch /extra/nope 2>&1"],
+            "/workspace",
+            {"/workspace": [self.host_dir, "rw"], "/extra": [extra, "ro"]},
+            "claude",
+        )
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        assert "readonly content" in proc.stdout
+        assert "Read-only" in proc.stdout or "Read-only" in proc.stderr
+
     def test_etc_shadow_not_accessible(self):
         proc = self._run_sandboxed("cat /etc/shadow 2>&1")
         assert proc.returncode != 0


### PR DESCRIPTION
## Summary
- User-defined ro mounts from tmpfs paths failed with EPERM because the remount omitted locked flags (`nosuid`/`nodev`) inherited from the source filesystem
- Use `os.statvfs()` to read current mount flags before remounting readonly

Fixes #259

## Test plan
- [x] Added regression test `test_user_defined_ro_mount` 
- [x] All 25 sandbox tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)