### PR TITLE
fix(google-calendar): expose send_updates; default to no notifications

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.31.11b1
-pkgver=0.31.11b1
+pkgver=0.31.11b2
+pkgver=0.31.11b2
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.31.11b1"
+version = "0.31.11b2"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/google_calendar/shared.py
+++ b/src/mcp_handley_lab/google_calendar/shared.py
@@ -287,6 +287,7 @@ def create(
     attendees: list[str] | None = None,
     recurrence: list[str] | None = None,
     attachments: list[str] | None = None,
+    send_updates: str = "none",
 ) -> CreatedEventResult:
     """Create a new calendar event with intelligent datetime parsing.
 
@@ -302,6 +303,8 @@ def create(
         attendees: A list of attendee email addresses to invite.
         recurrence: Recurrence rules as RRULE strings (e.g., ['RRULE:FREQ=WEEKLY;COUNT=10']).
         attachments: Files to attach (local paths or Google Drive URLs).
+        send_updates: Who to notify of the event. One of 'none' (default, no
+            notifications), 'externalOnly' (only non-Google attendees), or 'all'.
 
     Returns:
         CreatedEventResult with event details.
@@ -357,7 +360,7 @@ def create(
         .insert(
             calendarId=resolved_id,
             body=event_body,
-            sendUpdates="all",
+            sendUpdates=send_updates,
             supportsAttachments=True,
         )
         .execute()
@@ -423,6 +426,7 @@ def update(
     update_series: bool = False,
     recurrence: list[str] | None = None,
     attachments: list[str] | None = None,
+    send_updates: str = "none",
 ) -> UpdateEventResult:
     """Update or move a calendar event.
 
@@ -442,6 +446,9 @@ def update(
         update_series: If True, update the entire recurring series (resolves instance to master).
         recurrence: New recurrence rules. None=no change. []=remove recurrence.
         attachments: Files to attach (local paths or Google Drive URLs). Replaces existing.
+        send_updates: Who to notify of the change. One of 'none' (default, no
+            notifications), 'externalOnly' (only non-Google attendees), or 'all'.
+            Applies to both the patch path and the move path.
 
     Returns:
         UpdateEventResult with update details.
@@ -489,6 +496,7 @@ def update(
                 calendarId=resolved_id,
                 eventId=event_id,
                 destination=dest_resolved_id,
+                sendUpdates=send_updates,
             )
             .execute()
         )
@@ -604,7 +612,7 @@ def update(
             calendarId=resolved_id,
             eventId=target_event_id,
             body=update_body,
-            sendUpdates="all",
+            sendUpdates=send_updates,
             supportsAttachments=True,
         )
         .execute()

--- a/src/mcp_handley_lab/google_calendar/tool.py
+++ b/src/mcp_handley_lab/google_calendar/tool.py
@@ -986,6 +986,12 @@ def create(
         description="Files to attach. Accepts local paths (uploaded to Google Drive via rclone) "
         "or existing Google Drive URLs.",
     ),
+    send_updates: str = Field(
+        "none",
+        description="Who to notify of the new event. 'none' (default, no notifications), "
+        "'externalOnly' (only non-Google attendees), or 'all'. Default avoids "
+        "accidental notification spam; opt in to 'all' when you intend to invite attendees.",
+    ),
 ) -> CreatedEventResult:
     """Create a new calendar event with intelligent datetime parsing and flexible timezone handling."""
     from mcp_handley_lab.google_calendar.shared import create as _create
@@ -1002,6 +1008,7 @@ def create(
         attendees=attendees,
         recurrence=recurrence,
         attachments=attachments or None,
+        send_updates=send_updates,
     )
 
 
@@ -1059,6 +1066,12 @@ def update(
         description="Files to attach. Accepts local paths (uploaded to Google Drive via rclone) "
         "or existing Google Drive URLs. Replaces all existing attachments.",
     ),
+    send_updates: str = Field(
+        "none",
+        description="Who to notify of the change. 'none' (default, no notifications), "
+        "'externalOnly' (only non-Google attendees), or 'all'. Applies to both the patch path "
+        "and the move path. Default avoids accidental notification spam.",
+    ),
 ) -> UpdateEventResult:
     """Update or move an event. Move and update are mutually exclusive."""
     from mcp_handley_lab.google_calendar.shared import update as _update
@@ -1078,6 +1091,7 @@ def update(
         update_series=update_series,
         recurrence=recurrence,
         attachments=attachments or None,
+        send_updates=send_updates,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,7 @@ def vcr_config():
             "access_token",
             "api_key",
             "pageToken",  # Ignore pagination tokens for model listing
+            "sendUpdates",  # Notification preference, not core to test intent
         ],
         "filter_post_data_parameters": [
             "client_secret",

--- a/tests/unit/test_google_calendar_send_updates.py
+++ b/tests/unit/test_google_calendar_send_updates.py
@@ -1,0 +1,137 @@
+"""Unit tests for Google Calendar send_updates plumbing (#334) and the
+unknown-parameter validator (#313).
+
+These tests use mocked Google Calendar service objects so they run without
+network or credentials.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_handley_lab.google_calendar import shared
+from mcp_handley_lab.google_calendar.tool import mcp
+
+
+def _build_fake_service(returned_event: dict | None = None) -> MagicMock:
+    """Construct a Mock that mimics the chained Google Calendar service API.
+
+    Stubs the methods touched by `shared.create` and `shared.update` along
+    the patch + move paths: events().{insert,patch,move,get}(...).execute(),
+    and calendars().get(...).execute() (used by _get_calendar_timezone).
+    """
+    service = MagicMock()
+    event_payload = returned_event or {
+        "id": "evt-id",
+        "summary": "Test",
+        "start": {"dateTime": "2026-05-01T10:00:00Z", "timeZone": "UTC"},
+        "end": {"dateTime": "2026-05-01T11:00:00Z", "timeZone": "UTC"},
+        "attendees": [],
+        "htmlLink": "https://calendar.google.com/event?eid=evt-id",
+    }
+    service.events.return_value.insert.return_value.execute.return_value = event_payload
+    service.events.return_value.patch.return_value.execute.return_value = event_payload
+    service.events.return_value.move.return_value.execute.return_value = event_payload
+    service.events.return_value.get.return_value.execute.return_value = event_payload
+    service.calendars.return_value.get.return_value.execute.return_value = {
+        "timeZone": "UTC"
+    }
+    return service
+
+
+@pytest.fixture
+def fake_service(monkeypatch):
+    service = _build_fake_service()
+    monkeypatch.setattr(shared, "_get_calendar_service", lambda: service)
+    return service
+
+
+class TestCreateSendUpdates:
+    """#334: shared.create must thread send_updates to events().insert()."""
+
+    def test_default_is_none(self, fake_service):
+        shared.create(
+            summary="Test",
+            start_datetime="2026-05-01T10:00:00Z",
+            end_datetime="2026-05-01T11:00:00Z",
+            calendar_id="primary",
+        )
+        kwargs = fake_service.events.return_value.insert.call_args.kwargs
+        assert kwargs["sendUpdates"] == "none"
+
+    @pytest.mark.parametrize("value", ["all", "externalOnly", "none"])
+    def test_override_flows_through(self, fake_service, value):
+        shared.create(
+            summary="Test",
+            start_datetime="2026-05-01T10:00:00Z",
+            end_datetime="2026-05-01T11:00:00Z",
+            calendar_id="primary",
+            send_updates=value,
+        )
+        kwargs = fake_service.events.return_value.insert.call_args.kwargs
+        assert kwargs["sendUpdates"] == value
+
+
+class TestUpdatePatchSendUpdates:
+    """#334: shared.update patch path must thread send_updates to events().patch()."""
+
+    def test_default_is_none(self, fake_service):
+        shared.update(
+            event_id="evt-id",
+            calendar_id="primary",
+            summary="New title",
+        )
+        kwargs = fake_service.events.return_value.patch.call_args.kwargs
+        assert kwargs["sendUpdates"] == "none"
+
+    @pytest.mark.parametrize("value", ["all", "externalOnly"])
+    def test_override_flows_through(self, fake_service, value):
+        shared.update(
+            event_id="evt-id",
+            calendar_id="primary",
+            summary="New title",
+            send_updates=value,
+        )
+        kwargs = fake_service.events.return_value.patch.call_args.kwargs
+        assert kwargs["sendUpdates"] == value
+
+
+class TestUpdateMoveSendUpdates:
+    """#334: shared.update move path must thread send_updates to events().move()."""
+
+    def test_default_is_none(self, fake_service):
+        shared.update(
+            event_id="evt-id",
+            calendar_id="primary",
+            destination_calendar_id="other@group.calendar.google.com",
+        )
+        kwargs = fake_service.events.return_value.move.call_args.kwargs
+        assert kwargs["sendUpdates"] == "none"
+
+    def test_override_flows_through(self, fake_service):
+        shared.update(
+            event_id="evt-id",
+            calendar_id="primary",
+            destination_calendar_id="other@group.calendar.google.com",
+            send_updates="all",
+        )
+        kwargs = fake_service.events.return_value.move.call_args.kwargs
+        assert kwargs["sendUpdates"] == "all"
+
+
+class TestUnknownParameterValidator:
+    """#313: _validating_call_tool must raise on unknown parameters."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_params(self):
+        # Verbatim from the issue body — these are invalid: the real names
+        # are start_date / end_date / calendar_id, and there is no `op`.
+        with pytest.raises(ValueError, match="Unknown parameter"):
+            await mcp.call_tool(
+                "read",
+                {
+                    "op": "list_events",
+                    "date": "2026-02-20",
+                    "calendar": "Research",
+                },
+            )


### PR DESCRIPTION
## Summary

Replaces the three hardcoded `sendUpdates=\"all\"` call sites in `src/mcp_handley_lab/google_calendar/shared.py` (`events.insert`, `events.patch`, `events.move`) with a new `send_updates` parameter on `create` and `update`, defaulting to `\"none\"`. Notification spam is now opt-in. The move path inside `update()` is included so the parameter isn't silently ignored when callers route through `destination_calendar_id`.

## Closes

- **#334** — real fix
- **#313** — already fixed in #321 by the `_validating_call_tool` wrapper. This PR adds the missing regression test using the verbatim example from the issue body.
- **#320** — already fixed in #323 by `rapidfuzz` + `_normalize_text`. Existing `tests/unit/test_google_calendar_search.py::test_fuzzy_matching` already covers \"examiner\" / \"cafe\" / \"meting\". No new code or test needed.

## Behavior change

Callers that relied on the implicit \"all\" notification will see notifications stop unless they pass `send_updates=\"all\"` explicitly. This is the safer-by-default behavior the issue requested.

## Tests

- New `tests/unit/test_google_calendar_send_updates.py` — 10 mocked-service tests covering default and override on the `create` / `update`-patch / `update`-move paths plus the #313 validator regression. Uses `monkeypatch` on `mcp_handley_lab.google_calendar.shared._get_calendar_service` so the suite needs no API access.
- `tests/conftest.py` — `\"sendUpdates\"` added to VCR `filter_query_parameters` so existing cassettes don't depend on the notification preference.

## Test plan
- [x] `pytest tests/unit -q` — 690 passed (+10 new)
- [x] `pytest tests/integration/google_calendar -q` — same pass/skip pattern as master (pre-existing cassette staleness on `supportsAttachments=true` is unaffected; integration tests skip in CI without credentials)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)