### PR TITLE
fix(llm): improve files parameter description

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.28.7
+pkgver=0.28.8
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.28.7"
+version = "0.28.8"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/tool.py
+++ b/src/mcp_handley_lab/llm/tool.py
@@ -102,9 +102,9 @@ def chat(
     ),
     files: list[str] = Field(
         default_factory=list,
-        description="Files to include as context. Accepts: local paths, URLs, "
-        "or data URIs (data:mime/type;base64,...). Text content inlined, "
-        "binary files base64-encoded.",
+        description="Files to include as extra context (recommended for large content like code summaries). "
+        "Accepts local paths. Text is inlined, binary is base64-encoded. "
+        "Per-call only — not retained in branch history; re-pass on follow-up calls if needed.",
     ),
     images: list[str] = Field(
         default_factory=list,


### PR DESCRIPTION
## Summary
- Update `files` Field description on `chat` tool to document that it's the preferred way to pass large context (#262)
- Remove false claims about URL/data URI support (only local paths work)
- Document that file content is per-call only, not retained in branch history (#264)

Closes #262
Closes #264

## Test plan
- [x] Unit tests pass (163 passed)
- [x] Description-only change, no logic affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)