### PR TITLE
feat(otter): incremental transcript reading via since_offset_ms

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.28.6
+pkgver=0.28.7
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.28.6"
+version = "0.28.7"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/otter/shared.py
+++ b/src/mcp_handley_lab/otter/shared.py
@@ -231,7 +231,9 @@ def find_live_meetings() -> list[MeetingSummary]:
     return results
 
 
-def get_transcript(otid: str, max_segments: int = 0) -> TranscriptResult:
+def get_transcript(
+    otid: str, max_segments: int = 0, since_offset_ms: int = 0
+) -> TranscriptResult:
     """Get full transcript for a meeting."""
     data = _api_get("speech", {"otid": otid})
     speech = data.get("speech", data)
@@ -239,11 +241,18 @@ def get_transcript(otid: str, max_segments: int = 0) -> TranscriptResult:
     speakers = _get_speakers(otid)
     transcripts = speech.get("transcripts", [])
 
+    # Sort with stable tiebreaker for consistent filtering and truncation
+    indexed = list(enumerate(transcripts))
+    indexed.sort(key=lambda x: (x[1].get("start_offset", 0), x[0]))
+    transcripts = [t for _, t in indexed]
+
+    if since_offset_ms > 0:
+        transcripts = [
+            t for t in transcripts if t.get("start_offset", 0) > since_offset_ms
+        ]
+
     if max_segments > 0:
-        # Sort with stable tiebreaker (matching _format_transcript), keep last N
-        indexed = list(enumerate(transcripts))
-        indexed.sort(key=lambda x: (x[1].get("start_offset", 0), x[0]))
-        transcripts = [t for _, t in indexed[-max_segments:]]
+        transcripts = transcripts[-max_segments:]
 
     formatted_text, segments = _format_transcript(transcripts, speakers)
 

--- a/src/mcp_handley_lab/otter/tool.py
+++ b/src/mcp_handley_lab/otter/tool.py
@@ -22,7 +22,7 @@ Actions:
 - live: List currently live meetings (title, otid, status).
   No required params.
 - transcript: Get full transcript for a meeting (live or recent).
-  Required: otid. Optional: max_segments (0=all, default 0).
+  Required: otid. Optional: max_segments (0=all, default 0), since_offset_ms (0=all, for incremental reads).
 - recent: List recent meetings.
   Optional: limit (default 10).
 - search: Filter recent meetings by title (client-side).
@@ -45,6 +45,10 @@ def otter(
         default=0,
         description="Return last N segments (most recent), 0=all (for 'transcript').",
     ),
+    since_offset_ms: int = Field(
+        default=0,
+        description="Only return segments after this offset in ms. Track max start_offset_ms from previous call for incremental reading (for 'transcript').",
+    ),
 ) -> OtterResult:
     """Dispatch to the appropriate Otter.ai operation."""
     from mcp_handley_lab.otter.shared import (
@@ -60,7 +64,9 @@ def otter(
     elif action == "transcript":
         if not otid:
             raise ValueError("'otid' is required for transcript action")
-        return OtterResult(transcript=get_transcript(otid, max_segments))
+        return OtterResult(
+            transcript=get_transcript(otid, max_segments, since_offset_ms)
+        )
     elif action == "recent":
         return OtterResult(meetings=list_recent_meetings(limit))
     elif action == "search":

--- a/tests/integration/test_otter_integration.py
+++ b/tests/integration/test_otter_integration.py
@@ -142,6 +142,35 @@ class TestOtterIntegration:
         segments = response["transcript"]["segments"]
         assert len(segments) <= 3
 
+    @otter_vcr.use_cassette("test_transcript.yaml", allow_playback_repeats=True)
+    @pytest.mark.asyncio
+    async def test_transcript_since_offset(self, mock_session):
+        """Get a transcript with since_offset_ms filtering."""
+        # First get all segments to know the total
+        _, full_response = await mcp.call_tool(
+            "otter",
+            {"action": "transcript", "otid": "AOJlmcqnR1OC6ZhzTYmO2J0c5ak"},
+        )
+        all_segments = full_response["transcript"]["segments"]
+        assert len(all_segments) > 0
+
+        # Pick a mid-point offset and fetch only newer segments
+        mid_offset = all_segments[len(all_segments) // 2]["start_offset_ms"]
+
+        _, filtered_response = await mcp.call_tool(
+            "otter",
+            {
+                "action": "transcript",
+                "otid": "AOJlmcqnR1OC6ZhzTYmO2J0c5ak",
+                "since_offset_ms": mid_offset,
+            },
+        )
+        filtered_segments = filtered_response["transcript"]["segments"]
+        assert len(filtered_segments) < len(all_segments)
+        # All returned segments must have offset > mid_offset
+        for seg in filtered_segments:
+            assert seg["start_offset_ms"] > mid_offset
+
 
 @pytest.mark.integration
 class TestOtterValidation:

--- a/tests/unit/test_otter_formatting.py
+++ b/tests/unit/test_otter_formatting.py
@@ -1,10 +1,13 @@
 """Unit tests for Otter.ai transcript formatting and parsing logic."""
 
+from unittest.mock import patch
+
 from mcp_handley_lab.otter.shared import (
     MeetingSummary,
     OtterResult,
     _format_transcript,
     _parse_meeting,
+    get_transcript,
 )
 
 
@@ -144,3 +147,87 @@ class TestOtterResultSerialization:
         data = result.model_dump()
         assert "meetings" in data
         assert data["meetings"] == []
+
+
+# Mock data for get_transcript tests
+_MOCK_SPEECH = {
+    "speech": {
+        "title": "Test Meeting",
+        "live_status": "ended",
+        "created_at": 1700000000,
+        "transcripts": [
+            {"transcript": "First", "start_offset": 1000, "speaker_id": 1},
+            {"transcript": "Second", "start_offset": 5000, "speaker_id": 1},
+            {"transcript": "Third", "start_offset": 10000, "speaker_id": 2},
+            {"transcript": "Fourth", "start_offset": 20000, "speaker_id": 2},
+            {"transcript": "Fifth", "start_offset": 30000, "speaker_id": 1},
+        ],
+    }
+}
+_MOCK_SPEAKERS = {
+    "speakers": [{"id": 1, "speaker_name": "Alice"}, {"id": 2, "speaker_name": "Bob"}]
+}
+
+
+def _patch_api(speech=_MOCK_SPEECH, speakers=_MOCK_SPEAKERS):
+    """Patch _api_get to return mock data for get_transcript tests."""
+
+    def fake_api_get(path, params=None):
+        if path == "speech":
+            return speech
+        if path == "speakers":
+            return speakers
+        raise ValueError(f"Unexpected path: {path}")
+
+    return patch("mcp_handley_lab.otter.shared._api_get", side_effect=fake_api_get)
+
+
+class TestGetTranscriptSinceOffset:
+    """Test since_offset_ms filtering in get_transcript."""
+
+    def test_default_returns_all(self):
+        with _patch_api():
+            result = get_transcript("test-otid")
+        assert len(result.segments) == 5
+
+    def test_since_offset_filters(self):
+        with _patch_api():
+            result = get_transcript("test-otid", since_offset_ms=5000)
+        # Should exclude segments at offset <= 5000 (1000 and 5000)
+        assert len(result.segments) == 3
+        assert result.segments[0].text == "Third"
+        assert result.segments[0].start_offset_ms == 10000
+
+    def test_since_offset_zero_returns_all(self):
+        with _patch_api():
+            result = get_transcript("test-otid", since_offset_ms=0)
+        assert len(result.segments) == 5
+
+    def test_since_offset_beyond_all_returns_empty(self):
+        with _patch_api():
+            result = get_transcript("test-otid", since_offset_ms=99999)
+        assert len(result.segments) == 0
+        assert result.formatted_text == ""
+
+    def test_negative_offset_returns_all(self):
+        with _patch_api():
+            result = get_transcript("test-otid", since_offset_ms=-100)
+        assert len(result.segments) == 5
+
+    def test_since_offset_with_max_segments(self):
+        """Filter first, then truncate."""
+        with _patch_api():
+            result = get_transcript("test-otid", max_segments=2, since_offset_ms=5000)
+        # After filtering: Third(10000), Fourth(20000), Fifth(30000)
+        # After max_segments=2: Fourth(20000), Fifth(30000)
+        assert len(result.segments) == 2
+        assert result.segments[0].text == "Fourth"
+        assert result.segments[1].text == "Fifth"
+
+    def test_since_offset_exact_boundary(self):
+        """Passing exact offset of a segment excludes it (strictly >)."""
+        with _patch_api():
+            result = get_transcript("test-otid", since_offset_ms=10000)
+        # Excludes segments at 1000, 5000, 10000; keeps 20000 and 30000
+        assert len(result.segments) == 2
+        assert result.segments[0].text == "Fourth"


### PR DESCRIPTION
## Summary
- Add `since_offset_ms` parameter to the transcript action, allowing clients to fetch only new segments since their last read
- Client tracks `max(start_offset_ms)` from previous response and passes it back — segments with offset > that value are returned
- Uses strictly-greater-than (`>`) filtering so the last-seen segment is excluded without deduplication
- Composes with `max_segments`: sort → filter by offset → truncate to last N

## Test plan
- [x] 7 unit tests covering: default returns all, filtering works, zero/negative return all, beyond-all returns empty, interaction with max_segments, exact boundary exclusion
- [x] 1 integration test reusing VCR cassette with `allow_playback_repeats`
- [x] All 30 otter tests pass
- [x] Lint clean (`ruff check` + `ruff format`)

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)