### PR TITLE
feat(messenger): add commands /reset, /cancel, /model, /status, /help (#276)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.29.9
+pkgver=0.29.10
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.29.9"
+version = "0.29.10"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/loop/client.py
+++ b/src/mcp_handley_lab/loop/client.py
@@ -280,6 +280,17 @@ def read(loop_id: str) -> list[dict[str, Any]]:
     return response.get("cells", [])
 
 
+def read_raw(loop_id: str) -> list[dict[str, Any]]:
+    """Read cells with raw events from a loop.
+
+    Returns:
+        List of cell dicts with index, input, output, events
+    """
+    request = {"action": "read_raw", "loop_id": loop_id}
+    response = _send_request(request)
+    return json.loads(response.get("raw_output", "[]"))
+
+
 def terminate(loop_id: str) -> bool:
     """Send Ctrl-C to interrupt a running eval.
 

--- a/src/mcp_handley_lab/messenger/server.py
+++ b/src/mcp_handley_lab/messenger/server.py
@@ -28,8 +28,10 @@ from urllib.parse import parse_qs, urlparse
 from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
 from uuid import uuid4
 
-from mcp_handley_lab.loop.client import kill, run, spawn
+from mcp_handley_lab.loop.client import kill, run, spawn, terminate
+from mcp_handley_lab.loop.client import read_raw as read_cells_raw
 from mcp_handley_lab.loop.client import session_id as get_session_id
+from mcp_handley_lab.loop.client import status as loop_status
 
 # ---------------------------------------------------------------------------
 # Environment (set via systemd EnvironmentFile or shell exports)
@@ -142,6 +144,67 @@ def _extract_send_files(text: str, cwd: Path) -> tuple[list[Path], str]:
 
 
 _MESSAGE_LOG_MAX = 200
+
+
+def _extract_usage(cells: list[dict]) -> dict | None:
+    """Extract usage info from the last cell's result event.
+
+    modelUsage is keyed by model name, e.g.:
+      {"claude-opus-4-6": {"inputTokens": ..., "contextWindow": ..., "costUSD": ...}}
+    We sum across models and take max contextWindow.
+    """
+    if not cells:
+        return None
+    last_cell = cells[-1]
+    for event in reversed(last_cell.get("events", [])):
+        if event.get("type") == "result":
+            model_usage = event.get("modelUsage") or {}
+            if not model_usage:
+                continue
+            input_tokens = output_tokens = context_window = 0
+            for model_data in model_usage.values():
+                if isinstance(model_data, dict):
+                    input_tokens += model_data.get("inputTokens", 0)
+                    output_tokens += model_data.get("outputTokens", 0)
+                    context_window = max(
+                        context_window, model_data.get("contextWindow", 0)
+                    )
+            return {
+                "context_window": context_window,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }
+    return None
+
+
+def _context_footer(usage: dict) -> str:
+    """Format a context usage footer line from usage dict."""
+    ctx = usage["context_window"]
+    if not ctx:
+        return ""
+    used = usage["input_tokens"] + usage["output_tokens"]
+    pct = used / ctx * 100
+    return f"{pct:.0f}% context"
+
+
+COMMANDS = frozenset({"/reset", "/cancel", "/model", "/help", "/status"})
+
+
+def _parse_command(text: str) -> tuple[str, str] | None:
+    """Parse a command from text. Returns (cmd, args) or None if not a command."""
+    stripped = text.strip()
+    if not stripped.startswith("/"):
+        return None
+    parts = stripped.split(None, 1)
+    cmd_token = parts[0]
+    args = parts[1] if len(parts) > 1 else ""
+    # Strip @botname suffix from command token only (Telegram)
+    if "@" in cmd_token:
+        cmd_token = cmd_token.split("@", 1)[0]
+    cmd = cmd_token.lower()
+    if cmd not in COMMANDS:
+        return None
+    return cmd, args
 
 
 # ---------------------------------------------------------------------------
@@ -664,10 +727,13 @@ class ChatActor:
     def __init__(self, conversation_id: str, platform: Platform):
         self.conversation_id = conversation_id
         self.platform = platform
-        self.queue: asyncio.Queue[IncomingEvent] = asyncio.Queue(maxsize=50)
+        self.queue: asyncio.Queue[IncomingEvent | None] = asyncio.Queue(maxsize=50)
         self.cwd = _cwd_for_conversation(conversation_id)
         self.loop_id: str | None = None
         self.session_id: str = ""
+        self._model: str = ""
+        self._stopped = False
+        self._last_transcription: str | None = None
         self._state_file = self.cwd / "loop_state.json"
         self._msg_log_file = self.cwd / "message_log.json"
         self._message_log: dict[str, dict] = {}
@@ -677,11 +743,24 @@ class ChatActor:
         self.cwd.mkdir(parents=True, exist_ok=True)
         self._load_state()
         self._load_message_log()
+        if self._stopped:
+            return
         self._task = asyncio.create_task(self._run())
 
+    async def stop(self):
+        """Stop the actor gracefully."""
+        self._stopped = True
+        with contextlib.suppress(asyncio.QueueFull):
+            self.queue.put_nowait(None)  # Sentinel to unblock queue.get()
+        if self._task:
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+
     async def _run(self):
-        while True:
+        while not self._stopped:
             event = await self.queue.get()
+            if event is None:
+                break  # Sentinel from stop()
             try:
                 await self._handle(event)
             except Exception as e:
@@ -774,14 +853,29 @@ class ChatActor:
         # Send typing indicator
         self.platform.send_typing(self.conversation_id)
 
+        # Dispatch commands
+        if event.kind == "command":
+            parsed = _parse_command(event.text)
+            if parsed:
+                cmd, args = parsed
+                if cmd == "/reset":
+                    await self._handle_reset()
+                    return
+                await self._handle_command(cmd, args)
+                return
+
         text = await asyncio.to_thread(self._prepare_text, event)
         for attempt in (1, 2):
             try:
                 output = await asyncio.to_thread(self._query, text)
-                transcription = getattr(self, "_last_transcription", None)
+                transcription = self._last_transcription
                 if transcription:
                     output = f"> {transcription.strip()}\n\n{output}"
                     self._last_transcription = None
+                # Append context usage footer
+                footer = await self._get_context_footer()
+                if footer:
+                    output = f"{output}\n\n_{footer}_"
                 self._send_response(output, reply_to=event.message_id)
                 return
             except RuntimeError as e:
@@ -790,15 +884,108 @@ class ChatActor:
                     continue
                 raise
 
+    async def _handle_command(self, cmd: str, args: str) -> None:
+        if cmd == "/help":
+            self._send_help()
+        elif cmd == "/cancel":
+            self._send_text("Cancelled.")
+        elif cmd == "/model":
+            await self._handle_model(args)
+        elif cmd == "/status":
+            await self._handle_status()
+
+    async def _kill_loop(self):
+        """Kill the active loop. Suppresses errors to avoid wedging the actor."""
+        if not self.loop_id:
+            return
+        try:
+            await asyncio.to_thread(kill, self.loop_id)
+        except Exception as e:
+            print(f"kill({self.loop_id}) failed: {e}", flush=True)
+
+    async def _handle_reset(self):
+        """Handle /reset. New conversation, preserve model preference."""
+        await self._kill_loop()
+        self.loop_id = None
+        self.session_id = ""
+        self._save_state()
+        self._send_text("Session reset. Send a new message to start fresh.")
+
+    def _send_help(self):
+        self._send_text(
+            "Commands:\n"
+            "/cancel - Cancel current operation\n"
+            "/reset - New conversation\n"
+            "/model [name] - Show or set model\n"
+            "/status - Show session status\n"
+            "/help - Show this help"
+        )
+
+    async def _handle_model(self, model_name: str):
+        if not model_name:
+            self._send_text(f"Current model: {self._model or 'default'}")
+            return
+        self._model = model_name
+        self._save_state()
+        if self.loop_id:
+            if not self.session_id:
+                sid = get_session_id(self.loop_id)
+                if sid:
+                    self.session_id = sid
+            await self._kill_loop()
+            self.loop_id = None
+            self._save_state()
+            self._send_text(f"Model set to {model_name}. Session restarted.")
+        else:
+            self._send_text(f"Model set to {model_name}.")
+
+    async def _handle_status(self):
+        if not self.loop_id:
+            self._send_text("No active session.")
+            return
+        try:
+            st = await asyncio.to_thread(loop_status, self.loop_id)
+            running = "running" if st.get("running") else "idle"
+            elapsed = f" ({st['elapsed_seconds']:.0f}s)" if st.get("running") else ""
+            lines = [f"Session: {self.loop_id}", f"Status: {running}{elapsed}"]
+            if self.session_id:
+                lines.append(f"Session ID: {self.session_id}")
+            if self._model:
+                lines.append(f"Model: {self._model}")
+            self._send_text("\n".join(lines))
+        except RuntimeError as e:
+            if "not_found" in str(e) or "not found" in str(e):
+                self.loop_id = None
+                self._save_state()
+                self._send_text("Session expired. Send a new message to start fresh.")
+            else:
+                self._send_text(f"Status error: {e}")
+
+    async def _get_context_footer(self) -> str:
+        """Get context usage footer from last cell's events."""
+        if not self.loop_id:
+            return ""
+        try:
+            cells = await asyncio.to_thread(read_cells_raw, self.loop_id)
+            usage = _extract_usage(cells)
+            if usage:
+                return _context_footer(usage)
+        except Exception:
+            pass
+        return ""
+
     def _query(self, text: str) -> str:
         """Ensure loop exists and run text. Called via to_thread."""
         if not self.loop_id:
+            args = f"--permission-mode {CLAUDE_PERMISSION_MODE}"
+            if self._model:
+                args += f" --model {self._model}"
             self.loop_id = spawn(
                 "claude",
                 label=f"msg-{self.conversation_id[:20]}",
                 cwd=str(self.cwd),
                 prompt=_APPEND_SYSTEM_PROMPT,
-                args=f"--permission-mode {CLAUDE_PERMISSION_MODE}",
+                args=args,
                 session_id=self.session_id,
             )
             self._save_state()
@@ -811,24 +998,19 @@ class ChatActor:
                 self._save_state()
         return output
 
-    def reset(self):
-        if self.loop_id:
-            with contextlib.suppress(RuntimeError):
-                kill(self.loop_id)
-        self.loop_id = None
-        self.session_id = ""
-        self._state_file.unlink(missing_ok=True)
-
     def _load_state(self):
         with contextlib.suppress(FileNotFoundError, json.JSONDecodeError):
             data = json.loads(self._state_file.read_text())
             self.loop_id = data.get("loop_id")
             self.session_id = data.get("session_id", "")
+            self._model = data.get("model", "")
 
     def _save_state(self):
-        self._state_file.write_text(
-            json.dumps({"loop_id": self.loop_id, "session_id": self.session_id})
-        )
+        data = {"loop_id": self.loop_id, "session_id": self.session_id}
+        if self._model:
+            data["model"] = self._model
+        self._state_file.parent.mkdir(parents=True, exist_ok=True)
+        self._state_file.write_text(json.dumps(data))
 
     def _clear_state(self):
         self.loop_id = None
@@ -840,6 +1022,7 @@ class ChatActor:
             self._message_log = json.loads(self._msg_log_file.read_text())
 
     def _save_message_log(self):
+        self._msg_log_file.parent.mkdir(parents=True, exist_ok=True)
         tmp = self._msg_log_file.with_suffix(".tmp")
         tmp.write_text(json.dumps(self._message_log))
         tmp.rename(self._msg_log_file)
@@ -854,28 +1037,25 @@ _actors: dict[str, ChatActor] = {}
 
 
 def _get_or_create_actor(conversation_id: str, platform: Platform) -> ChatActor:
-    if conversation_id not in _actors:
+    actor = _actors.get(conversation_id)
+    if actor and actor._stopped:
+        del _actors[conversation_id]
+        actor = None
+    if actor is None:
         actor = ChatActor(conversation_id, platform)
         _actors[conversation_id] = actor
         _loop.create_task(actor.start())
-    return _actors[conversation_id]
+    return actor
 
 
 async def _dispatch(event: IncomingEvent):
-    if event.kind == "command":
-        cmd = event.text.strip().lower().split("@")[0]
-        if cmd in ("/reset", "/new"):
-            actor = _actors.get(event.conversation_id)
-            if actor:
-                actor.reset()
-                del _actors[event.conversation_id]
-            event.platform.send_text(
-                event.conversation_id,
-                "Session reset. Send a new message to start fresh.",
-            )
-            return
-
     actor = _get_or_create_actor(event.conversation_id, event.platform)
+    # /reset and /cancel must interrupt a stuck _query() — terminate the loop
+    # before enqueueing so the blocked _run() unblocks.
+    if event.kind == "command":
+        parsed = _parse_command(event.text)
+        if parsed and parsed[0] in ("/reset", "/cancel") and actor.loop_id:
+            await asyncio.to_thread(terminate, actor.loop_id)
     try:
         actor.queue.put_nowait(event)
     except asyncio.QueueFull:
@@ -911,8 +1091,7 @@ _wa_platform: WhatsAppPlatform | None = None
 def _classify_wa_event(wa_msg: WAMessage) -> IncomingEvent:
     conversation_id = f"whatsapp:{wa_msg.sender}"
     text = wa_msg.text or wa_msg.caption or ""
-    cmd = text.strip().lower().split("@")[0]
-    kind = "command" if cmd in ("/reset", "/new") else "text"
+    kind = "command" if _parse_command(text) is not None else "text"
     return IncomingEvent(
         conversation_id,
         kind=kind,
@@ -1104,8 +1283,7 @@ def _handle_tg_message(msg: dict):
     if not text and not media_id:
         return
 
-    cmd = text.strip().lower().split("@")[0]
-    kind = "command" if cmd in ("/reset", "/new") else "text"
+    kind = "command" if _parse_command(text) is not None else "text"
 
     event = IncomingEvent(
         conversation_id,

--- a/tests/messenger/test_commands.py
+++ b/tests/messenger/test_commands.py
@@ -1,0 +1,548 @@
+"""Tests for messenger command parsing and handling."""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from mcp_handley_lab.messenger.server import (
+    ChatActor,
+    IncomingEvent,
+    _context_footer,
+    _dispatch,
+    _extract_usage,
+    _get_or_create_actor,
+    _parse_command,
+)
+
+# ---------------------------------------------------------------------------
+# _parse_command tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseCommand:
+    def test_basic_reset(self):
+        assert _parse_command("/reset") == ("/reset", "")
+
+    def test_with_args(self):
+        assert _parse_command("/model opus") == ("/model", "opus")
+
+    def test_args_with_at(self):
+        assert _parse_command("/model foo@bar") == ("/model", "foo@bar")
+
+    def test_telegram_botname(self):
+        assert _parse_command("/reset@MyBot") == ("/reset", "")
+
+    def test_telegram_botname_with_args(self):
+        assert _parse_command("/model@MyBot opus") == ("/model", "opus")
+
+    def test_unknown_command(self):
+        assert _parse_command("/random") is None
+
+    def test_not_slash(self):
+        assert _parse_command("hello") is None
+
+    def test_path_not_command(self):
+        assert _parse_command("/home/user/file") is None
+
+    def test_all_commands(self):
+        for cmd in (
+            "/reset",
+            "/cancel",
+            "/model",
+            "/help",
+            "/status",
+        ):
+            assert _parse_command(cmd) is not None
+
+    def test_whitespace_padding(self):
+        assert _parse_command("  /reset  ") == ("/reset", "")
+
+    def test_case_insensitive(self):
+        assert _parse_command("/RESET") == ("/reset", "")
+
+    def test_empty_string(self):
+        assert _parse_command("") is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class MockPlatform:
+    """Mock platform that records send_text calls."""
+
+    def __init__(self):
+        self.sent: list[tuple[str, str]] = []
+
+    def send_text(self, conversation_id, text, reply_to=None):
+        self.sent.append((conversation_id, text))
+        return "msg-id"
+
+    def send_media(self, conversation_id, path, caption="", reply_to=None):
+        return None
+
+    def send_typing(self, conversation_id):
+        pass
+
+
+def _make_event(text: str, platform=None, conversation_id="test:123") -> IncomingEvent:
+    plat = platform or MockPlatform()
+    parsed = _parse_command(text)
+    kind = "command" if parsed is not None else "text"
+    return IncomingEvent(
+        conversation_id=conversation_id,
+        kind=kind,
+        text=text,
+        platform=plat,
+        message_id="ev-1",
+    )
+
+
+def _make_actor(platform=None, conversation_id="test:123", tmp_path=None):
+    plat = platform or MockPlatform()
+    actor = ChatActor(conversation_id, plat)
+    if tmp_path:
+        actor.cwd = tmp_path
+        actor._state_file = tmp_path / "loop_state.json"
+        actor._msg_log_file = tmp_path / "message_log.json"
+    return actor
+
+
+# ---------------------------------------------------------------------------
+# ChatActor command tests
+# ---------------------------------------------------------------------------
+
+
+class TestHelpCommand:
+    @pytest.mark.asyncio
+    async def test_help_sends_text(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        event = _make_event("/help", platform)
+        await actor._handle(event)
+        assert len(platform.sent) == 1
+        text = platform.sent[0][1]
+        assert "/reset" in text
+        assert "/help" in text
+
+
+class TestResetCommand:
+    @pytest.mark.asyncio
+    async def test_reset_clears_session_preserves_model(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        actor.loop_id = "claude-123"
+        actor.session_id = "sess-abc"
+        actor._model = "opus"
+        actor._state_file.parent.mkdir(parents=True, exist_ok=True)
+        actor._save_state()
+
+        event = _make_event("/reset", platform)
+        with patch("mcp_handley_lab.messenger.server.kill") as mock_kill:
+            await actor._handle(event)
+            mock_kill.assert_called_once_with("claude-123")
+
+        assert actor.loop_id is None
+        assert actor.session_id == ""
+        assert actor._model == "opus"  # preserved
+        assert not actor._stopped  # actor stays running
+        assert "reset" in platform.sent[0][1].lower()
+
+
+class TestInterruptCommands:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cmd", ["/reset", "/cancel"])
+    async def test_dispatch_terminates_running_loop(self, cmd):
+        """_dispatch sends terminate before enqueueing /reset or /cancel."""
+        import mcp_handley_lab.messenger.server as srv
+
+        old_actors = srv._actors
+        old_loop = srv._loop
+
+        try:
+            srv._loop = asyncio.new_event_loop()
+            srv._actors = {}
+
+            platform = MockPlatform()
+            conv_id = "test:interrupt"
+
+            actor = _get_or_create_actor(conv_id, platform)
+            actor.loop_id = "claude-stuck"
+
+            event = _make_event(cmd, platform, conversation_id=conv_id)
+            with patch("mcp_handley_lab.messenger.server.terminate") as mock_terminate:
+                await _dispatch(event)
+                mock_terminate.assert_called_once_with("claude-stuck")
+
+            assert not actor.queue.empty()
+        finally:
+            srv._loop.close()
+            srv._actors = old_actors
+            srv._loop = old_loop
+
+    @pytest.mark.asyncio
+    async def test_dispatch_no_terminate_without_loop(self):
+        """_dispatch skips terminate when no active loop."""
+        import mcp_handley_lab.messenger.server as srv
+
+        old_actors = srv._actors
+        old_loop = srv._loop
+
+        try:
+            srv._loop = asyncio.new_event_loop()
+            srv._actors = {}
+
+            platform = MockPlatform()
+            conv_id = "test:noop"
+
+            event = _make_event("/reset", platform, conversation_id=conv_id)
+            with patch("mcp_handley_lab.messenger.server.terminate") as mock_terminate:
+                await _dispatch(event)
+                mock_terminate.assert_not_called()
+        finally:
+            srv._loop.close()
+            srv._actors = old_actors
+            srv._loop = old_loop
+
+
+class TestCancelCommand:
+    @pytest.mark.asyncio
+    async def test_cancel_sends_confirmation(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        actor.loop_id = "claude-123"
+
+        event = _make_event("/cancel", platform)
+        await actor._handle(event)
+
+        assert "cancelled" in platform.sent[0][1].lower()
+        assert actor.loop_id == "claude-123"  # session preserved
+        assert not actor._stopped  # actor still running
+
+
+class TestModelCommand:
+    @pytest.mark.asyncio
+    async def test_model_set(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        actor.cwd.mkdir(parents=True, exist_ok=True)
+
+        event = _make_event("/model opus", platform)
+        await actor._handle(event)
+
+        assert actor._model == "opus"
+        assert "opus" in platform.sent[0][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_model_query(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        actor._model = "sonnet"
+
+        event = _make_event("/model", platform)
+        await actor._handle(event)
+
+        assert "sonnet" in platform.sent[0][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_model_query_default(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+
+        event = _make_event("/model", platform)
+        await actor._handle(event)
+
+        assert "default" in platform.sent[0][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_model_kills_active_loop(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        actor.loop_id = "claude-123"
+        actor.session_id = "sess-abc"
+        actor.cwd.mkdir(parents=True, exist_ok=True)
+
+        event = _make_event("/model opus", platform)
+        with patch("mcp_handley_lab.messenger.server.kill") as mock_kill:
+            await actor._handle(event)
+            mock_kill.assert_called_once_with("claude-123")
+
+        assert actor.loop_id is None
+        assert actor._model == "opus"
+        assert "restarted" in platform.sent[0][1].lower()
+
+
+class TestStatusCommand:
+    @pytest.mark.asyncio
+    async def test_status_active(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        actor.loop_id = "claude-123"
+        actor.session_id = "sess-abc"
+
+        with patch(
+            "mcp_handley_lab.messenger.server.loop_status",
+            return_value={"ok": True, "running": True, "elapsed_seconds": 42.0},
+        ):
+            event = _make_event("/status", platform)
+            await actor._handle(event)
+
+        text = platform.sent[0][1]
+        assert "running" in text.lower()
+        assert "42s" in text
+
+    @pytest.mark.asyncio
+    async def test_status_no_session(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+
+        event = _make_event("/status", platform)
+        await actor._handle(event)
+
+        assert "no active session" in platform.sent[0][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_status_clears_stale_loop(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        actor.loop_id = "claude-dead"
+        actor.cwd.mkdir(parents=True, exist_ok=True)
+
+        with patch(
+            "mcp_handley_lab.messenger.server.loop_status",
+            side_effect=RuntimeError("not_found: loop not found"),
+        ):
+            event = _make_event("/status", platform)
+            await actor._handle(event)
+
+        assert actor.loop_id is None
+        assert "expired" in platform.sent[0][1].lower()
+
+
+class TestActorLifecycle:
+    def test_stopped_actor_replaced(self, tmp_path):
+        """_get_or_create_actor replaces a stopped actor."""
+        import mcp_handley_lab.messenger.server as srv
+
+        old_actors = srv._actors
+        old_loop = srv._loop
+
+        try:
+            srv._loop = asyncio.new_event_loop()
+            srv._actors = {}
+
+            platform = MockPlatform()
+            conv_id = "test:lifecycle"
+
+            # Create initial actor
+            actor1 = _get_or_create_actor(conv_id, platform)
+            assert conv_id in srv._actors
+
+            # Mark it as stopped
+            actor1._stopped = True
+
+            # Should create a new actor
+            actor2 = _get_or_create_actor(conv_id, platform)
+            assert actor2 is not actor1
+            assert not actor2._stopped
+        finally:
+            srv._loop.close()
+            srv._actors = old_actors
+            srv._loop = old_loop
+
+
+class TestQueryThreadsModel:
+    @pytest.mark.asyncio
+    async def test_query_passes_model_in_args(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        actor._model = "opus"
+        actor.cwd.mkdir(parents=True, exist_ok=True)
+
+        with (
+            patch(
+                "mcp_handley_lab.messenger.server.spawn",
+                return_value="claude-test",
+            ) as mock_spawn,
+            patch(
+                "mcp_handley_lab.messenger.server.run",
+                return_value="response",
+            ),
+        ):
+            result = actor._query("hello")
+
+        assert result == "response"
+        args_str = mock_spawn.call_args[1]["args"]
+        assert "--model opus" in args_str
+
+    @pytest.mark.asyncio
+    async def test_query_no_model_default(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        actor.cwd.mkdir(parents=True, exist_ok=True)
+
+        with (
+            patch(
+                "mcp_handley_lab.messenger.server.spawn",
+                return_value="claude-test",
+            ) as mock_spawn,
+            patch(
+                "mcp_handley_lab.messenger.server.run",
+                return_value="response",
+            ),
+        ):
+            actor._query("hello")
+
+        args_str = mock_spawn.call_args[1]["args"]
+        assert "--model" not in args_str
+
+
+class TestStatePersistence:
+    def test_save_load_with_model(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        actor.loop_id = "claude-123"
+        actor.session_id = "sess-abc"
+        actor._model = "opus"
+        actor.cwd.mkdir(parents=True, exist_ok=True)
+        actor._save_state()
+
+        actor2 = _make_actor(platform, tmp_path=tmp_path)
+        actor2._load_state()
+        assert actor2.loop_id == "claude-123"
+        assert actor2.session_id == "sess-abc"
+        assert actor2._model == "opus"
+
+    def test_load_state_without_model(self, tmp_path):
+        """Old state files without model field still load correctly."""
+        import json
+
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        state_file = tmp_path / "loop_state.json"
+        state_file.write_text(
+            json.dumps({"loop_id": "claude-old", "session_id": "sess-old"})
+        )
+        actor._load_state()
+        assert actor.loop_id == "claude-old"
+        assert actor._model == ""
+
+
+# ---------------------------------------------------------------------------
+# _extract_usage / _context_footer tests
+# ---------------------------------------------------------------------------
+
+_RESULT_EVENT = {
+    "type": "result",
+    "total_cost_usd": 0.05,
+    "modelUsage": {
+        "claude-opus-4-6": {
+            "contextWindow": 200000,
+            "inputTokens": 80000,
+            "outputTokens": 20000,
+            "cacheCreationInputTokens": 5000,
+            "cacheReadInputTokens": 3000,
+            "costUSD": 0.05,
+        },
+    },
+}
+
+
+class TestExtractUsage:
+    def test_extracts_from_last_cell(self):
+        cells = [
+            {"index": 0, "events": []},
+            {"index": 1, "events": [{"type": "assistant"}, _RESULT_EVENT]},
+        ]
+        usage = _extract_usage(cells)
+        assert usage is not None
+        assert usage["context_window"] == 200000
+        assert usage["input_tokens"] == 80000
+        assert usage["output_tokens"] == 20000
+        assert "cost_usd" not in usage
+
+    def test_empty_cells(self):
+        assert _extract_usage([]) is None
+
+    def test_no_result_event(self):
+        cells = [{"index": 0, "events": [{"type": "assistant"}]}]
+        assert _extract_usage(cells) is None
+
+    def test_no_events_key(self):
+        cells = [{"index": 0}]
+        assert _extract_usage(cells) is None
+
+
+class TestContextFooter:
+    def test_basic_footer(self):
+        usage = {
+            "context_window": 200000,
+            "input_tokens": 80000,
+            "output_tokens": 20000,
+        }
+        assert _context_footer(usage) == "50% context"
+
+    def test_zero_context_window(self):
+        usage = {
+            "context_window": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+        }
+        assert _context_footer(usage) == ""
+
+
+class TestContextFooterOnResponse:
+    @pytest.mark.asyncio
+    async def test_response_includes_footer(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        actor.loop_id = "claude-123"
+        actor.cwd.mkdir(parents=True, exist_ok=True)
+
+        cells = [{"index": 0, "events": [_RESULT_EVENT]}]
+        event = _make_event("hello", platform)
+        event.kind = "text"
+
+        with (
+            patch(
+                "mcp_handley_lab.messenger.server.run",
+                return_value="Hello there!",
+            ),
+            patch(
+                "mcp_handley_lab.messenger.server.read_cells_raw",
+                return_value=cells,
+            ),
+        ):
+            await actor._handle(event)
+
+        text = platform.sent[0][1]
+        assert "Hello there!" in text
+        assert "50% context" in text
+
+    @pytest.mark.asyncio
+    async def test_response_no_footer_when_no_usage(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        actor.loop_id = "claude-123"
+        actor.cwd.mkdir(parents=True, exist_ok=True)
+
+        event = _make_event("hello", platform)
+        event.kind = "text"
+
+        with (
+            patch(
+                "mcp_handley_lab.messenger.server.run",
+                return_value="Hello there!",
+            ),
+            patch(
+                "mcp_handley_lab.messenger.server.read_cells_raw",
+                return_value=[],
+            ),
+        ):
+            await actor._handle(event)
+
+        text = platform.sent[0][1]
+        assert "Hello there!" in text
+        assert "context" not in text.lower()


### PR DESCRIPTION
## Summary

Expose process-level CLI commands via the messenger bridge (WhatsApp/Telegram):

- `/reset` - Kill loop, clear all state, start fresh
- `/cancel` - Send SIGINT to interrupt current operation  
- `/model [name]` - Show or set model (kills and respawns loop)
- `/status` - Show session info (running/idle, elapsed time, model)
- `/help` - Show available commands

Also adds context usage footer (e.g. `_50% context_`) to responses.

**`/compact` intentionally excluded**: Claude Code slash commands are interactive-only and not processed in `stream-json` mode. Sending `/compact` as input would just be treated as a regular user message.

## Changes

- `src/mcp_handley_lab/messenger/server.py` - Command parsing, dispatch, and handlers
- `src/mcp_handley_lab/loop/client.py` - `read_raw()` for context footer extraction
- `tests/messenger/test_commands.py` - 38 tests covering all commands and edge cases

## Test plan

- [x] All 38 messenger command tests pass
- [x] Linting clean (ruff check + format)
- [x] Pre-commit hooks pass
- [x] Version properly bumped from master (0.29.10)

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)