### PR TITLE
fix(otter): replace Playwright session refresh with pycookiecheat (#303)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.29.8
+pkgver=0.29.9
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.29.8"
+version = "0.29.9"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -46,6 +46,7 @@ dependencies = [
     "wolframclient>=1.1.0",
     "numpy>=1.24.0",
     "lxml>=4.9.0",
+    "pycookiecheat>=0.7.0",
 ]
 
 [project.optional-dependencies]

--- a/src/mcp_handley_lab/common/config.py
+++ b/src/mcp_handley_lab/common/config.py
@@ -66,10 +66,6 @@ class Settings(BaseSettings):
         default="~/.local/share/otter/session.json",
         description="Path to Otter.ai session file with cookies.",
     )
-    otter_chrome_profile: str = Field(
-        default="~/.local/share/otter/chrome-profile",
-        description="Path to dedicated Chrome profile for Otter.ai Playwright refresh.",
-    )
     otter_timeout: int = Field(
         default=30,
         description="HTTP timeout in seconds for Otter.ai API requests.",
@@ -94,11 +90,6 @@ class Settings(BaseSettings):
     def otter_session_path(self) -> Path:
         """Get resolved path for Otter.ai session."""
         return Path(self.otter_session_file).expanduser()
-
-    @property
-    def otter_chrome_profile_path(self) -> Path:
-        """Get resolved path for Otter.ai Chrome profile."""
-        return Path(self.otter_chrome_profile).expanduser()
 
 
 settings = Settings()

--- a/src/mcp_handley_lab/otter/shared.py
+++ b/src/mcp_handley_lab/otter/shared.py
@@ -5,10 +5,8 @@ All functions are usable without MCP server.
 
 import json
 import os
-import sys
 import tempfile
 from datetime import datetime
-from pathlib import Path
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, model_serializer
@@ -127,8 +125,9 @@ def _clear_session_cache():
 # --- API helpers ---
 
 
-_SESSION_EXPIRED = (
-    "Otter session expired. Call otter(action='refresh') or run otter-refresh-session."
+_NOT_LOGGED_IN = (
+    "No Otter.ai session found in any browser (tried Chrome, Chromium, Brave, Firefox). "
+    "Please log in at https://otter.ai in your browser, then retry."
 )
 
 
@@ -140,17 +139,37 @@ def _parse_json(resp: httpx.Response) -> dict:
     return resp.json()
 
 
+def _auto_refresh() -> bool:
+    """Try to refresh session from browser cookies. Returns True if successful."""
+    try:
+        refresh_session()
+        return True
+    except RuntimeError:
+        return False
+
+
 def _api_get(path: str, params: dict | None = None) -> dict:
-    """GET an Otter API endpoint with session cookies. Retries once on auth failure."""
+    """GET an Otter API endpoint with session cookies.
+
+    On auth failure: reloads session file, then auto-refreshes from browser cookies.
+    """
     client = _get_session()
     resp = client.get(f"{API_BASE}/{path}", params=params)
 
     if resp.status_code in (400, 401, 403):
+        # Try reloading from disk first (another process may have refreshed)
         _clear_session_cache()
         client = _get_session(force_reload=True)
         resp = client.get(f"{API_BASE}/{path}", params=params)
+
         if resp.status_code in (400, 401, 403):
-            raise RuntimeError(_SESSION_EXPIRED)
+            # Auto-refresh from browser cookies
+            if not _auto_refresh():
+                raise RuntimeError(_NOT_LOGGED_IN)
+            client = _get_session(force_reload=True)
+            resp = client.get(f"{API_BASE}/{path}", params=params)
+            if resp.status_code in (400, 401, 403):
+                raise RuntimeError(_NOT_LOGGED_IN)
 
     resp.raise_for_status()
 
@@ -158,6 +177,8 @@ def _api_get(path: str, params: dict | None = None) -> dict:
         return _parse_json(resp)
     except (RuntimeError, json.JSONDecodeError):
         _clear_session_cache()
+        if not _auto_refresh():
+            raise RuntimeError(_NOT_LOGGED_IN) from None
         client = _get_session(force_reload=True)
         resp = client.get(f"{API_BASE}/{path}", params=params)
         resp.raise_for_status()
@@ -318,119 +339,47 @@ def search_meetings(query: str, limit: int = 10) -> list[MeetingSummary]:
     return results
 
 
-_REFRESH_SCRIPT = """
-import json, sys
-from playwright.sync_api import sync_playwright
+def _extract_browser_cookies() -> dict:
+    """Try extracting otter.ai cookies from installed browsers.
 
-chrome_profile = sys.argv[1]
-output_file = sys.argv[2]
+    Tries Chrome, Chromium, Brave, then Firefox. Returns the first cookie jar
+    that contains a sessionid, or raises RuntimeError.
+    """
+    from pycookiecheat import BrowserType, chrome_cookies, firefox_cookies
 
-with sync_playwright() as p:
-    browser = p.chromium.launch_persistent_context(
-        user_data_dir=chrome_profile, headless=True, channel="chrome",
-    )
+    for browser in (BrowserType.CHROME, BrowserType.CHROMIUM, BrowserType.BRAVE):
+        try:
+            cookies = chrome_cookies("https://otter.ai", browser=browser)
+            if "sessionid" in cookies:
+                return cookies
+        except Exception:
+            continue
+
     try:
-        page = browser.pages[0] if browser.pages else browser.new_page()
-        page.goto("https://otter.ai/home", wait_until="domcontentloaded")
-        page.wait_for_timeout(5000)
-        all_cookies = browser.cookies("https://otter.ai")
-        cookies = [
-            {"name": c["name"], "value": c["value"],
-             "domain": c.get("domain", "otter.ai"), "path": c.get("path", "/")}
-            for c in all_cookies if "otter.ai" in c.get("domain", "")
-        ]
-    finally:
-        browser.close()
-with open(output_file, "w") as f:
-    json.dump(cookies, f)
-"""
+        cookies = firefox_cookies("https://otter.ai")
+        if "sessionid" in cookies:
+            return cookies
+    except Exception:
+        pass
 
+    import webbrowser
 
-_MANAGED_MARKER = ".mcp_otter_managed"
-
-# Directories to exclude when copying Chrome profile (~300MB vs ~4GB)
-_PROFILE_SKIP = {
-    "Cache",
-    "Code Cache",
-    "GPUCache",
-    "CacheStorage",
-    "DawnCache",
-    "Service Worker",
-    "WebStorage",
-    "File System",
-    "IndexedDB",
-    "SingletonLock",
-    "SingletonCookie",
-    "SingletonSocket",
-}
-
-
-def _ensure_chrome_profile():
-    """Ensure the Otter Chrome profile exists, copying from the system Chrome profile."""
-    import shutil
-
-    chrome_profile = settings.otter_chrome_profile_path
-    if chrome_profile.exists() and (chrome_profile / "Default").exists():
-        return
-
-    source = Path.home() / ".config" / "google-chrome"
-    if not (source / "Default").exists():
-        raise RuntimeError(
-            f"Chrome profile not found at {source}. "
-            "Start Chrome at least once, then retry."
-        )
-
-    # Remove stale/incomplete copies (only if we created them)
-    if chrome_profile.exists():
-        if not (chrome_profile / _MANAGED_MARKER).exists():
-            raise RuntimeError(
-                f"{chrome_profile} exists but is not managed by mcp-otter. "
-                "Delete it manually if safe, then retry."
-            )
-        shutil.rmtree(chrome_profile)
-
-    shutil.copytree(
-        str(source),
-        str(chrome_profile),
-        ignore=shutil.ignore_patterns(*_PROFILE_SKIP),
-    )
-    (chrome_profile / _MANAGED_MARKER).touch()
+    webbrowser.open("https://otter.ai/signin")
+    raise RuntimeError(_NOT_LOGGED_IN)
 
 
 def refresh_session() -> RefreshResult:
-    """Refresh Otter.ai session using Playwright headless with a Chrome profile copy.
+    """Refresh Otter.ai session by extracting cookies from the user's browser.
 
-    Runs in a subprocess to avoid asyncio loop conflicts with FastMCP.
+    Tries Chrome, Chromium, Brave, and Firefox via pycookiecheat.
+    If no browser has a valid session, opens otter.ai sign-in page and raises an error.
     """
-    import subprocess
+    raw_cookies = _extract_browser_cookies()
 
-    _ensure_chrome_profile()
-    chrome_profile = settings.otter_chrome_profile_path
-
-    session_path = settings.otter_session_path
-    session_path.parent.mkdir(parents=True, exist_ok=True)
-
-    fd, tmp_cookies = tempfile.mkstemp(suffix=".json")
-    os.close(fd)
-
-    try:
-        result = subprocess.run(
-            [sys.executable, "-c", _REFRESH_SCRIPT, str(chrome_profile), tmp_cookies],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(f"Refresh failed: {result.stderr.strip()}")
-
-        with open(tmp_cookies) as f:
-            cookies = json.load(f)
-    finally:
-        if os.path.exists(tmp_cookies):
-            os.unlink(tmp_cookies)
-
-    if not any(c["name"] == "sessionid" for c in cookies):
-        raise RuntimeError("Not logged in to Otter.ai. Log in via Chrome, then retry.")
+    cookies = [
+        {"name": name, "value": value, "domain": ".otter.ai", "path": "/"}
+        for name, value in raw_cookies.items()
+    ]
 
     session_data = {
         "cookies": cookies,

--- a/src/mcp_handley_lab/otter/tool.py
+++ b/src/mcp_handley_lab/otter/tool.py
@@ -1,7 +1,7 @@
 """Otter.ai MCP tool for accessing live meeting transcripts.
 
 Uses undocumented Otter.ai API with session cookies.
-Session must be refreshed via 'refresh' action or otter-refresh-session.
+Cookies auto-extracted from browser (Chrome/Chromium/Brave/Firefox) via pycookiecheat.
 """
 
 from typing import Literal
@@ -28,8 +28,9 @@ Actions:
   Optional: limit (default 10).
 - search: Filter recent meetings by title (client-side).
   Required: query. Optional: limit (default 10).
-- refresh: Refresh session cookies using Playwright headless.
-  No params. Auto-copies Chrome profile on first run. Requires: playwright installed.
+- refresh: Refresh session cookies from browser cookie store.
+  Tries Chrome, Chromium, Brave, Firefox. If not logged in, opens otter.ai sign-in page.
+  Note: API calls auto-refresh on auth failure, so explicit refresh is rarely needed.
 """
 )
 def otter(


### PR DESCRIPTION
## Summary

- Replaces fragile Playwright-based session refresh (copy Chrome profile → launch headless browser → extract cookies) with `pycookiecheat`, which reads cookies directly from the browser's encrypted store via the OS keyring
- API calls now auto-refresh on auth failure — sessions self-heal transparently as long as the user is logged in to otter.ai in any supported browser
- If no browser has a valid session, opens the Otter sign-in page so the user can log in
- Removes ~120 lines of Chrome profile copy machinery, subprocess management, and Playwright script
- Tries Chrome, Chromium, Brave, and Firefox in order

## Test plan

- [x] `pycookiecheat` extracts valid `sessionid` and `csrftoken` from Chrome
- [x] `otter(action='refresh')` succeeds via JSON-RPC (50 cookies extracted)
- [x] `otter(action='recent')` returns meetings with refreshed session
- [x] Auto-refresh: corrupted session.json → API call self-heals from Chrome cookies
- [x] All 35 tests pass (27 unit + 8 integration)
- [x] Linting clean

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)