### PR TITLE
fix(llm): document deep-research alias, add output_file to conversation response

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.28.9
+pkgver=0.28.10
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.28.9"
+version = "0.28.10"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/shared.py
+++ b/src/mcp_handley_lab/llm/shared.py
@@ -473,6 +473,7 @@ def conversation(
     index: int = -1,
     limit: int = 20,
     force: bool = False,
+    output_file: str = "",
 ) -> dict[str, Any]:
     """Manage conversation branches. Identical interface to MCP conversation() tool.
 
@@ -483,6 +484,7 @@ def conversation(
         index: For response action: assistant message index (-1=last, 0=first)
         limit: For log action: maximum entries to return
         force: For done action: force removal even if lock not held
+        output_file: For response action: save content to file (omits content from result)
 
     Returns:
         Dict with action-specific results
@@ -512,7 +514,14 @@ def conversation(
     elif action == "response":
         if not branch:
             raise ValueError("branch required for 'response' action")
-        return memory.get_response(project_dir, branch, index)
+        result = memory.get_response(project_dir, branch, index)
+        if output_file and "content" in result:
+            output_path = Path(output_file).expanduser()
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(result["content"], encoding="utf-8")
+            result["output_file"] = str(output_path)
+            del result["content"]
+        return result
 
     elif action == "edit":
         return memory.start_edit(project_dir)

--- a/src/mcp_handley_lab/llm/tool.py
+++ b/src/mcp_handley_lab/llm/tool.py
@@ -94,7 +94,8 @@ def chat(
         default="gemini",
         description="Model or provider name. Provider is inferred automatically. "
         "Use provider names (gemini, openai, claude) for latest defaults, "
-        "or specific model IDs. Use model://list resource or list_models() to see available options.",
+        "or specific model IDs. Aliases: 'deep-research' (autonomous web research). "
+        "Use model://list resource or list_models() to see available options.",
     ),
     temperature: float = Field(
         default=1.0,
@@ -204,6 +205,10 @@ def conversation(
         default=False,
         description="For done action: force removal even if lock not held by this process.",
     ),
+    output_file: str = Field(
+        default="",
+        description="For response action: save content to this file path instead of returning inline.",
+    ),
 ) -> dict[str, Any]:
     """Git interface for conversation management."""
     resolved_branch = _resolve_session_branch(branch) if branch else branch
@@ -214,6 +219,7 @@ def conversation(
         index=index,
         limit=limit,
         force=force,
+        output_file=output_file,
     )
 
 


### PR DESCRIPTION
## Summary
- Add `deep-research` example to `model` parameter description so callers discover it without browsing model://list (#272)
- Add `output_file` parameter to `conversation(action='response')` so past responses can be written to disk without entering the caller's context (#263)

Closes #272
Closes #263

## Test plan
- [x] Unit tests pass (179 passed)
- [ ] `conversation(action='response', branch='...', output_file='/tmp/test.md')` writes content to file

🤖 Generated with [Claude Code](https://claude.com/claude-code)