### PR TITLE
fix(pkgbuild): correct jupyter-client dependency name

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Will Handley <wh260@cam.ac.uk>
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
-pkgver=0.30.1
+pkgver=0.30.2
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')
@@ -50,7 +50,7 @@ depends=(
     'python-opentelemetry-exporter-otlp-proto-http'
     'python-dateutil>=2.8.0'
     'python-lxml>=4.9.0'
-    'python-jupyter_client>=8.0.0'
+    'python-jupyter-client>=8.0.0'
 )
 makedepends=(
     'python-build'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-handley-lab"
-version = "0.30.1"
+version = "0.30.2"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Fixed `python-jupyter_client` → `python-jupyter-client` (underscore → hyphen) in PKGBUILD
- The underscore variant doesn't resolve in pacman, causing install failures on fresh machines

## Test plan
- [ ] `makepkg -si` resolves all dependencies without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)