### PR TITLE
chore: sync provider model YAMLs to 2026-05 listings

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.31.11b9
-pkgver=0.31.11b9
+pkgver=0.31.11b10
+pkgver=0.31.11b10
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.31.11b9"
+version = "0.31.11b10"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/providers/claude/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/claude/adapter.py
@@ -45,7 +45,7 @@ def get_model_config(model: str) -> dict:
 def resolve_model_alias(model: str) -> str:
     """Resolve model aliases to full model names."""
     aliases = {
-        "opus": "claude-opus-4-7",
+        "opus": "claude-opus-4-8",
         "sonnet": "claude-sonnet-4-6",
         "haiku": "claude-haiku-4-5-20251001",
     }

--- a/src/mcp_handley_lab/llm/providers/claude/models.yaml
+++ b/src/mcp_handley_lab/llm/providers/claude/models.yaml
@@ -1,9 +1,28 @@
 models:
-  claude-opus-4-7:
+  claude-opus-4-8:
     # Model metadata
     description: "Most intelligent Claude model for agents and coding (new tokenizer uses up to 35% more tokens for the same text)"
     capabilities: "🌟 Best for: Complex reasoning, agents, coding, extended thinking, adaptive thinking"
-    tags: ["claude-4.7", "opus", "premium", "latest"]
+    tags: ["claude-4.8", "opus", "premium", "latest"]
+    context_window: "200,000 tokens / 1M tokens (beta)"
+    input_tokens: 200000
+    output_tokens: 128000
+
+    # Capabilities
+    supports_vision: true
+    supports_system_prompt: true
+    supports_extended_thinking: true
+    supports_adaptive_thinking: true
+
+    # Pricing
+    input_per_1m: 5.00
+    output_per_1m: 25.00
+
+  claude-opus-4-7:
+    # Model metadata
+    description: "Previous Opus generation for agents and coding (new tokenizer uses up to 35% more tokens for the same text)"
+    capabilities: "🌟 Best for: Complex reasoning, agents, coding, extended thinking, adaptive thinking"
+    tags: ["claude-4.7", "opus", "premium"]
     context_window: "200,000 tokens / 1M tokens (beta)"
     input_tokens: 200000
     output_tokens: 128000
@@ -130,6 +149,7 @@ models:
 # 5-minute cache writes are 1.25x base input; 1-hour cache writes are 2x base input; cache reads are 0.1x base input
 cache_pricing:
   cache_write:
+    claude-opus-4-8: 6.25
     claude-opus-4-7: 6.25
     claude-opus-4-6: 6.25
     claude-opus-4-5-20251101: 6.25
@@ -146,6 +166,7 @@ cache_pricing:
     claude-haiku-4-5-20251001: 1.25
 
   cache_write_1h:
+    claude-opus-4-8: 10.00
     claude-opus-4-7: 10.00
     claude-opus-4-6: 10.00
     claude-opus-4-5-20251101: 10.00
@@ -162,6 +183,7 @@ cache_pricing:
     claude-haiku-4-5-20251001: 2.00
 
   cache_read:
+    claude-opus-4-8: 0.50
     claude-opus-4-7: 0.50
     claude-opus-4-6: 0.50
     claude-opus-4-5-20251101: 0.50
@@ -179,9 +201,12 @@ cache_pricing:
 
 # Display categories (how to group models by tags for presentation)
 display_categories:
+  - name: "🚀 Claude 4.8 Series"
+    tags: ["claude-4.8"]
+    description: "Latest Claude generation with new tokenizer for improved performance"
   - name: "🚀 Claude 4.7 Series"
     tags: ["claude-4.7"]
-    description: "Latest Claude generation with new tokenizer for improved performance"
+    description: "Previous Claude generation with new tokenizer"
   - name: "🚀 Claude 4.6 Series"
     tags: ["claude-4.6"]
     description: "Previous generation Claude model with adaptive thinking and 128K output"
@@ -190,20 +215,21 @@ display_categories:
     description: "Claude models with extended thinking and enhanced capabilities"
 
 # Default model
-default_model: "claude-opus-4-7"
+default_model: "claude-opus-4-8"
 
 # Usage notes
 usage_notes:
-  - "Claude Opus 4.7 is the flagship — uses a new tokenizer (up to 35% more tokens for the same text)"
-  - "Claude Opus 4.7/4.6 have 200K context (1M beta) and 128K max output"
-  - "Claude Opus 4.7/4.6 and Sonnet 4.6/4.5 support 1M token context window with beta header (context-1m-2025-08-07)"
+  - "Claude Opus 4.8 is the flagship — uses a new tokenizer (up to 35% more tokens for the same text)"
+  - "Claude Opus 4.8/4.7/4.6 have 200K context (1M beta) and 128K max output"
+  - "Claude Opus 4.8/4.7/4.6 and Sonnet 4.6/4.5 support 1M token context window with beta header (context-1m-2025-08-07)"
   - "Long context pricing: requests >200K input tokens charged at 2x input and 1.5x output rates"
   - "All models support vision and image analysis capabilities"
   - "All models support extended thinking for complex reasoning tasks"
-  - "Claude Opus 4.7/4.6 support adaptive thinking"
+  - "Claude Opus 4.8/4.7/4.6 support adaptive thinking"
   - "System prompts supported via separate parameter"
   - "Prompt caching: 5-minute cache write (1.25x), 1-hour cache write (2x), cache read (0.1x)"
-  - "Claude Opus 4.7: Most intelligent for agents and coding ($5/$25 per 1M tokens)"
+  - "Claude Opus 4.8: Most intelligent for agents and coding ($5/$25 per 1M tokens)"
+  - "Claude Opus 4.7: Previous Opus generation ($5/$25 per 1M tokens)"
   - "Claude Opus 4.6: Previous Opus generation ($5/$25 per 1M tokens)"
   - "Claude Sonnet 4.6: Fast, intelligent model for agents and coding ($3/$15 per 1M tokens)"
   - "Claude Sonnet 4.5: Previous generation Sonnet ($3/$15 per 1M tokens)"

--- a/src/mcp_handley_lab/llm/providers/gemini/models.yaml
+++ b/src/mcp_handley_lab/llm/providers/gemini/models.yaml
@@ -1,4 +1,21 @@
 models:
+  gemini-3.5-flash:
+    # Model metadata
+    description: "Most intelligent Gemini Flash model for sustained frontier performance on agentic and coding tasks"
+    capabilities: "🌟 Best for: Agentic workflows, coding, complex reasoning at Flash speed"
+    tags: ["gemini-3.5", "flash", "latest", "multimodal", "reasoning"]
+    context_window: "1,000,000 tokens"
+    output_tokens: 65536
+
+    # Capabilities
+    supports_vision: true
+    supports_grounding: true
+    supports_thinking_level: true
+
+    # Pricing
+    input_per_1m: 1.50
+    output_per_1m: 9.00
+
   gemini-3.1-pro-preview:
     # Model metadata
     description: "Most intelligent Gemini model with advanced reasoning and precise tool usage"
@@ -53,7 +70,7 @@ models:
       - threshold: .inf
         price: 18.00
 
-  gemini-3.1-flash-lite-preview:
+  gemini-3.1-flash-lite:
     # Model metadata
     description: "Cost-effective Gemini 3.1 Flash Lite model for fast, high-volume tasks"
     capabilities: "⚡ Best for: High-volume tasks, cost-sensitive applications, fast inference"
@@ -111,9 +128,9 @@ models:
       audio: 1.00
     output_per_1m: 3.00
 
-  gemini-3-pro-image-preview:
+  gemini-3-pro-image:
     # Model metadata
-    description: "Gemini 3 Pro with native multimodal image generation capabilities"
+    description: "Nano Banana Pro - Gemini 3 Pro with native multimodal image generation capabilities"
     capabilities: "🎨 Best for: Native image generation, multimodal creation, text-to-image"
     tags: ["gemini-3", "pro", "image-generation", "multimodal"]
     context_window: "1,000,000 tokens"
@@ -207,7 +224,7 @@ models:
     free_tier: true
 
   # Native image generation models (Nano Banana family)
-  gemini-3.1-flash-image-preview:
+  gemini-3.1-flash-image:
     # Model metadata
     description: "Nano Banana 2 - high-efficiency image generation at Flash speed"
     capabilities: "🎨 Best for: High-volume image generation, fast iteration, text rendering"
@@ -361,9 +378,12 @@ models:
 
 # Display categories (how to group models by tags for presentation)
 display_categories:
+  - name: "🌟 Gemini 3.5 Series"
+    tags: ["gemini-3.5"]
+    description: "Newest GA Flash model for frontier agentic and coding performance"
   - name: "🌟 Gemini 3.1 Series"
     tags: ["gemini-3.1"]
-    description: "Latest generation with advanced reasoning and precise tool usage (recommended)"
+    description: "Advanced reasoning and precise tool usage (Pro recommended)"
   - name: "⭐ Gemini 3 Series"
     tags: ["gemini-3"]
     description: "Previous generation with strong reasoning and multimodal capabilities"
@@ -390,12 +410,13 @@ default_model: "gemini-3.1-pro-preview"
 # Usage notes
 usage_notes:
   - "Gemini 3.1 Pro Preview is the recommended default for best performance"
+  - "Gemini 3.5 Flash (GA) is the newest flagship Flash model for agentic and coding tasks ($1.50/$9.00 per 1M tokens)"
   - "Gemini 3.1 Pro supports thinking_level (low/medium/high) for controlling reasoning depth"
   - "Gemini 3.1 Pro supports media_resolution for multimodal vision control"
   - "Gemini 3.1 Pro uses thought signatures for maintaining reasoning context"
   - "Gemini 3.1 Pro Preview has a customtools variant optimized for tool use and bash"
   - "Gemini 3 Flash Preview offers fast inference with Gemini 3 capabilities"
-  - "Gemini 3 Pro Image Preview supports native multimodal image generation"
+  - "Nano Banana Pro (gemini-3-pro-image) supports native multimodal image generation"
   - "All Gemini 3+ models have 1M token context window"
   - "Gemini 3+ models default to temperature 1.0 (strongly recommended per documentation)"
   - "Gemini 2.5 Pro, Flash, and Flash-Lite have free tiers available"
@@ -405,9 +426,9 @@ usage_notes:
   - "Audio input has higher costs than text/image/video for Flash models"
   - "Tiered pricing applies to Pro models based on token count thresholds"
   - "Google Search grounding: 1,500 RPD free, then additional charges apply"
-  - "Gemini 3.1 Flash Lite Preview: Cost-effective model ($0.25/$1.50 per 1M tokens)"
+  - "Gemini 3.1 Flash Lite (GA): Cost-effective model ($0.25/$1.50 per 1M tokens)"
   - "Gemini 3.1 Flash Live Preview: Audio-to-audio realtime model (text $0.75/M, audio $3/M)"
-  - "Nano Banana 2 (gemini-3.1-flash-image-preview): Fast image gen ~$0.045-$0.15/image depending on resolution"
+  - "Nano Banana 2 (gemini-3.1-flash-image): Fast image gen ~$0.045-$0.15/image depending on resolution"
   - "Nano Banana (gemini-2.5-flash-image): Native image generation and editing"
   - "Imagen 4 models charge per image ($0.02-$0.06)"
   - "Veo 3.1: State-of-the-art video generation with native audio ($0.75/sec)"

--- a/src/mcp_handley_lab/llm/providers/grok/models.yaml
+++ b/src/mcp_handley_lab/llm/providers/grok/models.yaml
@@ -1,10 +1,10 @@
 models:
-  grok-4.20-0309-reasoning:
+  grok-4.3:
     # Model metadata
-    description: "Most intelligent Grok model — recommended flagship reasoning model with 2M context"
-    capabilities: "🌟 Best for: Complex reasoning, large context tasks, advanced problem solving"
+    description: "Most intelligent Grok model — recommended flagship with 1M context and native video input"
+    capabilities: "🌟 Best for: Complex reasoning, large context tasks, advanced problem solving, video understanding"
     tags: ["latest", "flagship", "reasoning", "fast"]
-    context_window: "2,000,000 tokens"
+    context_window: "1,000,000 tokens"
     output_tokens: 100000
     param: "max_tokens"
     supports_temperature: true
@@ -13,15 +13,34 @@ models:
     supports_structured_output: true
 
     # Pricing
-    input_per_1m: 2.00
-    output_per_1m: 6.00
+    input_per_1m: 1.25
+    output_per_1m: 2.50
+    cached_input_per_1m: 0.20
+
+  grok-4.20-0309-reasoning:
+    # Model metadata
+    description: "Grok 4.20 reasoning model with 1M context"
+    capabilities: "🎯 Best for: Complex reasoning, large context tasks, advanced problem solving"
+    tags: ["reasoning", "fast"]
+    context_window: "1,000,000 tokens"
+    output_tokens: 100000
+    param: "max_tokens"
+    supports_temperature: true
+    supports_vision: true
+    supports_tool_calling: true
+    supports_structured_output: true
+
+    # Pricing
+    input_per_1m: 1.25
+    output_per_1m: 2.50
+    cached_input_per_1m: 0.20
 
   grok-4.20-0309-non-reasoning:
     # Model metadata
-    description: "Recommended Grok flagship non-reasoning model with 2M context"
+    description: "Grok 4.20 non-reasoning model with 1M context"
     capabilities: "⚡ Best for: Fast responses, large context, high-throughput processing"
-    tags: ["latest", "general", "fast"]
-    context_window: "2,000,000 tokens"
+    tags: ["general", "fast"]
+    context_window: "1,000,000 tokens"
     output_tokens: 100000
     param: "max_tokens"
     supports_temperature: true
@@ -30,15 +49,16 @@ models:
     supports_structured_output: true
 
     # Pricing
-    input_per_1m: 2.00
-    output_per_1m: 6.00
+    input_per_1m: 1.25
+    output_per_1m: 2.50
+    cached_input_per_1m: 0.20
 
   grok-4.20-multi-agent-0309:
     # Model metadata
     description: "Grok 4.20 multi-agent variant for orchestrated, parallel reasoning workflows"
     capabilities: "🤖 Best for: Multi-agent orchestration, parallel reasoning tasks"
-    tags: ["latest", "reasoning", "fast"]
-    context_window: "2,000,000 tokens"
+    tags: ["reasoning", "fast"]
+    context_window: "1,000,000 tokens"
     output_tokens: 100000
     param: "max_tokens"
     supports_temperature: true
@@ -47,168 +67,27 @@ models:
     supports_structured_output: true
 
     # Pricing
-    input_per_1m: 2.00
-    output_per_1m: 6.00
+    input_per_1m: 1.25
+    output_per_1m: 2.50
+    cached_input_per_1m: 0.20
 
-  grok-4-1-fast-reasoning:
+  grok-build-0.1:
     # Model metadata
-    description: "Grok 4.1 lightning-fast reasoning model with 2M context"
-    capabilities: "🎯 Best for: Fast reasoning, large context tasks, cost-effective complex analysis"
-    tags: ["reasoning", "fast", "cost-effective"]
-    context_window: "2,000,000 tokens"
-    output_tokens: 100000
-    param: "max_tokens"
-    supports_temperature: true
-    supports_vision: true
-    supports_tool_calling: true
-    supports_structured_output: true
-
-    # Pricing
-    input_per_1m: 0.20
-    output_per_1m: 0.50
-    cached_input_per_1m: 0.05
-
-  grok-4-1-fast-non-reasoning:
-    # Model metadata
-    description: "Grok 4.1 lightning-fast non-reasoning model with 2M context"
-    capabilities: "⚡ Best for: Fast responses, large context tasks, high-throughput processing"
-    tags: ["fast", "cost-effective"]
-    context_window: "2,000,000 tokens"
-    output_tokens: 100000
-    param: "max_tokens"
-    supports_temperature: true
-    supports_vision: true
-    supports_tool_calling: true
-    supports_structured_output: true
-
-    # Pricing
-    input_per_1m: 0.20
-    output_per_1m: 0.50
-    cached_input_per_1m: 0.05
-
-  grok-4-fast-reasoning:
-    # Model metadata
-    description: "Lightning-fast reasoning model with massive 2M context window"
-    capabilities: "🎯 Best for: Fast reasoning, large context tasks, cost-effective complex analysis"
-    tags: ["reasoning", "fast", "cost-effective"]
-    context_window: "2,000,000 tokens"
-    output_tokens: 100000
-    param: "max_tokens"
-    supports_temperature: true
-    supports_vision: true
-    supports_tool_calling: true
-    supports_structured_output: true
-
-    # Pricing
-    input_per_1m: 0.20
-    output_per_1m: 0.50
-    cached_input_per_1m: 0.05
-
-  grok-4-fast-non-reasoning:
-    # Model metadata
-    description: "Lightning-fast non-reasoning model with massive 2M context window"
-    capabilities: "⚡ Best for: Fast responses, large context tasks, high-throughput processing"
-    tags: ["fast", "cost-effective"]
-    context_window: "2,000,000 tokens"
-    output_tokens: 100000
-    param: "max_tokens"
-    supports_temperature: true
-    supports_vision: true
-    supports_tool_calling: true
-    supports_structured_output: true
-
-    # Pricing
-    input_per_1m: 0.20
-    output_per_1m: 0.50
-    cached_input_per_1m: 0.05
-
-  grok-4-0709:
-    # Model metadata
-    description: "Grok 4 snapshot from July 2024 for consistent behavior"
-    capabilities: "🎯 Best for: Complex reasoning, advanced problem solving, multimodal tasks"
-    tags: ["snapshot", "premium", "reasoning"]
-    context_window: "256,000 tokens"
-    output_tokens: 100000
-    param: "max_tokens"
-    supports_temperature: true
-    supports_vision: true
-    supports_tool_calling: true
-    supports_structured_output: true
-
-    # Pricing
-    input_per_1m: 3.00
-    output_per_1m: 15.00
-    cached_input_per_1m: 0.75
-
-  grok-3:
-    # Model metadata
-    description: "Flagship model that excels at enterprise tasks like data extraction, programming, and text summarization"
-    capabilities: "⚖️ Best for: Enterprise tasks, data extraction, programming, text summarization"
-    tags: ["general", "enterprise"]
-    context_window: "131,072 tokens"
-    output_tokens: 65536
-    param: "max_tokens"
-    supports_temperature: true
-    supports_vision: false
-    supports_tool_calling: true
-    supports_structured_output: true
-
-    # Pricing
-    input_per_1m: 3.00
-    output_per_1m: 15.00
-    cached_input_per_1m: 0.75
-
-  grok-3-mini:
-    # Model metadata
-    description: "A lightweight model that thinks before responding. Excels at quantitative tasks that involve math and reasoning"
-    capabilities: "⚡ Best for: Math and reasoning tasks, cost-effective analysis"
-    tags: ["cost-effective", "reasoning"]
-    context_window: "131,072 tokens"
-    output_tokens: 65536
-    param: "max_tokens"
-    supports_temperature: true
-    supports_vision: false
-    supports_tool_calling: true
-    supports_structured_output: true
-
-    # Pricing
-    input_per_1m: 0.30
-    output_per_1m: 0.50
-    cached_input_per_1m: 0.07
-
-  grok-code-fast-1:
-    # Model metadata
-    description: "A lightning fast reasoning model built for agentic coding"
+    description: "Coding-focused Grok model (successor to grok-code-fast-1) with 256K context"
     capabilities: "⚡ Best for: Agentic coding, fast reasoning, development tasks"
     tags: ["coding", "fast", "cost-effective"]
     context_window: "256,000 tokens"
     output_tokens: 100000
     param: "max_tokens"
     supports_temperature: true
-    supports_tool_calling: true
-    supports_structured_output: true
-
-    # Pricing
-    input_per_1m: 0.20
-    output_per_1m: 1.50
-    cached_input_per_1m: 0.02
-
-  grok-2-vision-1212:
-    # Model metadata
-    description: "Multimodal Grok model capable of analyzing images and responding to text prompts"
-    capabilities: "👁️ Best for: Image analysis, multimodal tasks, visual content understanding"
-    tags: ["multimodal", "vision", "general", "legacy"]
-    context_window: "32,768 tokens"
-    output_tokens: 32768
-    param: "max_tokens"
-    supports_temperature: true
     supports_vision: true
     supports_tool_calling: true
     supports_structured_output: true
 
     # Pricing
-    input_per_1m: 2.00
-    output_per_1m: 10.00
+    input_per_1m: 1.00
+    output_per_1m: 2.00
+    cached_input_per_1m: 0.20
 
   grok-imagine-image:
     # Model metadata
@@ -222,7 +101,7 @@ models:
     price_per_image: 0.02
     pricing_type: "per_image"
 
-  grok-imagine-image-pro:
+  grok-imagine-image-quality:
     # Model metadata
     description: "High-quality image generation with enhanced detail and fidelity"
     capabilities: "🎨 Best for: Professional image generation, high-quality creative content"
@@ -231,7 +110,7 @@ models:
     supports_image_generation: true
 
     # Pricing
-    price_per_image: 0.07
+    price_per_image: 0.05
     pricing_type: "per_image"
 
   grok-imagine-video:
@@ -246,65 +125,51 @@ models:
     price_per_second: 0.050
     pricing_type: "per_second"
 
-  grok-2-image-1212:
+  grok-imagine-video-1.5-preview:
     # Model metadata
-    description: "Previous generation image model for text-to-image generation"
-    capabilities: "🎨 Best for: Image generation, creative visual content"
-    tags: ["image-generation", "creative", "legacy"]
+    description: "Grok Imagine Video 1.5 — video generation from text and image prompts"
+    capabilities: "🎬 Best for: Higher-quality video creation"
+    tags: ["video-generation", "creative", "latest"]
     context_window: "131,072 tokens"
-    supports_image_generation: true
-    supports_tool_calling: true
-    supports_structured_output: true
+    output_tokens: 0
 
-    # Pricing
-    price_per_image: 0.07
-    pricing_type: "per_image"
+    # Pricing (per second)
+    price_per_second: 0.080
+    pricing_type: "per_second"
 
 # Display categories (how to group models by tags for presentation)
 display_categories:
-  - name: "🧠 Latest Reasoning Models"
-    tags: ["latest", "reasoning"]
+  - name: "🧠 Reasoning Models"
+    tags: ["reasoning"]
     description: "Advanced Grok models for complex problem solving and analysis"
   - name: "⚡ Coding Models"
     tags: ["coding"]
     description: "Fast models optimized for agentic coding tasks"
-  - name: "💭 Latest General Models"
-    tags: ["latest", "general"]
-    exclude_tags: ["reasoning", "multimodal", "coding"]
-    description: "Newest general-purpose Grok models"
-  - name: "👁️ Multimodal Models"
-    tags: ["multimodal", "vision"]
-    exclude_tags: ["image-generation"]
-    description: "Grok models with vision and text capabilities"
+  - name: "💭 General Models"
+    tags: ["general"]
+    exclude_tags: ["reasoning", "coding"]
+    description: "General-purpose Grok models"
   - name: "🎨 Grok Imagine (Image)"
     tags: ["image-generation"]
     description: "Grok Imagine models for image creation"
   - name: "🎬 Grok Imagine (Video)"
     tags: ["video-generation"]
     description: "Grok Imagine models for video creation with native audio"
-  - name: "🏢 Enterprise Models"
-    tags: ["enterprise"]
-    description: "Grok models optimized for enterprise workflows"
-  - name: "📜 Legacy Models"
-    tags: ["legacy"]
-    description: "Previous generation Grok models"
 
 # Default model (most capable reasoning model)
-default_model: "grok-4.20-0309-reasoning"
+default_model: "grok-4.3"
 
 # Usage notes
 usage_notes:
   - "All Grok models support function calling, tool use, and structured outputs"
-  - "Grok-4.20 family is the recommended flagship with 2M context ($2/$6 per 1M tokens)"
-  - "Grok-4.20 includes reasoning, non-reasoning, and multi-agent variants"
-  - "Grok-4.1-fast models offer cost-effective 2M context ($0.20/$0.50 per 1M tokens) with cached input pricing"
-  - "Grok-4 fast models support vision (image analysis); grok-3 and grok-3-mini do NOT support vision"
-  - "grok-code-fast-1 is optimized for lightning-fast agentic coding tasks"
-  - "Grok Imagine: grok-imagine-image ($0.02/image), grok-imagine-image-pro ($0.07/image)"
-  - "Grok Imagine Video: $0.05/second with native audio"
-  - "Legacy image generation (grok-2-image-1212): $0.07/image"
+  - "Grok-4.3 is the recommended flagship with 1M context and native video input ($1.25/$2.50 per 1M tokens)"
+  - "Grok-4.20 family (reasoning, non-reasoning, multi-agent) has 1M context ($1.25/$2.50 per 1M tokens)"
+  - "All text models support cached input pricing ($0.20 per 1M tokens)"
+  - "grok-build-0.1 is optimized for agentic coding (256K context, $1.00/$2.00 per 1M tokens)"
+  - "Grok Imagine: grok-imagine-image ($0.02/image), grok-imagine-image-quality ($0.05/image)"
+  - "Grok Imagine Video: grok-imagine-video ($0.05/sec, native audio), grok-imagine-video-1.5-preview ($0.08/sec)"
   - "Grok has less restrictive moderation compared to other providers"
   - "API is compatible with OpenAI and Anthropic SDKs for easy migration"
   - "Real-time search integration available with live web data from X"
-  - "Context windows: Grok-4.20 + 4.1-fast (2M), grok-code-fast-1 (256K), others (131K)"
+  - "Context windows: Grok-4.3 + 4.20 (1M), grok-build-0.1 (256K)"
   - "Image constraints: max 20MB, JPG/JPEG and PNG formats only"

--- a/src/mcp_handley_lab/llm/providers/groq/models.yaml
+++ b/src/mcp_handley_lab/llm/providers/groq/models.yaml
@@ -70,6 +70,39 @@ models:
     input_per_1m: 0.075
     output_per_1m: 0.30
 
+  # Agentic Systems (Production)
+  groq/compound:
+    description: "Groq agentic system combining LLMs with web search and code execution tools."
+    capabilities: "Best for: Agentic workflows, web search, code execution, multi-step tasks."
+    tags: ["compound", "agentic", "production"]
+    context_window: "131,072 tokens"
+    output_tokens: 8192
+    param: "max_tokens"
+    supports_temperature: true
+    supports_vision: false
+    supports_tool_calling: true
+    supports_system_prompt: true
+    # Passthrough billing: underlying model tokens + per-request tool fees
+    # (Basic Search $5/1k, Advanced Search $8/1k, Visit Website $1/1k,
+    #  Code Execution $0.18/hr, Browser Automation $0.08/hr). Free tier in practice.
+    input_per_1m: 0.0
+    output_per_1m: 0.0
+
+  groq/compound-mini:
+    description: "Lightweight Groq agentic system with web search and code execution tools."
+    capabilities: "Best for: Fast agentic tasks, web search, code execution, cost-effective workflows."
+    tags: ["compound", "agentic", "production"]
+    context_window: "131,072 tokens"
+    output_tokens: 8192
+    param: "max_tokens"
+    supports_temperature: true
+    supports_vision: false
+    supports_tool_calling: true
+    supports_system_prompt: true
+    # Passthrough billing: underlying model tokens + per-request tool fees. Free tier in practice.
+    input_per_1m: 0.0
+    output_per_1m: 0.0
+
   # Preview Models
   meta-llama/llama-4-scout-17b-16e-instruct:
     description: "Meta's Llama 4 Scout 17B with 16 experts - efficient multimodal model."
@@ -208,6 +241,9 @@ display_categories:
   - name: "OpenAI GPT-OSS Models"
     tags: ["gpt-oss"]
     description: "OpenAI's open-weight GPT models."
+  - name: "🤖 Agentic Systems"
+    tags: ["compound", "agentic"]
+    description: "Groq compound systems with built-in web search and code execution."
   - name: "Qwen Models"
     tags: ["qwen"]
     description: "Alibaba's Qwen multilingual models."
@@ -227,6 +263,7 @@ usage_notes:
   - "Llama 4 Scout (17B/16E) supports vision/multimodal inputs."
   - "Context windows: Most models support 131K tokens."
   - "Preview models may be deprecated with short notice."
+  - "groq/compound and groq/compound-mini are agentic systems with built-in web search and code execution; billed as underlying-model tokens plus per-request tool fees, $0 in practice on the free tier."
   - "TTS models: Orpheus English ($22/M chars), Orpheus Arabic ($40/M chars)"
   - "ASR models: Whisper v3 ($0.111/hr), Whisper Turbo ($0.04/hr) - billed min 10s"
   - "⚠️ Audio I/O handling not fully implemented - models listed for completeness"

--- a/src/mcp_handley_lab/llm/providers/mistral/models.yaml
+++ b/src/mcp_handley_lab/llm/providers/mistral/models.yaml
@@ -12,35 +12,38 @@ models:
     output_per_1m: 1.50
 
   mistral-medium-latest:
-    description: "Mistral Medium 3.1 - frontier multimodal model (v25.08)"
-    capabilities: "🎯 Best for: Complex tasks, balanced cost/performance"
-    tags: ["mistral-medium", "latest", "frontier", "multimodal"]
-    context_window: "128,000 tokens"
+    description: "Mistral Medium 3.5 - hybrid frontier model unifying instruct, reasoning, coding and vision (v26.04)"
+    capabilities: "🎯 Best for: Complex tasks, reasoning, coding, balanced cost/performance"
+    tags: ["mistral-medium", "latest", "frontier", "multimodal", "reasoning"]
+    context_window: "256,000 tokens"
     output_tokens: 8192
     supports_vision: true
     supports_grounding: false
-    input_per_1m: 0.40
-    output_per_1m: 2.00
+    supports_reasoning: true
+    input_per_1m: 1.50
+    output_per_1m: 7.50
 
   mistral-small-latest:
-    description: "Mistral Small 4.0 - efficient general model (v26.03, floating tag)"
-    capabilities: "⚡ Best for: Everyday tasks, cost-effective"
-    tags: ["mistral-small", "latest", "cost-effective"]
-    context_window: "128,000 tokens"
+    description: "Mistral Small 4 - hybrid efficient model with reasoning and vision (v26.03, floating tag)"
+    capabilities: "⚡ Best for: Everyday tasks, reasoning, cost-effective"
+    tags: ["mistral-small", "latest", "cost-effective", "reasoning"]
+    context_window: "256,000 tokens"
     output_tokens: 8192
     supports_vision: true
     supports_grounding: false
+    supports_reasoning: true
     input_per_1m: 0.10
     output_per_1m: 0.30
 
   mistral-small-4-0-26-03:
-    description: "Mistral Small 4.0 - efficient general model (v26.03, snapshot)"
-    capabilities: "⚡ Best for: Everyday tasks, cost-effective"
-    tags: ["mistral-small", "snapshot"]
-    context_window: "128,000 tokens"
+    description: "Mistral Small 4 - hybrid efficient model with reasoning and vision (v26.03, snapshot)"
+    capabilities: "⚡ Best for: Everyday tasks, reasoning, cost-effective"
+    tags: ["mistral-small", "snapshot", "reasoning"]
+    context_window: "256,000 tokens"
     output_tokens: 8192
     supports_vision: true
     supports_grounding: false
+    supports_reasoning: true
     input_per_1m: 0.10
     output_per_1m: 0.30
 
@@ -78,31 +81,6 @@ models:
     input_per_1m: 0.20
     output_per_1m: 0.20
 
-  # === REASONING MODELS (MAGISTRAL) ===
-  magistral-medium-latest:
-    description: "Magistral Medium 1.2 - frontier reasoning model (v25.09)"
-    capabilities: "🧠 Best for: Complex reasoning, step-by-step thinking"
-    tags: ["magistral", "reasoning", "frontier"]
-    context_window: "128,000 tokens"
-    output_tokens: 40000
-    supports_vision: false
-    supports_grounding: false
-    supports_reasoning: true
-    input_per_1m: 2.00
-    output_per_1m: 5.00
-
-  magistral-small-latest:
-    description: "Magistral Small 1.2 - efficient reasoning model (v25.09)"
-    capabilities: "🧠 Best for: Cost-effective reasoning tasks"
-    tags: ["magistral", "reasoning", "cost-effective"]
-    context_window: "128,000 tokens"
-    output_tokens: 40000
-    supports_vision: false
-    supports_grounding: false
-    supports_reasoning: true
-    input_per_1m: 0.50
-    output_per_1m: 1.50
-
   # === CODING MODELS ===
   codestral-latest:
     description: "Codestral - cutting-edge coding model (v25.08)"
@@ -115,42 +93,6 @@ models:
     supports_fim: true
     input_per_1m: 0.30
     output_per_1m: 0.90
-
-  devstral-medium-latest:
-    description: "Devstral 2 Medium - advanced open SWE model (v25.12)"
-    capabilities: "💻 Best for: Complex software engineering, agentic coding"
-    tags: ["devstral", "coding", "swe"]
-    context_window: "256,000 tokens"
-    output_tokens: 8192
-    supports_vision: false
-    supports_grounding: false
-    supports_fim: true
-    input_per_1m: 0.40
-    output_per_1m: 2.00
-
-  devstral-small-latest:
-    description: "Devstral Small 2 - efficient open SWE model (v25.12)"
-    capabilities: "💻 Best for: Software engineering tasks, cost-effective"
-    tags: ["devstral", "coding", "swe"]
-    context_window: "256,000 tokens"
-    output_tokens: 8192
-    supports_vision: false
-    supports_grounding: false
-    supports_fim: true
-    input_per_1m: 0.10
-    output_per_1m: 0.30
-
-  # === VISION MODELS (PIXTRAL) ===
-  pixtral-large-latest:
-    description: "Pixtral Large - multimodal vision model (v24.11)"
-    capabilities: "👁️ Best for: Image analysis, multimodal tasks"
-    tags: ["pixtral", "vision", "multimodal"]
-    context_window: "128,000 tokens"
-    output_tokens: 8192
-    supports_vision: true
-    supports_grounding: false
-    input_per_1m: 2.00
-    output_per_1m: 6.00
 
   # === AUDIO MODELS (VOXTRAL) ===
   voxtral-small-latest:
@@ -203,6 +145,19 @@ models:
     supports_transcription: true
     input_per_1m: 0.04
     output_per_1m: 0.04
+
+  voxtral-tts-latest:
+    description: "Voxtral TTS - text-to-speech with voice cloning (v26.03)"
+    capabilities: "🎤 Best for: Speech synthesis, voice cloning"
+    tags: ["voxtral", "audio", "tts", "latest"]
+    context_window: "N/A (TTS)"
+    output_tokens: 0
+    supports_vision: false
+    supports_grounding: false
+    supports_audio: true
+    # Pricing: $0.016 per 1,000 characters
+    price_per_1m_chars: 16.00
+    pricing_type: "per_character"
 
   # === SPECIALIST MODELS ===
   ocr-3-25-12:
@@ -281,15 +236,12 @@ display_categories:
   - name: "🎯 Frontier Generalist"
     tags: ["frontier"]
     description: "Most capable models for complex tasks"
-  - name: "🧠 Reasoning Models"
-    tags: ["magistral", "reasoning"]
-    description: "Step-by-step thinking and complex reasoning"
+  - name: "⚡ Efficient Generalist"
+    tags: ["mistral-small"]
+    description: "Efficient hybrid models with reasoning and vision"
   - name: "💻 Coding Models"
-    tags: ["codestral", "devstral", "coding"]
+    tags: ["codestral", "coding"]
     description: "Specialized for code generation and SWE"
-  - name: "👁️ Vision Models"
-    tags: ["pixtral", "vision"]
-    description: "Multimodal image understanding"
   - name: "🎤 Audio Models"
     tags: ["voxtral", "audio"]
     description: "Speech-to-text and audio chat"
@@ -311,13 +263,15 @@ default_model: "mistral-large-latest"
 
 # Usage notes
 usage_notes:
-  - "Mistral Large 3 (v25.12): Latest flagship with vision ($0.50/$1.50 per 1M tokens)"
-  - "Devstral 2 Medium ($0.40/$2.00), Devstral Small 2 ($0.10/$0.30) for agentic coding"
-  - "Magistral models: Use prompt_mode='reasoning' for step-by-step thinking"
+  - "Mistral Large 3 (v25.12): Flagship with vision ($0.50/$1.50 per 1M tokens)"
+  - "Mistral Medium 3.5 (v26.04): Hybrid frontier model with reasoning and vision ($1.50/$7.50 per 1M tokens)"
+  - "Mistral Small 4 (v26.03): Hybrid efficient model with reasoning and vision ($0.10/$0.30 per 1M tokens)"
+  - "Medium 3.5 / Small 4 unify instruct, reasoning, coding and vision — use prompt_mode='reasoning' for step-by-step thinking"
+  - "Magistral (reasoning), Devstral (coding) and Pixtral (vision) families are deprecated; capabilities folded into Medium 3.5 / Small 4"
   - "Codestral: Supports FIM (fill-in-middle) for code completion"
-  - "Voxtral: Audio input for chat and transcription"
+  - "Voxtral: Audio input for chat and transcription; voxtral-tts ($0.016/1k chars) for text-to-speech with voice cloning"
   - "Ministral: Edge-optimized models (3B, 8B, 14B) for high-volume tasks"
   - "OCR 3 (ocr-3-25-12): Latest document OCR, $2 per 1,000 pages"
   - "Voxtral Transcribe (26-02): Latest transcription models including realtime"
-  - "Context windows: Large/Ministral/Devstral 256k, Codestral/Magistral/Mistral-Medium/Small 128k, Voxtral 32k"
+  - "Context windows: Large/Medium/Small/Ministral 256k, Codestral 128k, Voxtral 32k"
   - "Free tier available for experimentation"

--- a/src/mcp_handley_lab/llm/providers/openai/models.yaml
+++ b/src/mcp_handley_lab/llm/providers/openai/models.yaml
@@ -814,11 +814,33 @@ models:
     # NOTE: Audio output handling not fully implemented
 
   # Realtime API Models
+  gpt-realtime-2:
+    # Model metadata
+    description: "Latest realtime API model with reasoning for low-latency multimodal experiences"
+    capabilities: "🔴 Best for: Voice assistants, real-time audio/text/image interaction with reasoning"
+    tags: ["realtime", "audio", "multimodal", "latest"]
+    context_window: "128,000 tokens"
+    output_tokens: 4096
+    param: "max_output_tokens"
+    supports_temperature: true
+    supports_vision: true
+
+    # Pricing (per token, per modality)
+    text_input_per_1m: 4.00
+    text_output_per_1m: 24.00
+    audio_input_per_1m: 32.00
+    audio_output_per_1m: 64.00
+    image_input_per_1m: 5.00
+    cached_text_input_per_1m: 0.40
+    cached_audio_input_per_1m: 0.40
+    cached_image_input_per_1m: 0.50
+    pricing_type: "realtime"
+
   gpt-realtime-1.5:
     # Model metadata
-    description: "Latest realtime API model for low-latency multimodal experiences"
+    description: "Realtime API model for low-latency multimodal experiences"
     capabilities: "🔴 Best for: Voice assistants, real-time audio/text/image interaction"
-    tags: ["realtime", "audio", "multimodal", "latest"]
+    tags: ["realtime", "audio", "multimodal"]
     context_window: "128,000 tokens"
     output_tokens: 4096
     param: "max_output_tokens"
@@ -1001,7 +1023,7 @@ usage_notes:
   - "Cached input pricing available via Responses API"
   - "Fine-tuning models have separate training costs"
   - "Built-in tools have additional per-use charges"
-  - "Realtime API: gpt-realtime-1.5 (current), gpt-realtime-mini (cost-effective), gpt-4o-realtime-preview (legacy)"
+  - "Realtime API: gpt-realtime-2 (current, with reasoning), gpt-realtime-1.5, gpt-realtime-mini (cost-effective), gpt-4o-realtime-preview (legacy)"
   - "Priority processing offers reliable, high-speed performance with pay-as-you-go"
   - "Web search content tokens: free for gpt-4o/4.1 preview, fixed 8K block for mini models"
   - "TTS models: tts-1 ($15/M chars), tts-1-hd ($30/M chars)"

--- a/src/mcp_handley_lab/llm/registry.py
+++ b/src/mcp_handley_lab/llm/registry.py
@@ -48,7 +48,7 @@ MODEL_PREFIXES = [
 # Model aliases (shorthand → full model ID)
 MODEL_ALIASES = {
     # Claude shorthand aliases
-    "opus": "claude-opus-4-7",
+    "opus": "claude-opus-4-8",
     "sonnet": "claude-sonnet-4-6",
     "haiku": "claude-haiku-4-5-20251001",
     # Gemini shorthand aliases

--- a/src/mcp_handley_lab/llm/tool.py
+++ b/src/mcp_handley_lab/llm/tool.py
@@ -363,7 +363,7 @@ def generate_image(
         description="File path to save the generated image. Nano Banana outputs JPEG, Imagen outputs PNG.",
     ),
     model: str = Field(
-        default="gemini-3-pro-image-preview",
+        default="gemini-3-pro-image",
         description="Image model. Provider auto-detected from name.",
     ),
     input_images: list[str] = Field(

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -37,7 +37,7 @@ llm_providers = [
     pytest.param(
         "grok",
         "XAI_API_KEY",
-        "grok-3-mini",
+        "grok-4.3",
         "7+1",
         "8",
         id="grok",
@@ -69,7 +69,7 @@ image_providers = [
     pytest.param(
         "grok",
         "XAI_API_KEY",
-        "grok-2-vision-1212",
+        "grok-4.3",
         id="grok",
         marks=pytest.mark.skip(
             reason="Grok uses gRPC (no VCR cassettes) - consume tokens without recording benefit"
@@ -385,7 +385,7 @@ error_scenarios = [
     pytest.param(
         "grok",
         "XAI_API_KEY",
-        "grok-3-mini",
+        "grok-4.3",
         "invalid-model-name-that-does-not-exist",
         "model",
         id="grok-invalid-model",

--- a/tests/integration/test_mistral_integration.py
+++ b/tests/integration/test_mistral_integration.py
@@ -156,7 +156,7 @@ async def test_mistral_chat_different_models(skip_if_no_api_key, test_output_fil
     models_to_test = [
         "mistral-small-latest",
         "mistral-large-latest",
-        "pixtral-large-latest",
+        "mistral-medium-latest",
     ]
 
     for model in models_to_test:

--- a/tests/integration/test_system_prompt_integration.py
+++ b/tests/integration/test_system_prompt_integration.py
@@ -45,7 +45,7 @@ system_prompt_providers = [
     pytest.param(
         "grok",
         "XAI_API_KEY",
-        "grok-3-mini",
+        "grok-4.3",
         id="grok",
         marks=pytest.mark.skip(reason="Grok uses gRPC (no VCR cassettes)"),
     ),
@@ -82,7 +82,7 @@ image_analysis_providers = [
     pytest.param(
         "grok",
         "XAI_API_KEY",
-        "grok-2-vision-1212",
+        "grok-4.3",
         id="grok",
         marks=pytest.mark.skip(reason="Grok uses gRPC (no VCR cassettes)"),
     ),

--- a/tests/unit/test_claude_unit.py
+++ b/tests/unit/test_claude_unit.py
@@ -14,6 +14,7 @@ class TestClaudeModelConfiguration:
     def test_model_configs_all_present(self):
         """Test that all expected Claude models are in MODEL_CONFIGS."""
         expected_models = {
+            "claude-opus-4-8",
             "claude-opus-4-7",
             "claude-opus-4-6",
             "claude-sonnet-4-6",
@@ -59,7 +60,7 @@ class TestClaudeModelConfiguration:
 
     def test_resolve_model_alias(self):
         """Test model alias resolution."""
-        assert resolve_model_alias("opus") == "claude-opus-4-7"
+        assert resolve_model_alias("opus") == "claude-opus-4-8"
         assert resolve_model_alias("sonnet") == "claude-sonnet-4-6"
         assert resolve_model_alias("haiku") == "claude-haiku-4-5-20251001"
 

--- a/tests/unit/test_gemini_unit.py
+++ b/tests/unit/test_gemini_unit.py
@@ -30,13 +30,14 @@ class TestModelConfiguration:
     def test_model_configs_all_present(self):
         """Test that all expected models are in MODEL_CONFIGS."""
         expected_models = {
+            "gemini-3.5-flash",
             "gemini-3.1-pro-preview",
             "gemini-3.1-pro-preview-customtools",
-            "gemini-3.1-flash-lite-preview",
+            "gemini-3.1-flash-lite",
             "gemini-3.1-flash-live-preview",
-            "gemini-3.1-flash-image-preview",
+            "gemini-3.1-flash-image",
             "gemini-3-flash-preview",
-            "gemini-3-pro-image-preview",
+            "gemini-3-pro-image",
             "gemini-2.5-pro",
             "gemini-2.5-flash",
             "gemini-2.5-flash-lite",

--- a/tests/unit/test_grok_unit.py
+++ b/tests/unit/test_grok_unit.py
@@ -13,41 +13,27 @@ class TestGrokModelConfiguration:
     def test_model_configs_all_present(self):
         """Test that all expected Grok models are in MODEL_CONFIGS."""
         expected_models = {
+            "grok-4.3",
             "grok-4.20-0309-reasoning",
             "grok-4.20-0309-non-reasoning",
             "grok-4.20-multi-agent-0309",
-            "grok-4-1-fast-reasoning",
-            "grok-4-1-fast-non-reasoning",
-            "grok-4-fast-reasoning",
-            "grok-4-fast-non-reasoning",
-            "grok-4-0709",
-            "grok-3",
-            "grok-3-mini",
-            "grok-2-vision-1212",
-            "grok-2-image-1212",
-            "grok-code-fast-1",
+            "grok-build-0.1",
             "grok-imagine-image",
-            "grok-imagine-image-pro",
+            "grok-imagine-image-quality",
             "grok-imagine-video",
+            "grok-imagine-video-1.5-preview",
         }
         assert set(MODEL_CONFIGS.keys()) == expected_models
 
     def test_model_configs_token_limits(self):
         """Test that model configurations have correct token limits."""
-        # Grok 4 series
-        assert MODEL_CONFIGS["grok-4-fast-reasoning"]["output_tokens"] == 100000
-        assert MODEL_CONFIGS["grok-4-fast-non-reasoning"]["output_tokens"] == 100000
-        assert MODEL_CONFIGS["grok-4-0709"]["output_tokens"] == 100000
+        # Grok 4 text models
+        assert MODEL_CONFIGS["grok-4.3"]["output_tokens"] == 100000
+        assert MODEL_CONFIGS["grok-4.20-0309-reasoning"]["output_tokens"] == 100000
+        assert MODEL_CONFIGS["grok-build-0.1"]["output_tokens"] == 100000
 
-        # Grok 3 series
-        assert MODEL_CONFIGS["grok-3"]["output_tokens"] == 65536
-        assert MODEL_CONFIGS["grok-3-mini"]["output_tokens"] == 65536
-
-        # Grok 2 series (text models) - 32K context per official pricing
-        assert MODEL_CONFIGS["grok-2-vision-1212"]["output_tokens"] == 32768
-
-        # Grok 2 image generation model has None (doesn't use token limits)
-        assert MODEL_CONFIGS["grok-2-image-1212"]["output_tokens"] is None
+        # Image generation models have None (don't use token limits)
+        assert MODEL_CONFIGS["grok-imagine-image"]["output_tokens"] is None
 
     def test_model_configs_structure(self):
         """Test that model configurations have required structure."""
@@ -61,7 +47,7 @@ class TestGrokModelConfiguration:
 
     def test_get_model_config_valid_model(self):
         """Test get_model_config with valid model names."""
-        config = get_model_config("grok-4-fast-reasoning")
+        config = get_model_config("grok-4.3")
         assert config["output_tokens"] == 100000
 
     def test_get_model_config_fallback_to_default(self):
@@ -85,7 +71,7 @@ class TestGrokErrorHandling:
         """Test that all model configs have basic required fields."""
         for model_name, config in MODEL_CONFIGS.items():
             assert "output_tokens" in config, f"Missing output_tokens in {model_name}"
-            # Allow None for image generation models (like grok-2-image-1212)
+            # Allow None for image generation models (like grok-imagine-image)
             output_tokens = config["output_tokens"]
             assert output_tokens is None or isinstance(output_tokens, int), (
                 f"Invalid output_tokens type in {model_name}: {type(output_tokens)}"
@@ -93,4 +79,4 @@ class TestGrokErrorHandling:
 
     def test_model_count_matches_expected(self):
         """Test that we have the expected number of models."""
-        assert len(MODEL_CONFIGS) == 16
+        assert len(MODEL_CONFIGS) == 9

--- a/tests/unit/test_mistral_unit.py
+++ b/tests/unit/test_mistral_unit.py
@@ -20,11 +20,7 @@ class TestModelConfiguration:
             ("mistral-small-latest", 8192),
             ("ministral-3b-latest", 8192),
             ("ministral-8b-latest", 8192),
-            ("magistral-medium-latest", 40000),
-            ("magistral-small-latest", 40000),
             ("codestral-latest", 8192),
-            ("devstral-small-latest", 8192),
-            ("pixtral-large-latest", 8192),
             ("voxtral-small-latest", 8192),
             ("voxtral-mini-latest", 8192),
             ("mistral-ocr-latest", 0),
@@ -50,20 +46,14 @@ class TestModelConfiguration:
             "ministral-3b-latest",
             "ministral-8b-latest",
             "ministral-14b-latest",
-            # Reasoning (Magistral)
-            "magistral-medium-latest",
-            "magistral-small-latest",
             # Coding
             "codestral-latest",
-            "devstral-medium-latest",
-            "devstral-small-latest",
-            # Vision (Pixtral)
-            "pixtral-large-latest",
             # Audio (Voxtral)
             "voxtral-small-latest",
             "voxtral-mini-latest",
             "voxtral-mini-transcribe-26-02",
             "voxtral-mini-transcribe-realtime-26-02",
+            "voxtral-tts-latest",
             # Specialist
             "mistral-ocr-latest",
             "ocr-3-25-12",
@@ -81,7 +71,7 @@ class TestModelConfiguration:
         "model_name,expected_output_tokens",
         [
             ("mistral-large-latest", 8192),
-            ("magistral-medium-latest", 40000),
+            ("mistral-medium-latest", 8192),
             ("codestral-latest", 8192),
         ],
     )
@@ -113,7 +103,6 @@ class TestModelConfiguration:
             "mistral-small-latest",
             "ministral-3b-latest",
             "ministral-8b-latest",
-            "pixtral-large-latest",
             "mistral-ocr-latest",
         ]
         for model_id in vision_models:
@@ -124,7 +113,7 @@ class TestModelConfiguration:
 
     def test_reasoning_models_have_supports_reasoning(self):
         """Test that reasoning models have supports_reasoning flag."""
-        reasoning_models = ["magistral-medium-latest", "magistral-small-latest"]
+        reasoning_models = ["mistral-medium-latest", "mistral-small-latest"]
         for model_id in reasoning_models:
             config = MODEL_CONFIGS[model_id]
             assert config.get("supports_reasoning") is True, (
@@ -142,7 +131,7 @@ class TestModelConfiguration:
 
     def test_fim_models_have_supports_fim(self):
         """Test that FIM-capable models have supports_fim flag."""
-        fim_models = ["codestral-latest", "devstral-small-latest"]
+        fim_models = ["codestral-latest"]
         for model_id in fim_models:
             config = MODEL_CONFIGS[model_id]
             assert config.get("supports_fim") is True, (

--- a/tests/unit/test_model_loader.py
+++ b/tests/unit/test_model_loader.py
@@ -67,7 +67,7 @@ class TestLoadModelConfig:
         assert "claude-opus-4-5-20251101" in config["models"]
 
         # Verify default model
-        assert config["default_model"] == "claude-opus-4-7"
+        assert config["default_model"] == "claude-opus-4-8"
 
     def test_load_model_config_nonexistent_provider(self):
         """Test loading configuration for non-existent provider."""
@@ -237,7 +237,7 @@ class TestFormatModelListing:
 
         # Check summary section
         assert "Claude Model Summary" in listing
-        assert "Default Model: claude-opus-4-7" in listing
+        assert "Default Model: claude-opus-4-8" in listing
 
         # Check model categories
         assert "🚀 Claude 4.5 Series" in listing

--- a/tests/unit/test_openai_unit.py
+++ b/tests/unit/test_openai_unit.py
@@ -68,6 +68,7 @@ class TestOpenAIModelConfiguration:
             "gpt-4o-transcribe",
             "gpt-4o-mini-transcribe",
             # Realtime API
+            "gpt-realtime-2",
             "gpt-realtime-1.5",
             "gpt-realtime-mini",
             "gpt-4o-realtime-preview",


### PR DESCRIPTION
## Summary

Refreshes all six LLM provider model configs against each provider's official models/pricing pages (researched 2026-05-31), then **iteratively reviewed with gpt-5.5 (APPROVED)** over two rounds. The previous sync (#345) was 2026-04-27.

## Additions
- **Claude:** `claude-opus-4-8` — new flagship/default (new tokenizer; ~35% more tokens). `opus` alias retargeted (registry + adapter).
- **Grok:** `grok-4.3` (new default, 1M ctx, native video), `grok-build-0.1`, `grok-imagine-image-quality`, `grok-imagine-video-1.5-preview`.
- **Gemini:** `gemini-3.5-flash` (GA flagship Flash).
- **Mistral:** `voxtral-tts-latest`.
- **OpenAI:** `gpt-realtime-2`.
- **Groq:** `groq/compound`, `groq/compound-mini` (agentic systems; free-tier passthrough billing, documented).

## Renames (preview → GA)
- **Gemini:** `gemini-3.1-flash-lite`, `gemini-3.1-flash-image`, `gemini-3-pro-image` (preview forms shut down). Image-gen default in `tool.py` updated to `gemini-3-pro-image`.

## Repricing / metadata
- **Grok:** 4.20 family `$2/$6 → $1.25/$2.50` (+cached `$0.20`), context `2M → 1M`.
- **Mistral:** Medium → 3.5 (`$0.40/$2.00 → $1.50/$7.50`, 256k, reasoning); Small 4 → 256k + reasoning.

## Removals (deprecated / gone from provider listings)
- **Grok (11 slugs):** `grok-4-fast-*`, `grok-4-1-fast-*`, `grok-4-0709`, `grok-3`, `grok-3-mini`, `grok-code-fast-1`, `grok-2-vision-1212`, `grok-2-image-1212`, `grok-imagine-image-pro`.
- **Mistral:** Magistral, Devstral and Pixtral families (capabilities folded into Medium 3.5 / Small 4).

## Tests
Unit tests updated to match new model sets/defaults; integration model refs repointed to current models. 99 LLM unit tests pass. Version bumped to `0.31.11b10`.

## Review notes
gpt-5.5 review (2 rounds) → APPROVED. Addressed: Mistral Small display-category coverage, `gpt-realtime-2` image-pricing consistency. The `groq/compound` $0 pricing is a deliberate, documented choice — it reflects real free-tier usage. Separately filed #359 for the `review(diff=true)` large-file failure encountered during this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)