### PR TITLE
feat(messenger): transcribe voice notes with Groq Whisper (#258)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.28.3
+pkgver=0.28.4
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.28.3"
+version = "0.28.4"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/providers/groq/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/groq/adapter.py
@@ -6,6 +6,7 @@ These adapters are used by the unified mcp-chat tool.
 
 import os
 import threading
+from pathlib import Path
 from typing import Any
 
 from openai import BadRequestError, OpenAI
@@ -124,6 +125,29 @@ def generation_adapter(
         "timing": timing,
         "groq_metadata": groq_metadata,
     }
+
+
+def audio_transcription_adapter(
+    audio_path: str,
+    language: str = "",
+    include_timestamps: bool = False,
+) -> dict[str, Any]:
+    """Groq Whisper audio transcription (whisper-large-v3-turbo)."""
+    file_path = Path(audio_path).expanduser()
+    with open(file_path, "rb") as f:
+        params = {"model": "whisper-large-v3-turbo", "file": f}
+        if language:
+            params["language"] = language
+        if include_timestamps:
+            params["response_format"] = "verbose_json"
+            params["timestamp_granularities"] = ["segment"]
+        response = get_client().audio.transcriptions.create(**params)
+    result = {"text": response.text}
+    if include_timestamps and hasattr(response, "segments"):
+        result["segments"] = [
+            {"start": s.start, "end": s.end, "text": s.text} for s in response.segments
+        ]
+    return result
 
 
 def list_api_models() -> set[str]:

--- a/src/mcp_handley_lab/llm/providers/openai/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/openai/adapter.py
@@ -6,6 +6,7 @@ These adapters are used by the unified mcp-chat tool.
 
 import base64
 import threading
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -375,6 +376,29 @@ def list_api_models() -> set[str]:
     """List model IDs available from the OpenAI API."""
     api_models = get_client().models.list()
     return {m.id for m in api_models.data}
+
+
+def audio_transcription_adapter(
+    audio_path: str,
+    language: str = "",
+    include_timestamps: bool = False,
+) -> dict[str, Any]:
+    """OpenAI Whisper audio transcription."""
+    file_path = Path(audio_path).expanduser()
+    with open(file_path, "rb") as f:
+        params = {"model": "whisper-1", "file": f}
+        if language:
+            params["language"] = language
+        if include_timestamps:
+            params["response_format"] = "verbose_json"
+            params["timestamp_granularities"] = ["segment"]
+        response = get_client().audio.transcriptions.create(**params)
+    result = {"text": response.text}
+    if include_timestamps and hasattr(response, "segments"):
+        result["segments"] = [
+            {"start": s.start, "end": s.end, "text": s.text} for s in response.segments
+        ]
+    return result
 
 
 def embeddings_adapter(texts: list[str], model: str) -> list[list[float]]:

--- a/src/mcp_handley_lab/llm/registry.py
+++ b/src/mcp_handley_lab/llm/registry.py
@@ -427,6 +427,7 @@ def get_adapter(provider: str, adapter_type: str):
             "image_analysis": adapter.image_analysis_adapter,
             "image_generation": adapter.image_generation_adapter,
             "embeddings": adapter.embeddings_adapter,
+            "audio_transcription": adapter.audio_transcription_adapter,
         }
     elif provider == "claude":
         from mcp_handley_lab.llm.providers.claude import adapter
@@ -458,7 +459,10 @@ def get_adapter(provider: str, adapter_type: str):
     elif provider == "groq":
         from mcp_handley_lab.llm.providers.groq import adapter
 
-        adapters = {"generation": adapter.generation_adapter}
+        adapters = {
+            "generation": adapter.generation_adapter,
+            "audio_transcription": adapter.audio_transcription_adapter,
+        }
     else:
         raise ValueError(f"Unknown provider: {provider}")
 

--- a/src/mcp_handley_lab/llm/tool.py
+++ b/src/mcp_handley_lab/llm/tool.py
@@ -354,14 +354,14 @@ def generate_image(
 
 
 @mcp.tool(
-    description="Transcribe audio to text using Mistral Voxtral. "
+    description="Transcribe audio to text using Groq Whisper. "
     "Supports MP3, WAV, FLAC, OGG, M4A. Use model://list resource to discover audio models. "
     "Returns: {text, segments?: [{start, end, text}]}. Segments included if include_timestamps=true."
 )
 def transcribe(
     audio_path: str = Field(
         ...,
-        description="Path to audio file or URL.",
+        description="Path to audio file.",
     ),
     output_file: str = Field(
         default="",
@@ -376,8 +376,8 @@ def transcribe(
         description="Include segment-level timestamps in output.",
     ),
 ) -> dict[str, Any]:
-    """Transcribe audio using Mistral Voxtral model."""
-    adapter = get_adapter("mistral", "audio_transcription")
+    """Transcribe audio using Groq Whisper."""
+    adapter = get_adapter("groq", "audio_transcription")
     result = adapter(
         audio_path=audio_path,
         language=language,

--- a/src/mcp_handley_lab/messenger/server.py
+++ b/src/mcp_handley_lab/messenger/server.py
@@ -722,9 +722,17 @@ class ChatActor:
                     path = _download_tg_media(
                         event.media_id, media_dir, event.media_type
                     )
-                media_ref = (
-                    f"[User sent {event.media_type}: {path.relative_to(self.cwd)}]"
-                )
+                if event.media_type == "audio":
+                    from mcp_handley_lab.llm.registry import get_adapter
+
+                    transcribe = get_adapter("groq", "audio_transcription")
+                    result = transcribe(str(path))
+                    self._last_transcription = result["text"]
+                    media_ref = f"[Voice message transcription: {result['text']}]"
+                else:
+                    media_ref = (
+                        f"[User sent {event.media_type}: {path.relative_to(self.cwd)}]"
+                    )
                 text = f"{media_ref}\n{text}" if text else media_ref
             except Exception as e:
                 print(f"Media download failed: {e}", flush=True)
@@ -752,6 +760,10 @@ class ChatActor:
         for attempt in (1, 2):
             try:
                 output = await asyncio.to_thread(self._query, text)
+                transcription = getattr(self, "_last_transcription", None)
+                if transcription:
+                    output = f"> {transcription.strip()}\n\n{output}"
+                    self._last_transcription = None
                 self._send_response(output, reply_to=event.message_id)
                 return
             except RuntimeError as e:


### PR DESCRIPTION
## Summary
- Add OpenAI Whisper and Groq Whisper `audio_transcription_adapter` to both providers, wired into LLM registry
- Transcribe audio messages in messenger `_prepare_text()` via Groq Whisper (sub-second latency)
- Prefix replies with block-quoted transcription so user sees what was heard
- Switch MCP `transcribe` tool to Groq Whisper

## Test plan
- [x] `ruff check` passes on all modified files
- [x] Unit tests pass (`pytest tests/ -k "not slow and not integration"`)
- [x] Send a WhatsApp voice note — Claude receives transcribed text
- [x] Transcription appears as block quote in reply
- [x] Send an image — non-audio media still shows file path reference

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)