### PR TITLE
fix(llm): OpenAI Responses API compatibility with subscription-backed Codex proxies

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.31.11b4
-pkgver=0.31.11b4
+pkgver=0.31.11b5
+pkgver=0.31.11b5
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.31.11b4"
+version = "0.31.11b5"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/providers/openai/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/openai/adapter.py
@@ -79,20 +79,18 @@ def generation_adapter(
         user_content += "\n\n" + "\n\n".join(inline_content)
 
     # Build input with conversation history (Responses API supports array format)
-    if history:
-        input_messages = []
-        for msg in history:
-            role = msg.get("role", "user")
-            input_messages.append({"role": role, "content": msg.get("content", "")})
-        input_messages.append({"role": "user", "content": user_content})
-        input_value: str | list = input_messages
-    else:
-        input_value = user_content
+    input_messages: list = []
+    for msg in history:
+        role = msg.get("role", "user")
+        input_messages.append({"role": role, "content": msg.get("content", "")})
+    input_messages.append({"role": "user", "content": user_content})
+    input_value: list = input_messages
 
     # Build request parameters for Responses API
     request_params: dict[str, Any] = {
         "model": model,
         "input": input_value,
+        "stream": False,
     }
 
     if system_instruction:


### PR DESCRIPTION
## Summary
- Always send the structured `[{role, content}]` form for the Responses API `input` field, instead of a bare string when history is empty.
- Explicitly set `stream=False` on the request body.

## Why
Both forms work against \`api.openai.com\` directly, but break against subscription-backed Codex proxies (\`codex-proxy\`, \`ccproxy\`) which translate to \`chatgpt.com\`'s Codex backend:

- Codex backend rejects bare-string \`input\` with HTTP 400 (\`One of "input" or "previous_response_id" or 'prompt' or 'conversation_id' must be provided.\`) — it requires the structured array.
- These proxies default to streaming SSE when \`stream\` isn't specified; the SDK's non-stream code path then errors with \`'str' object has no attribute 'id'\`.

This change unblocks routing OpenAI traffic through a local codex-proxy backed by a ChatGPT Plus/Pro subscription, while remaining a no-op against the real OpenAI API.

## Test plan
- [x] \`mcp__llm__chat model=openai\` against codex-proxy (Plus seat) returns expected output
- [ ] \`mcp__llm__chat model=openai\` against \`api.openai.com\` (no behaviour change expected)
- [ ] Existing \`tests/integration/test_gpt5_integration.py\` still passes