### PR TITLE
fix(messenger): disable EnterPlanMode to prevent deadlock (#302)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.30.0b2
+pkgver=0.29.12
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.30.0b2"
+version = "0.29.12"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/messenger/server.py
+++ b/src/mcp_handley_lab/messenger/server.py
@@ -50,6 +50,7 @@ TELEGRAM_ALLOWED_CHAT_IDS: set[int] | None = (
 )
 
 CLAUDE_PERMISSION_MODE = os.environ.get("CLAUDE_PERMISSION_MODE", "acceptEdits")
+CLAUDE_DISALLOWED_TOOLS = os.environ.get("CLAUDE_DISALLOWED_TOOLS", "EnterPlanMode")
 _APPEND_SYSTEM_PROMPT = (
     "Keep responses concise for mobile. "
     "When a user sends an image, sticker, video, or document, "
@@ -978,6 +979,8 @@ class ChatActor:
         """Ensure loop exists and run text. Called via to_thread."""
         if not self.loop_id:
             args = f"--permission-mode {CLAUDE_PERMISSION_MODE}"
+            if CLAUDE_DISALLOWED_TOOLS:
+                args += f" --disallowed-tools {CLAUDE_DISALLOWED_TOOLS}"
             if self._model:
                 args += f" --model {self._model}"
             self.loop_id = spawn(

--- a/tests/messenger/test_commands.py
+++ b/tests/messenger/test_commands.py
@@ -398,6 +398,28 @@ class TestQueryThreadsModel:
         args_str = mock_spawn.call_args[1]["args"]
         assert "--model" not in args_str
 
+    @pytest.mark.asyncio
+    async def test_query_disallows_plan_mode(self, tmp_path):
+        platform = MockPlatform()
+        actor = _make_actor(platform, tmp_path=tmp_path)
+        actor.cwd.mkdir(parents=True, exist_ok=True)
+
+        with (
+            patch(
+                "mcp_handley_lab.messenger.server.spawn",
+                return_value="claude-test",
+            ) as mock_spawn,
+            patch(
+                "mcp_handley_lab.messenger.server.run",
+                return_value="response",
+            ),
+        ):
+            actor._query("hello")
+
+        args_str = mock_spawn.call_args[1]["args"]
+        assert "--disallowed-tools" in args_str
+        assert "EnterPlanMode" in args_str
+
 
 class TestStatePersistence:
     def test_save_load_with_model(self, tmp_path):


### PR DESCRIPTION
## Summary
- Add `CLAUDE_DISALLOWED_TOOLS` env var (default: `EnterPlanMode`) passed as `--disallowed-tools` when spawning Claude loops
- Prevents plan mode deadlock in non-terminal interfaces (WhatsApp/Telegram) where the approval prompt cannot be answered

Closes #302

## Test plan
- [x] Unit test verifies `--disallowed-tools` is present in spawn args
- [x] All 39 messenger tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)