### PR TITLE
feat(loop): dynamic bind-mounts for sandboxed loops

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.27.1
+pkgver=0.28.0
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.27.1"
+version = "0.28.0"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/loop/client.py
+++ b/src/mcp_handley_lab/loop/client.py
@@ -285,6 +285,21 @@ def kill(loop_id: str) -> bool:
     return response.get("ok", False)
 
 
+def mount(loop_id: str, source: str, target: str) -> None:
+    """Bind-mount source to target inside a sandboxed loop's namespace.
+
+    Both source and target are guest paths (inside the namespace).
+    """
+    _send_request(
+        {
+            "action": "mount",
+            "loop_id": loop_id,
+            "source": source,
+            "target": target,
+        }
+    )
+
+
 def my_loop_id() -> str:
     """Get the loop_id of the current loop (from env)."""
     return _get_parent_id()

--- a/src/mcp_handley_lab/loop/daemon.py
+++ b/src/mcp_handley_lab/loop/daemon.py
@@ -53,6 +53,7 @@ class LoopState:
     parent_id: str  # session_id or loop_id of spawner
     label: str  # human-readable tag for tmux window naming
     pane_id: str = ""  # for tmux backend
+    sandbox_pid: int = 0  # PID of sandboxed process (for nsenter)
     cancelled: bool = False
     eval_running: bool = False
     eval_started_at: float = 0.0
@@ -65,6 +66,7 @@ class LoopState:
             "parent_id": self.parent_id,
             "label": self.label,
             "pane_id": self.pane_id,
+            "sandbox_pid": self.sandbox_pid,
         }
 
     @classmethod
@@ -90,6 +92,7 @@ class LoopState:
             parent_id=d.get("parent_id", ""),
             label=d.get("label", d.get("backend", "")),
             pane_id=d.get("pane_id", ""),
+            sandbox_pid=d.get("sandbox_pid", 0),
         )
 
 
@@ -195,6 +198,8 @@ class LoopDaemon:
             return await self._kill(request)
         elif action == "prune":
             return await self._prune(request)
+        elif action == "mount":
+            return await self._mount(request)
         else:
             return Response.error_response(f"unknown action: {action}")
 
@@ -226,12 +231,22 @@ class LoopDaemon:
         except Exception as e:
             return Response.error_response(str(e), ERROR_BACKEND_ERROR)
 
+        # Get sandbox PID if available (for dynamic mounts via nsenter)
+        sandbox_pid = 0
+        if request.sandbox:
+            try:
+                proc = backend._state[pane_id]["proc"]
+                sandbox_pid = proc.pid
+            except (KeyError, AttributeError):
+                pass
+
         state = LoopState(
             loop_id=loop_id,
             backend=request.backend,
             parent_id=request.parent_id,
             label=label,
             pane_id=pane_id,
+            sandbox_pid=sandbox_pid,
         )
         self.loops[loop_id] = state
         self.save_state()
@@ -452,6 +467,29 @@ class LoopDaemon:
                 f"loop {request.loop_id} is not orphaned", ERROR_INVALID_REQUEST
             )
         return await self._kill(request)
+
+    async def _mount(self, request: Request) -> Response:
+        """Bind-mount a path inside a sandboxed loop's namespace."""
+        loop = self._get_loop(request.loop_id)
+        if not loop:
+            return Response.error_response(
+                f"loop not found: {request.loop_id}", ERROR_NOT_FOUND
+            )
+        if not loop.sandbox_pid:
+            return Response.error_response(
+                "loop has no sandbox (not spawned with sandbox)", ERROR_INVALID_REQUEST
+            )
+
+        from mcp_handley_lab.loop.sandbox import sandbox_mount
+
+        try:
+            await asyncio.to_thread(
+                sandbox_mount, loop.sandbox_pid, request.source, request.target
+            )
+        except Exception as e:
+            return Response.error_response(str(e), ERROR_BACKEND_ERROR)
+
+        return Response(ok=True)
 
     def _get_backend(self, name: str) -> Any:
         """Get or create backend instance."""

--- a/src/mcp_handley_lab/loop/protocol.py
+++ b/src/mcp_handley_lab/loop/protocol.py
@@ -18,7 +18,9 @@ ERROR_CANCELLED = "cancelled"
 class Request:
     """Request to the loop daemon."""
 
-    action: str  # spawn, run, read, read_raw, list, status, terminate, kill, prune
+    action: (
+        str  # spawn, run, read, read_raw, list, status, terminate, kill, prune, mount
+    )
     loop_id: str = ""  # for operations on existing loops
     parent_id: str = ""  # for spawn: session_id or parent loop_id
     label: str = ""  # for spawn: optional human-readable tag for tmux window
@@ -40,6 +42,8 @@ class Request:
     sandbox: dict[str, list[str]] = field(
         default_factory=dict
     )  # for spawn: {guest_path: [host_path, mode]}
+    source: str = ""  # for mount: guest source path
+    target: str = ""  # for mount: guest target path
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -59,6 +63,8 @@ class Request:
             "current_session_id": self.current_session_id,
             "venv": self.venv,
             "sandbox": self.sandbox,
+            "source": self.source,
+            "target": self.target,
         }
 
     @classmethod
@@ -80,6 +86,8 @@ class Request:
             current_session_id=d.get("current_session_id", ""),
             venv=d.get("venv", ""),
             sandbox=d.get("sandbox", {}),
+            source=d.get("source", ""),
+            target=d.get("target", ""),
         )
 
 

--- a/src/mcp_handley_lab/loop/sandbox.py
+++ b/src/mcp_handley_lab/loop/sandbox.py
@@ -264,3 +264,16 @@ def sandbox_cmd(
 
     launcher_path = STATE_DIR / "sandbox_launcher.py"
     return [sys.executable, str(launcher_path), config_path], None
+
+
+def sandbox_mount(pid: int, source: str, target: str) -> None:
+    """Bind-mount source to target inside a sandboxed process's mount namespace.
+
+    Both source and target are guest paths (inside the namespace).
+    Uses nsenter to enter the process's user + mount namespaces.
+    """
+    import subprocess
+
+    nsenter = ["nsenter", "-U", "-m", "-t", str(pid), "--"]
+    subprocess.run([*nsenter, "mkdir", "-p", target], check=True)
+    subprocess.run([*nsenter, "mount", "--bind", source, target], check=True)


### PR DESCRIPTION
## Summary

- Add `mount` protocol action to bind-mount guest paths inside a running sandboxed loop's namespace via `nsenter -U -m`
- Store `sandbox_pid` in `LoopState` for sandboxed backends (captured from `proc.pid` at spawn time)
- New `sandbox_mount(pid, source, target)` in sandbox.py — runs `nsenter` to `mkdir -p` + `mount --bind`
- New `mount(loop_id, source, target)` client function

Uses a "bridge mount" pattern: pre-mount a host directory at spawn time, then later bind subdirs to new guest paths at runtime.

## Test plan

- [ ] Verify existing tests still pass (`python -m pytest tests/unit/ -v`)
- [ ] Manual test: spawn sandboxed loop with bridge mount, call `mount()`, verify file visibility inside namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)