### PR TITLE
fix(llm): add path parameter to review tool

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.30.0
+pkgver=0.30.1
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.30.0"
+version = "0.30.1"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/tool.py
+++ b/src/mcp_handley_lab/llm/tool.py
@@ -242,7 +242,7 @@ DEFAULT_REVIEW_PROMPT = (
 
 @mcp.tool(
     description="Review code with an external LLM. Runs code2prompt internally "
-    "(with --line-numbers) from the current directory, then sends the summary + "
+    "(with --line-numbers) on the specified path, then sends the summary + "
     "plan + any extra files to the LLM for review. "
     "Default system prompt: 'You are a code reviewer. Review the provided code against "
     "any plan/specification. Be specific: reference file paths and line numbers. "
@@ -256,6 +256,11 @@ DEFAULT_REVIEW_PROMPT = (
     "Returns: {content, usage, branch, commit_sha}."
 )
 def review(
+    path: str = Field(
+        default=".",
+        description="Path to the codebase directory to review. "
+        "Use absolute path when calling from a different working directory.",
+    ),
     plan: str = Field(
         default="",
         description="Path to plan/specification file to review against. "
@@ -309,7 +314,12 @@ def review(
     os.close(fd)
 
     try:
-        args = [".", "--output-file", c2p_output, "--line-numbers"]
+        args = [
+            str(Path(path).expanduser()),
+            "--output-file",
+            c2p_output,
+            "--line-numbers",
+        ]
         for pat in include:
             args.extend(["--include", pat])
         for pat in exclude:


### PR DESCRIPTION
## Summary
- Adds `path` parameter to `review()` so callers can specify which codebase to scan
- Replaces hardcoded `"."` which resolved to the MCP server's cwd, not the user's project
- Expands `path` with `expanduser()` matching existing parameter handling

Closes #311

## Test plan
- [ ] Call `review(path="/absolute/path", include=["*.py"])` and verify code2prompt includes files from that path
- [ ] Verify default `path="."` preserves existing behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)