### PR TITLE
fix(email): normalize folder: query quoting and auto-attach on forward (#248, #247)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.29.1
+pkgver=0.29.2
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.29.1"
+version = "0.29.2"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/email/mutt/shared.py
+++ b/src/mcp_handley_lab/email/mutt/shared.py
@@ -3,6 +3,8 @@
 Identical interface to MCP tools, usable without MCP server.
 """
 
+import re
+import tempfile
 from email.parser import HeaderParser
 from pathlib import Path
 
@@ -278,14 +280,37 @@ def send(
             else f"{forward_intro}\n{header_block}\n\n{forwarded_content}\n\n{forward_trailer}"
         )
 
-        return _compose_email(
-            to=to,
-            cc=cc,
-            bcc=bcc,
-            subject=forward_subject,
-            body=complete_forward_body,
-            attachments=attachments,
-        )
+        # Extract original attachments to temp dir for forwarding
+        with tempfile.TemporaryDirectory(prefix="mcp-fwd-") as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            original_attachments = []
+            for part in raw_msg.walk():
+                if part.get_content_disposition() != "attachment":
+                    continue
+                if part_filename := part.get_filename():
+                    clean_filename = re.sub(
+                        r'[\\/*?:"<>|]', "_", Path(part_filename).name
+                    )
+                    file_path = tmpdir_path / clean_filename
+                    counter = 1
+                    stem, suffix = file_path.stem, file_path.suffix
+                    while file_path.exists():
+                        file_path = tmpdir_path / f"{stem}_{counter}{suffix}"
+                        counter += 1
+                    if payload := part.get_payload(decode=True):
+                        file_path.write_bytes(payload)
+                        original_attachments.append(str(file_path))
+
+            all_attachments = original_attachments + (attachments or [])
+
+            return _compose_email(
+                to=to,
+                cc=cc,
+                bcc=bcc,
+                subject=forward_subject,
+                body=complete_forward_body,
+                attachments=all_attachments or None,
+            )
 
     else:
         raise ValueError(f"Unknown mode: {mode}. Use 'compose', 'reply', or 'forward'.")

--- a/src/mcp_handley_lab/email/notmuch/shared.py
+++ b/src/mcp_handley_lab/email/notmuch/shared.py
@@ -3,6 +3,8 @@
 Identical interface to MCP tools, usable without MCP server.
 """
 
+import re
+
 from mcp_handley_lab.email.common import _list_accounts
 from mcp_handley_lab.email.notmuch.tool import (
     Contact,
@@ -20,6 +22,24 @@ from mcp_handley_lab.email.notmuch.tool import (
     _show_email,
     _tag_email,
 )
+
+
+def _normalize_folder_query(query: str) -> str:
+    """Normalize partially-quoted folder: terms in notmuch queries.
+
+    Rewrites e.g. folder:Hermes/"Sent Items.2024" to folder:"Hermes/Sent Items.2024".
+    Already fully-quoted values are left unchanged.
+    """
+    pattern = re.compile(r'folder:("(?:[^"\\]|\\.)*"|[^\s\)\]\}]+)')
+
+    def _rewrite(match: re.Match) -> str:
+        value = match.group(1)
+        if value.startswith('"') and value.endswith('"'):
+            return match.group(0)
+        clean = value.replace('"', "")
+        return f'folder:"{clean}"'
+
+    return pattern.sub(_rewrite, query)
 
 
 def read(
@@ -80,6 +100,10 @@ def read(
     # Resolve abbreviated message IDs in query (supports id: and mid: terms)
     if "id:" in query or "mid:" in query:
         query = _resolve_id_in_query(query)
+
+    # Normalize folder: quoting (e.g. folder:Hermes/"Sent Items" → folder:"Hermes/Sent Items")
+    if "folder:" in query:
+        query = _normalize_folder_query(query)
 
     # Headers mode: lightweight search (no body parsing)
     if mode == "headers":


### PR DESCRIPTION
## Summary
- **#248**: Partially-quoted `folder:` terms (e.g. `folder:Hermes/"Sent Items"`) are now normalized to fully-quoted form before passing to notmuch
- **#247**: Forwarding an email now automatically extracts and includes original attachments from the raw MIME message, filtered to `Content-Disposition: attachment` only

Closes #248
Closes #247

## Test plan
- [x] Unit tests pass (52/52 email tests)
- [ ] Manual: search with `folder:Hermes/"Sent Items.2024"` returns results
- [ ] Manual: forward an email with attachments, verify they arrive at destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)