### PR TITLE
Update model definitions for latest OpenAI, Gemini, and Claude models

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.31.11
-pkgver=0.31.11
+pkgver=0.31.12
+pkgver=0.31.12
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.31.11"
+version = "0.31.12"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/providers/claude/models.yaml
+++ b/src/mcp_handley_lab/llm/providers/claude/models.yaml
@@ -170,7 +170,7 @@ default_model: "claude-opus-4-6"
 # Usage notes
 usage_notes:
   - "Claude Opus 4.6 has 200K context (1M beta) and 128K max output"
-  - "Claude Opus 4.6 and Sonnet 4.5 support 1M token context window with beta header (context-1m-2025-08-07)"
+  - "Claude Opus 4.6 and Sonnet 4.6 support 1M token context window with beta header (context-1m-2025-08-07)"
   - "Long context pricing: requests >200K input tokens charged at 2x input and 1.5x output rates"
   - "All models support vision and image analysis capabilities"
   - "All models support extended thinking for complex reasoning tasks"

--- a/src/mcp_handley_lab/llm/providers/gemini/models.yaml
+++ b/src/mcp_handley_lab/llm/providers/gemini/models.yaml
@@ -70,7 +70,8 @@ models:
       text: 0.50
       image: 0.50
       audio: 1.00
-    output_per_1m: 3.00
+    text_output_per_1m: 1.50
+    audio_output_per_1m: 6.00
 
   gemini-3.1-flash-lite-preview:
     # Model metadata

--- a/src/mcp_handley_lab/llm/providers/gemini/models.yaml
+++ b/src/mcp_handley_lab/llm/providers/gemini/models.yaml
@@ -53,6 +53,25 @@ models:
       - threshold: .inf
         price: 18.00
 
+  gemini-3.1-flash-live-preview:
+    # Model metadata
+    description: "Real-time audio-to-audio model for Live API with low-latency streaming"
+    capabilities: "🔴 Best for: Real-time audio conversations, low-latency voice interaction, Live API"
+    tags: ["gemini-3.1", "flash", "realtime", "audio"]
+    context_window: "1,000,000 tokens"
+    output_tokens: 65536
+
+    # Capabilities
+    supports_vision: true
+    supports_grounding: false
+
+    # Pricing (by modality)
+    input_by_modality:
+      text: 0.50
+      image: 0.50
+      audio: 1.00
+    output_per_1m: 3.00
+
   gemini-3.1-flash-lite-preview:
     # Model metadata
     description: "Cost-effective Gemini 3.1 Flash Lite model for fast, high-volume tasks"

--- a/src/mcp_handley_lab/llm/providers/openai/models.yaml
+++ b/src/mcp_handley_lab/llm/providers/openai/models.yaml
@@ -179,7 +179,77 @@ models:
     output_per_1m: 120.00
     supports_caching: false
 
+  gpt-5.4-mini:
+    # Model metadata
+    description: "Cheaper, faster version of GPT-5.4 with 1M context"
+    capabilities: "⚖️ Best for: Most tasks requiring large context, balanced performance and cost"
+    tags: ["flagship", "latest", "general", "cost-effective", "vision"]
+    context_window: "1,050,000 tokens"
+    output_tokens: 128000
+    param: "max_output_tokens"
+    supports_temperature: false
+    supports_vision: true
+    supports_reasoning: true
+    supports_verbosity: true
+
+    # Pricing (tiered: <272K and >272K context)
+    input_tiers:
+      - threshold: 272000
+        price: 0.40
+      - threshold: .inf
+        price: 0.80
+    output_tiers:
+      - threshold: 272000
+        price: 2.00
+      - threshold: .inf
+        price: 3.00
+    cached_input_per_1m: 0.04
+    supports_caching: true
+
+  gpt-5.4-nano:
+    # Model metadata
+    description: "Cheapest, fastest GPT-5.4 variant for high-volume tasks (API-only)"
+    capabilities: "⚡ Best for: High-volume processing, cost optimization, fast inference"
+    tags: ["flagship", "latest", "general", "fast", "cost-effective"]
+    context_window: "1,050,000 tokens"
+    output_tokens: 128000
+    param: "max_output_tokens"
+    supports_temperature: false
+    supports_reasoning: true
+
+    # Pricing (tiered: <272K and >272K context)
+    input_tiers:
+      - threshold: 272000
+        price: 0.08
+      - threshold: .inf
+        price: 0.16
+    output_tiers:
+      - threshold: 272000
+        price: 0.40
+      - threshold: .inf
+        price: 0.60
+    cached_input_per_1m: 0.008
+    supports_caching: true
+
   # Codex Models (agentic coding)
+  gpt-5.3-codex-spark:
+    # Model metadata
+    description: "Faster variant of GPT-5.3 Codex for agentic coding, research preview (>1000 tok/s)"
+    capabilities: "💻 Best for: Fast agentic coding, rapid iteration, high-throughput development"
+    tags: ["codex", "coding", "fast", "preview"]
+    context_window: "400,000 tokens"
+    output_tokens: 128000
+    param: "max_output_tokens"
+    supports_temperature: false
+    supports_vision: true
+    supports_reasoning: true
+
+    # Pricing
+    input_per_1m: 1.00
+    output_per_1m: 8.00
+    cached_input_per_1m: 0.10
+    supports_caching: true
+
   gpt-5.3-codex:
     # Model metadata
     description: "Most capable agentic coding model combining Codex + GPT-5 training"

--- a/src/mcp_handley_lab/llm/providers/openai/models.yaml
+++ b/src/mcp_handley_lab/llm/providers/openai/models.yaml
@@ -215,6 +215,7 @@ models:
     output_tokens: 128000
     param: "max_output_tokens"
     supports_temperature: false
+    supports_vision: true
     supports_reasoning: true
 
     # Pricing (tiered: <272K and >272K context)

--- a/src/mcp_handley_lab/llm/registry.py
+++ b/src/mcp_handley_lab/llm/registry.py
@@ -48,8 +48,8 @@ MODEL_PREFIXES = [
 # Model aliases (shorthand → full model ID)
 MODEL_ALIASES = {
     # Claude shorthand aliases
-    "opus": "claude-opus-4-5-20251101",
-    "sonnet": "claude-sonnet-4-5-20250929",
+    "opus": "claude-opus-4-6",
+    "sonnet": "claude-sonnet-4-6",
     "haiku": "claude-haiku-4-5-20251001",
     # Gemini shorthand aliases
     "deep-research": "gemini-deep-research",


### PR DESCRIPTION
## Summary

- **OpenAI**: Added `gpt-5.4-mini` (cheaper/faster GPT-5.4, ~1.05M context, reasoning/vision/caching), `gpt-5.4-nano` (cheapest/fastest GPT-5.4, API-only), and `gpt-5.3-codex-spark` (faster Codex variant, research preview, >1000 tok/s)
- **Gemini**: Added `gemini-3.1-flash-live-preview` (real-time audio-to-audio model for Live API, low-latency streaming)
- **Claude aliases**: Updated `opus` alias from `claude-opus-4-5-20251101` to `claude-opus-4-6`, and `sonnet` alias from `claude-sonnet-4-5-20250929` to `claude-sonnet-4-6`

## Files changed

- `src/mcp_handley_lab/llm/providers/openai/models.yaml` — 3 new model entries
- `src/mcp_handley_lab/llm/providers/gemini/models.yaml` — 1 new model entry
- `src/mcp_handley_lab/llm/registry.py` — updated 2 alias mappings

## Test plan

- [ ] Verify YAML files parse correctly
- [ ] Verify new models appear in model listing
- [ ] Verify `opus` and `sonnet` aliases resolve to the new model IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)