### PR TITLE
fix(llm): lazy-import xai_sdk and mistralai SDKs in adapters

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.31.11b3
-pkgver=0.31.11b3
+pkgver=0.31.11b4
+pkgver=0.31.11b4
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')
@@ -56,6 +56,7 @@ checkdepends=(
     'python-pytest-asyncio>=0.21.0'
     'python-pytest-vcr>=1.0.0'
     'python-vcrpy>=4.0.0'
+    'python-nest-asyncio>=1.6.0'
 )
 optdepends=(
     'jq: JSON processing'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.31.11b3"
+version = "0.31.11b4"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/providers/grok/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/grok/adapter.py
@@ -5,9 +5,7 @@ These adapters are used by the unified mcp-chat tool.
 """
 
 import threading
-from typing import Any
-
-from xai_sdk import Client
+from typing import TYPE_CHECKING, Any
 
 from mcp_handley_lab.common.config import settings
 from mcp_handley_lab.llm.common import (
@@ -16,17 +14,22 @@ from mcp_handley_lab.llm.common import (
     resolve_images_for_multimodal_prompt,
 )
 
+if TYPE_CHECKING:
+    from xai_sdk import Client
+
 # Lazy initialization of Grok client
-_client: Client | None = None
+_client: "Client | None" = None
 _client_lock = threading.Lock()
 
 
-def get_client() -> Client:
+def get_client() -> "Client":
     """Get or create the global Grok client with thread safety."""
     global _client
     with _client_lock:
         if _client is None:
             try:
+                from xai_sdk import Client
+
                 _client = Client(api_key=settings.xai_api_key)
             except Exception as e:
                 raise RuntimeError(f"Failed to initialize Grok client: {e}") from e

--- a/src/mcp_handley_lab/llm/providers/mistral/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/mistral/adapter.py
@@ -7,9 +7,7 @@ These adapters are used by the unified mcp-chat tool.
 import base64
 import threading
 from pathlib import Path
-from typing import Any
-
-from mistralai import Mistral
+from typing import TYPE_CHECKING, Any
 
 from mcp_handley_lab.common.config import settings
 from mcp_handley_lab.llm.common import (
@@ -19,17 +17,22 @@ from mcp_handley_lab.llm.common import (
     resolve_image_data,
 )
 
+if TYPE_CHECKING:
+    from mistralai import Mistral
+
 # Lazy initialization of Mistral client
-_client: Mistral | None = None
+_client: "Mistral | None" = None
 _client_lock = threading.Lock()
 
 
-def get_client() -> Mistral:
+def get_client() -> "Mistral":
     """Get or create the global Mistral client with thread safety."""
     global _client
     with _client_lock:
         if _client is None:
             try:
+                from mistralai import Mistral
+
                 _client = Mistral(api_key=settings.mistral_api_key)
             except Exception as e:
                 raise RuntimeError(f"Failed to initialize Mistral client: {e}") from e


### PR DESCRIPTION
## Summary

- Move `from xai_sdk import Client` and `from mistralai import Mistral` from module top into the `if _client is None:` branch of `get_client()` (smallest possible scope; only runs on first call).
- Gate the type annotations with `TYPE_CHECKING` (precedent: `microsoft/visio/ops/properties.py:20-21`).
- Lazy import sits inside the existing `try/except`, so SDK failures still get the uniform `RuntimeError("Failed to initialize X client: …")` — no change to the public error contract.
- Bundle the previously-unstaged `python-nest-asyncio>=1.6.0` checkdep that PKGBUILD `check()` requires.
- Version bump: `0.31.11b3` → `0.31.11b4`.

## Why

The PKGBUILD `check()` step on Arch Linux fails because pytest can't even *collect* `tests/unit/test_grok_unit.py` and `tests/unit/test_mistral_unit.py` — both adapters trigger broken upstream Arch packages at module import time:

1. **xai_sdk** — Arch's `python-protobuf 34.1-1` is upstream protobuf 7.34.1; `xai_sdk`'s `proto/__init__.py` raises `ValueError: Unsupported protobuf version: 7.34.1`.
2. **mistralai** — Arch's `python-mistralai 2.3.2` ships only `azure/`, `client/`, `extra/`, `gcp/` subpackages, no top-level `Mistral` re-export, so `from mistralai import Mistral` raises `ImportError`.

These are upstream Arch packaging issues, not bugs in this repo, but they expose a real design weakness: the affected unit tests only exercise pure-Python config helpers (`MODEL_CONFIGS`, `get_model_config`, `resolve_files`) — code paths that should not require the third-party SDK.

## Reviewer

This PR was reviewed by OpenAI gpt-5.5 in three rounds via `mcp-llm review`:
- Plan review (APPROVED, refinements folded back into the implementation).
- Phase 1 review of the Grok diff (APPROVED).
- Phase 2 review of the Mistral diff (APPROVED).

## Test plan

- [x] `python -m pytest tests/unit/test_grok_unit.py -v` → 8 passed (was 1 collection error).
- [x] `python -m pytest tests/unit/test_mistral_unit.py -v` → 28 passed (was 1 collection error).
- [x] Full PKGBUILD-style sweep `PYTHONPATH=src python -m pytest tests/ -m "not slow" --ignore=tests/integration/` → 2047 passed, 12 skipped, 0 errors.
- [ ] `makepkg -f` completes the `check()` step on Arch.
- [ ] CI passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)