### PR TITLE
fix(llm): support mistralai 2.x import path

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.31.11b6
-pkgver=0.31.11b6
+pkgver=0.31.11b7
+pkgver=0.31.11b7
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.31.11b5
-pkgver=0.31.11b5
+pkgver=0.31.11b6
+pkgver=0.31.11b6
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.31.11b5"
+version = "0.31.11b6"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.31.11b6"
+version = "0.31.11b7"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -23,7 +23,7 @@ dependencies = [
     "googlemaps>=4.0.0",
     "openai>=1.0.0",
     "anthropic>=0.21.3",
-    "mistralai>=1.9.0,<2",
+    "mistralai>=1.9.0",
     "xai-sdk>=1.0.0",
     "Pillow>=10.0.0",
     "httpx>=0.25.0",

--- a/src/mcp_handley_lab/llm/providers/mistral/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/mistral/adapter.py
@@ -18,7 +18,10 @@ from mcp_handley_lab.llm.common import (
 )
 
 if TYPE_CHECKING:
-    from mistralai import Mistral
+    try:
+        from mistralai.client import Mistral
+    except ImportError:
+        from mistralai import Mistral
 
 # Lazy initialization of Mistral client
 _client: "Mistral | None" = None
@@ -31,7 +34,10 @@ def get_client() -> "Mistral":
     with _client_lock:
         if _client is None:
             try:
-                from mistralai import Mistral
+                try:
+                    from mistralai.client import Mistral
+                except ImportError:
+                    from mistralai import Mistral
 
                 _client = Mistral(api_key=settings.mistral_api_key)
             except Exception as e:


### PR DESCRIPTION
## Summary
- Mistral adapter fails on `mistralai 2.x` (e.g. Arch `python-mistralai 2.4.5-1`) because the top-level package no longer re-exports `Mistral` — it lives at `mistralai.client.Mistral`.
- Try the 2.x path first, fall back to the 1.x top-level import.

## Repro
```
/usr/bin/python -c 'from mistralai import Mistral'           # ImportError on 2.x
/usr/bin/python -c 'from mistralai.client import Mistral'    # OK
```

Closes #354

## Test plan
- [x] `from mistralai.client import Mistral` resolves under `/usr/bin/python` (mistralai 2.4.5)
- [ ] `mcp__llm__ocr` succeeds end-to-end after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)