### PR TITLE
docs: document codex-proxy for ChatGPT subscription routing

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.31.11b7
-pkgver=0.31.11b7
+pkgver=0.31.11b8
+pkgver=0.31.11b8
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/README.md
+++ b/README.md
@@ -90,6 +90,67 @@ export GOOGLE_MAPS_API_KEY="AIza..."
 # Note: Google Calendar requires OAuth setup (see tool description below)
 ```
 
+### Using a ChatGPT Subscription via Codex Proxy (Optional)
+
+If you have a ChatGPT Plus / Pro / Business subscription and would prefer to spend
+those bundled Codex tokens rather than pay-as-you-go OpenAI API credits, you can
+point `mcp-llm` at a local **codex-proxy** instance. The proxy exposes an
+OpenAI-compatible `/v1` endpoint backed by your subscription's Codex session.
+
+1. **Install the proxy.** On Arch Linux it is available from the AUR as
+   [`codex-proxy`](https://github.com/icebear0828/codex-proxy):
+
+   ```bash
+   paru -S codex-proxy
+   systemctl --user enable --now codex-proxy.service
+   ```
+
+   On other systems, follow the upstream install instructions and run
+   `codex-proxy` as a long-lived process (it listens on `http://localhost:8080`
+   by default).
+
+2. **Sign in once.** Open `http://localhost:8080/` in a browser and authenticate
+   with the ChatGPT account that holds the subscription. The proxy stores the
+   session locally and refreshes it transparently.
+
+3. **Verify it's running.** The proxy advertises the models it can route to:
+
+   ```bash
+   curl -s http://localhost:8080/v1/models | jq '.data[].id'
+   # → "gpt-5.2", "gpt-5-codex", "gpt-oss-120b", ...
+   ```
+
+4. **Register `mcp-llm` against the proxy** by overriding the OpenAI base URL.
+   With Claude Code:
+
+   ```bash
+   claude mcp add llm --scope user \
+     --env OPENAI_BASE_URL=http://localhost:8080/v1 \
+     --env OPENAI_API_KEY=pwd \
+     mcp-llm
+   ```
+
+   `OPENAI_API_KEY` is only used as the proxy's local password (set to whatever
+   you configured in the proxy dashboard — `pwd` is the default). No
+   `sk-…` key is sent anywhere; requests never leave your machine for the
+   public OpenAI API.
+
+5. **Use it from any LLM call.** Any OpenAI model (e.g. `gpt-5.2`,
+   `gpt-5-codex`) routed through `mcp-llm` will now be billed against your
+   ChatGPT subscription quota instead of the OpenAI API:
+
+   ```text
+   > ask gpt-5.2 to review the diff
+   ```
+
+   Other providers (Gemini, Claude, Mistral, …) are unaffected and continue to
+   use their own API keys.
+
+> **Caveats**: `codex-proxy` is a third-party project, not affiliated with
+> OpenAI. Treat it as you would any browser session — read the upstream
+> [README](https://github.com/icebear0828/codex-proxy) and OpenAI's terms before
+> relying on it for production work.
+
 ### Register Tools with Claude
 
 Register only the tools you need to avoid context bloat:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.31.11b7"
+version = "0.31.11b8"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Adds a README section that shows how to route `mcp-llm`'s OpenAI requests
through a local [`codex-proxy`](https://github.com/icebear0828/codex-proxy)
instance, so they are served by a ChatGPT Plus / Pro / Business subscription
quota instead of pay-as-you-go OpenAI API credits.

The proxy runs locally (default `http://localhost:8080`), exposes an
OpenAI-compatible `/v1` endpoint, and is wired in by setting
`OPENAI_BASE_URL` + `OPENAI_API_KEY` (the latter is the proxy's local password,
not an `sk-...` key) when registering `mcp-llm`.

No code changes — README + version bump only (`0.31.11b7` → `0.31.11b8`, as required by repo CI).

## Test plan

- [ ] `paru -S codex-proxy && systemctl --user enable --now codex-proxy.service` works on a fresh machine
- [ ] `curl http://localhost:8080/v1/models` returns the expected model list
- [ ] `mcp-llm` registered with `OPENAI_BASE_URL=http://localhost:8080/v1` routes a chat request to ChatGPT quota
- [ ] Other providers (Gemini, Claude, …) continue to work unchanged