### PR TITLE
fix(llm): include default prompts in review tool description

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.29.12
+pkgver=0.29.13
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.29.12"
+version = "0.29.13"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/tool.py
+++ b/src/mcp_handley_lab/llm/tool.py
@@ -244,6 +244,15 @@ DEFAULT_REVIEW_PROMPT = (
     description="Review code with an external LLM. Runs code2prompt internally "
     "(with --line-numbers) from the current directory, then sends the summary + "
     "plan + any extra files to the LLM for review. "
+    "Default system prompt: 'You are a code reviewer. Review the provided code against "
+    "any plan/specification. Be specific: reference file paths and line numbers. "
+    "Assess: plan adherence, code quality, completeness, and readiness. "
+    "If you cannot make a decision because relevant code is missing from the summary, "
+    "state NEEDS MORE CODE and list the specific files or modules you need to see. "
+    "If no blocking issues remain, state APPROVED. "
+    "Otherwise, list required fixes with specific locations.' "
+    "Default user prompt: 'Review this implementation. "
+    "Check code quality, completeness, and readiness to proceed.' "
     "Returns: {content, usage, branch, commit_sha}."
 )
 def review(
@@ -254,8 +263,8 @@ def review(
     ),
     prompt: str = Field(
         default="",
-        description="Additional instructions for the reviewer. "
-        "If empty, uses a default review prompt.",
+        description="Appended to the default user prompt. Use for extra steering "
+        "(e.g., 'Focus on security'). Leave empty for standard review.",
     ),
     model: str = Field(
         default="openai",


### PR DESCRIPTION
## Summary
- Embeds the verbatim default system and user prompts in the `review` tool description so callers can see exactly what's already sent
- Clarifies that the `prompt` parameter appends to (not replaces) the default, preventing redundant restating of built-in review behaviour

## Test plan
- [ ] Verify `mcp__llm__review` tool description shows default prompts in Claude Code
- [ ] Confirm passing no `prompt` still produces a standard review

🤖 Generated with [Claude Code](https://claude.com/claude-code)