### PR TITLE
fix(otter): add include_formatted_text to reduce transcript verbosity (#299)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.29.6
+pkgver=0.29.7
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.29.6"
+version = "0.29.7"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/otter/shared.py
+++ b/src/mcp_handley_lab/otter/shared.py
@@ -47,6 +47,8 @@ class TranscriptSegment(BaseModel):
 class TranscriptResult(BaseModel):
     """Full transcript for a meeting."""
 
+    model_config = ConfigDict(extra="forbid")
+
     title: str = Field(default="", description="Meeting title.")
     otid: str = Field(..., description="Unique meeting identifier.")
     live_status: str = Field(default="", description="Meeting status.")
@@ -56,7 +58,14 @@ class TranscriptResult(BaseModel):
     segments: list[TranscriptSegment] = Field(
         default_factory=list, description="Transcript segments."
     )
-    formatted_text: str = Field(default="", description="Formatted transcript text.")
+    formatted_text: str | None = Field(
+        default=None, description="Formatted transcript text."
+    )
+
+    @model_serializer
+    def serialize(self) -> dict:
+        """Exclude None fields from serialization."""
+        return {k: v for k, v in self.__dict__.items() if v is not None}
 
 
 class RefreshResult(BaseModel):
@@ -181,39 +190,51 @@ def _get_speakers(otid: str) -> dict[int, str]:
     return mapping
 
 
-def _format_transcript(
+def _build_segments(
     transcripts: list, speakers: dict[int, str]
-) -> tuple[str, list[TranscriptSegment]]:
-    """Format transcript segments into readable text and structured segments."""
-    indexed = list(enumerate(transcripts))
-    indexed.sort(key=lambda x: (x[1].get("start_offset", 0), x[0]))
-
-    lines = []
+) -> list[TranscriptSegment]:
+    """Build structured segments from raw transcript data (assumes pre-sorted)."""
     segments = []
-    for _, t in indexed:
+    for t in transcripts:
         text = t.get("transcript", "")
         if not text.strip():
             continue
-        start = t.get("start_offset", 0)
-        total_secs = start // 1000
-        mins = total_secs // 60
-        secs = total_secs % 60
         speaker_id = t.get("speaker_id")
         speaker = (
             speakers.get(speaker_id, f"Speaker {speaker_id}")
             if speaker_id is not None
             else "Unknown"
         )
-        lines.append(f"[{mins:02d}:{secs:02d}] **{speaker}**: {text}")
         segments.append(
             TranscriptSegment(
                 speaker_name=speaker,
-                start_offset_ms=start,
+                start_offset_ms=t.get("start_offset", 0),
                 text=text,
             )
         )
+    return segments
 
-    return "\n\n".join(lines), segments
+
+def _format_segments(segments: list[TranscriptSegment]) -> str:
+    """Render segments as human-readable markdown text."""
+    lines = []
+    for seg in segments:
+        total_secs = seg.start_offset_ms // 1000
+        mins = total_secs // 60
+        secs = total_secs % 60
+        lines.append(f"[{mins:02d}:{secs:02d}] **{seg.speaker_name}**: {seg.text}")
+    return "\n\n".join(lines)
+
+
+def _format_transcript(
+    transcripts: list, speakers: dict[int, str]
+) -> tuple[str, list[TranscriptSegment]]:
+    """Format transcript segments into readable text and structured segments."""
+    indexed = list(enumerate(transcripts))
+    indexed.sort(key=lambda x: (x[1].get("start_offset", 0), x[0]))
+    transcripts = [t for _, t in indexed]
+    segments = _build_segments(transcripts, speakers)
+    return _format_segments(segments), segments
 
 
 # --- Public operations ---
@@ -232,7 +253,10 @@ def find_live_meetings() -> list[MeetingSummary]:
 
 
 def get_transcript(
-    otid: str, max_segments: int = 0, since_offset_ms: int = 0
+    otid: str,
+    max_segments: int = 0,
+    since_offset_ms: int = 0,
+    include_formatted_text: bool = True,
 ) -> TranscriptResult:
     """Get full transcript for a meeting."""
     data = _api_get("speech", {"otid": otid})
@@ -254,7 +278,7 @@ def get_transcript(
     if max_segments > 0:
         transcripts = transcripts[-max_segments:]
 
-    formatted_text, segments = _format_transcript(transcripts, speakers)
+    segments = _build_segments(transcripts, speakers)
 
     return TranscriptResult(
         title=speech.get("title", ""),
@@ -264,7 +288,7 @@ def get_transcript(
         url=f"https://otter.ai/u/{otid}",
         speakers=sorted({seg.speaker_name for seg in segments}),
         segments=segments,
-        formatted_text=formatted_text,
+        formatted_text=_format_segments(segments) if include_formatted_text else None,
     )
 
 

--- a/src/mcp_handley_lab/otter/tool.py
+++ b/src/mcp_handley_lab/otter/tool.py
@@ -22,7 +22,8 @@ Actions:
 - live: List currently live meetings (title, otid, status).
   No required params.
 - transcript: Get full transcript for a meeting (live or recent).
-  Required: otid. Optional: max_segments (0=all, default 0), since_offset_ms (0=all, for incremental reads).
+  Required: otid. Optional: max_segments (0=all, default 0), since_offset_ms (0=all, for incremental reads),
+  include_formatted_text (default true; set false to omit formatted_text and reduce response size for live monitoring).
 - recent: List recent meetings.
   Optional: limit (default 10).
 - search: Filter recent meetings by title (client-side).
@@ -49,6 +50,10 @@ def otter(
         default=0,
         description="Only return segments after this offset in ms. Track max start_offset_ms from previous call for incremental reading (for 'transcript').",
     ),
+    include_formatted_text: bool = Field(
+        default=True,
+        description="Include formatted_text in transcript response. Set false to reduce response size for live monitoring (for 'transcript').",
+    ),
 ) -> OtterResult:
     """Dispatch to the appropriate Otter.ai operation."""
     from mcp_handley_lab.otter.shared import (
@@ -65,7 +70,12 @@ def otter(
         if not otid:
             raise ValueError("'otid' is required for transcript action")
         return OtterResult(
-            transcript=get_transcript(otid, max_segments, since_offset_ms)
+            transcript=get_transcript(
+                otid,
+                max_segments,
+                since_offset_ms,
+                include_formatted_text=include_formatted_text,
+            )
         )
     elif action == "recent":
         return OtterResult(meetings=list_recent_meetings(limit))

--- a/tests/unit/test_otter_formatting.py
+++ b/tests/unit/test_otter_formatting.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from mcp_handley_lab.otter.shared import (
     MeetingSummary,
     OtterResult,
+    TranscriptResult,
     _format_transcript,
     _parse_meeting,
     get_transcript,
@@ -149,6 +150,26 @@ class TestOtterResultSerialization:
         assert data["meetings"] == []
 
 
+class TestTranscriptResultSerialization:
+    """Test TranscriptResult omits None formatted_text."""
+
+    def test_formatted_text_none_omitted(self):
+        result = TranscriptResult(otid="abc", formatted_text=None)
+        data = result.model_dump()
+        assert "formatted_text" not in data
+
+    def test_formatted_text_present_included(self):
+        result = TranscriptResult(otid="abc", formatted_text="some text")
+        data = result.model_dump()
+        assert data["formatted_text"] == "some text"
+
+    def test_formatted_text_empty_string_included(self):
+        result = TranscriptResult(otid="abc", formatted_text="")
+        data = result.model_dump()
+        assert "formatted_text" in data
+        assert data["formatted_text"] == ""
+
+
 # Mock data for get_transcript tests
 _MOCK_SPEECH = {
     "speech": {
@@ -208,6 +229,21 @@ class TestGetTranscriptSinceOffset:
             result = get_transcript("test-otid", since_offset_ms=99999)
         assert len(result.segments) == 0
         assert result.formatted_text == ""
+
+    def test_include_formatted_text_false(self):
+        with _patch_api():
+            result = get_transcript("test-otid", include_formatted_text=False)
+        assert len(result.segments) == 5
+        data = result.model_dump()
+        assert "formatted_text" not in data
+
+    def test_include_formatted_text_true(self):
+        with _patch_api():
+            result = get_transcript("test-otid", include_formatted_text=True)
+        assert len(result.segments) == 5
+        data = result.model_dump()
+        assert "formatted_text" in data
+        assert "Alice" in data["formatted_text"]
 
     def test_negative_offset_returns_all(self):
         with _patch_api():


### PR DESCRIPTION
## Summary
- Add `include_formatted_text: bool = True` param to transcript action
- When False, skip building formatted text and omit from response (None fields dropped by serializer)
- Split `_format_transcript` into `_build_segments` + `_format_segments` so formatted text can be skipped entirely
- Add `model_config = ConfigDict(extra="forbid")` and `@model_serializer` to `TranscriptResult` matching `OtterResult` pattern
- Closes #299

## Test plan
- [ ] `python -m pytest tests/unit/test_otter_formatting.py -v` — 27 tests pass
- [ ] Backwards compatible: default `include_formatted_text=True` preserves existing behaviour
- [ ] `include_formatted_text=False` omits `formatted_text` key from serialized response

🤖 Generated with [Claude Code](https://claude.com/claude-code)