### PR TITLE
fix(messenger): instruct Claude to Read media files instead of hallucinating (#267)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.29.4
+pkgver=0.29.5
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.29.4"
+version = "0.29.5"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/messenger/server.py
+++ b/src/mcp_handley_lab/messenger/server.py
@@ -50,6 +50,9 @@ TELEGRAM_ALLOWED_CHAT_IDS: set[int] | None = (
 CLAUDE_PERMISSION_MODE = os.environ.get("CLAUDE_PERMISSION_MODE", "acceptEdits")
 _APPEND_SYSTEM_PROMPT = (
     "Keep responses concise for mobile. "
+    "When a user sends an image, sticker, video, or document, "
+    "ALWAYS use the Read tool to view the file before responding. "
+    "Never guess or assume the contents of media files. "
     "To send a file to the user, output send:<filename> on its own line "
     "(e.g. send:media/chart.png). Files must be under the current working directory."
 )
@@ -743,8 +746,10 @@ class ChatActor:
                     self._last_transcription = result["text"]
                     media_ref = f"[Voice message transcription: {result['text']}]"
                 else:
+                    rel = path.relative_to(self.cwd)
                     media_ref = (
-                        f"[User sent {event.media_type}: {path.relative_to(self.cwd)}]"
+                        f"[User sent {event.media_type}: {rel} — "
+                        f"use the Read tool on {rel} to view it]"
                     )
                 text = f"{media_ref}\n{text}" if text else media_ref
             except Exception as e:


### PR DESCRIPTION
## Summary
- Add media-reading instruction to `_APPEND_SYSTEM_PROMPT` so Claude always uses the Read tool on images, stickers, videos, and documents before responding
- Change inline media reference text to explicitly tell Claude to use Read on the specific file path
- Fixes #267: Claude was hallucinating image content because it only saw a text reference, never the actual file

## Test plan
- [ ] `python -c "from mcp_handley_lab.messenger.server import _APPEND_SYSTEM_PROMPT; print(_APPEND_SYSTEM_PROMPT)"` — verify prompt text
- [ ] Send an image via WhatsApp, verify Claude uses Read tool before responding
- [ ] Send a document via Telegram, verify Claude uses Read tool before responding
- [ ] Verify voice messages still use Whisper transcription (not Read tool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)