### PR TITLE
feat(llm): add generate_video tool for Google Veo

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.31.11b12
-pkgver=0.31.11b12
+pkgver=0.32.0
+pkgver=0.32.0
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Register only the tools you need to avoid context bloat:
 
 ```bash
 # Unified LLM tools (one tool handles all providers via model inference)
-claude mcp add llm --scope user mcp-llm                # Chat, vision, image gen, transcribe, OCR, models
+claude mcp add llm --scope user mcp-llm                # Chat, vision, image/video gen, transcribe, OCR, models
 
 # Other essential tools
 claude mcp add arxiv --scope user mcp-arxiv
@@ -183,7 +183,7 @@ Verify tools are working with the `/mcp` command in Claude.
 
 ### 🤖 **Unified LLM Tools** (`llm`, `llm-embeddings`)
 Connect with multiple AI providers through unified interfaces
-  - **llm**: Chat, vision, image generation, transcription, OCR, model discovery - all in one tool
+  - **llm**: Chat, vision, image generation, video generation (Veo), transcription, OCR, model discovery - all in one tool
   - **llm-embeddings**: Semantic embeddings for text (OpenAI, Gemini, Mistral)
   - Provider inferred from model name (e.g., `gpt-5.2` → OpenAI, `gemini-2.5-flash` → Gemini)
   - Persistent conversations with memory via `agent_name` parameter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.31.11b12"
+version = "0.32.0"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/model_loader.py
+++ b/src/mcp_handley_lab/llm/model_loader.py
@@ -128,9 +128,12 @@ def build_model_configs_dict(provider: str) -> dict[str, dict[str, Any]]:
                 }
             elif model_info.get("pricing_type") in ["per_image", "per_second"]:
                 # Image/video generation models don't need output_tokens
-                model_configs[model_id] = {
-                    "output_tokens": None  # N/A for image/video generation
-                }
+                entry = {"output_tokens": None}  # N/A for image/video generation
+                if "default_duration_seconds" in model_info:
+                    entry["default_duration_seconds"] = model_info[
+                        "default_duration_seconds"
+                    ]
+                model_configs[model_id] = entry
             else:
                 # Text generation models require explicit values in YAML
                 if "output_tokens" not in model_info:

--- a/src/mcp_handley_lab/llm/providers/gemini/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/gemini/adapter.py
@@ -17,6 +17,7 @@ from google.genai.types import (
     FileData,
     GenerateContentConfig,
     GenerateImagesConfig,
+    GenerateVideosConfig,
     GoogleSearch,
     GoogleSearchRetrieval,
     ImageConfig,
@@ -25,6 +26,7 @@ from google.genai.types import (
     Tool,
     UploadFileConfig,
 )
+from google.genai.types import Image as GenAIImage
 from PIL import Image
 
 from mcp_handley_lab.common.config import settings
@@ -544,6 +546,69 @@ def image_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
         return _generate_with_nano_banana(prompt, model, **kwargs)
     else:
         return _generate_with_imagen(prompt, model, **kwargs)
+
+
+def _resolve_video_image(input_image: str) -> GenAIImage:
+    """Resolve an image-to-video input (local path or base64 data URI) to a genai Image."""
+    if input_image.startswith("data:"):
+        header, b64 = input_image.split(",", 1)
+        mime_type = header.split(":")[1].split(";")[0]
+        return GenAIImage(image_bytes=base64.b64decode(b64), mime_type=mime_type)
+    return GenAIImage.from_file(location=str(Path(input_image).expanduser()))
+
+
+def video_generation_adapter(prompt: str, model: str, **kwargs) -> dict:
+    """Gemini Veo video generation via the long-running generate_videos operation."""
+    config_params: dict[str, Any] = {}
+    if negative_prompt := kwargs.get("negative_prompt"):
+        config_params["negative_prompt"] = negative_prompt
+    if aspect_ratio := kwargs.get("aspect_ratio"):
+        config_params["aspect_ratio"] = aspect_ratio
+    if resolution := kwargs.get("resolution"):
+        config_params["resolution"] = resolution
+    if duration_seconds := kwargs.get("duration_seconds"):
+        config_params["duration_seconds"] = duration_seconds
+
+    image = (
+        _resolve_video_image(kwargs["input_image"])
+        if kwargs.get("input_image")
+        else None
+    )
+
+    poll_interval = kwargs.get("poll_interval", 10)
+    operation = get_client().models.generate_videos(
+        model=model,
+        prompt=prompt,
+        image=image,
+        config=GenerateVideosConfig(**config_params),
+    )
+    for _ in range(kwargs.get("max_polls", 60)):
+        if operation.done:
+            break
+        time.sleep(poll_interval)
+        operation = get_client().operations.get(operation)
+    if not operation.done:
+        raise TimeoutError("Video generation timed out")
+
+    if operation.error:
+        raise RuntimeError(f"Video generation failed: {operation.error}")
+
+    generated_videos = operation.response.generated_videos
+    if not generated_videos:
+        raise RuntimeError(
+            f"No video generated: {operation.response.rai_media_filtered_reasons}"
+        )
+
+    video = generated_videos[0].video
+    if not video.video_bytes:
+        get_client().files.download(file=video)
+
+    return {
+        "video_bytes": video.video_bytes,
+        "mime_type": video.mime_type or "video/mp4",
+        "duration_seconds": config_params.get("duration_seconds")
+        or get_model_config(model)["default_duration_seconds"],
+    }
 
 
 def list_api_models() -> set[str]:

--- a/src/mcp_handley_lab/llm/providers/gemini/models.yaml
+++ b/src/mcp_handley_lab/llm/providers/gemini/models.yaml
@@ -343,6 +343,7 @@ models:
     # Pricing (per second)
     price_per_second: 0.75
     pricing_type: "per_second"
+    default_duration_seconds: 8
 
   veo-2.0-generate-001:
     # Model metadata
@@ -358,6 +359,7 @@ models:
     # Pricing (per second)
     price_per_second: 0.35
     pricing_type: "per_second"
+    default_duration_seconds: 8
 
   # Deep research agents
   gemini-deep-research:

--- a/src/mcp_handley_lab/llm/registry.py
+++ b/src/mcp_handley_lab/llm/registry.py
@@ -331,6 +331,7 @@ def get_model_capabilities(model: str) -> dict[str, Any]:
             "reasoning": config.get("supports_reasoning", False),
             "extended_thinking": config.get("supports_extended_thinking", False),
             "image_generation": config.get("pricing_type") == "per_image",
+            "video_generation": config.get("pricing_type") == "per_second",
         },
         "supported_options": option_details,
         "constraints": _get_model_constraints(provider, config),
@@ -389,6 +390,7 @@ def list_all_models() -> dict[str, list[dict[str, Any]]]:
                         "supports_extended_thinking", False
                     ),
                     "image_generation": config.get("pricing_type") == "per_image",
+                    "video_generation": config.get("pricing_type") == "per_second",
                 },
                 "supported_options": option_details,
                 "constraints": _get_model_constraints(provider, config),
@@ -422,6 +424,7 @@ def get_adapter(provider: str, adapter_type: str):
             "generation": adapter.generation_adapter,
             "image_analysis": adapter.image_analysis_adapter,
             "image_generation": adapter.image_generation_adapter,
+            "video_generation": adapter.video_generation_adapter,
             "embeddings": adapter.embeddings_adapter,
             "deep_research": adapter.deep_research_adapter,
         }

--- a/src/mcp_handley_lab/llm/tool.py
+++ b/src/mcp_handley_lab/llm/tool.py
@@ -474,6 +474,121 @@ def generate_image(
 
 
 @mcp.tool(
+    description="Generate a video from a text prompt (and optional input image) using "
+    "Google Veo. Supports Gemini Veo models (veo-3.1-generate-preview with native audio, "
+    "veo-2.0-generate-001). Long-running: polls until the video is ready, then writes it to "
+    "output_file. Unlike generate_image there is no inline preview — the tool always writes "
+    "the .mp4 to output_file and returns metadata only. "
+    "Returns: {file_path, file_size_bytes, model, provider, cost, duration_seconds, mime_type, "
+    "original_prompt}."
+)
+def generate_video(
+    output_file: str = Field(
+        ...,
+        description="File path to save the generated video (.mp4).",
+    ),
+    prompt: str = Field(
+        default="",
+        description="Text description of the video to generate.",
+    ),
+    prompt_file: str = Field(
+        default="",
+        description="Path to a file containing the prompt. Cannot be used with 'prompt'.",
+    ),
+    prompt_vars: dict[str, str] = Field(
+        default_factory=dict,
+        description="Variables for template substitution using ${var} syntax.",
+    ),
+    model: str = Field(
+        default="veo-3.1-generate-preview",
+        description="Video model. Provider auto-detected from name.",
+    ),
+    input_image: str = Field(
+        default="",
+        description="Optional image to animate (image-to-video). "
+        "Accepts a local path or a base64 data URI (data:image/png;base64,...).",
+    ),
+    negative_prompt: str = Field(
+        default="",
+        description="Description of what to avoid in the generated video.",
+    ),
+    aspect_ratio: str = Field(
+        default="",
+        description="Aspect ratio, e.g. '16:9' or '9:16'.",
+    ),
+    resolution: str = Field(
+        default="",
+        description="Output resolution, e.g. '720p' or '1080p' (veo-3.1).",
+    ),
+    duration_seconds: int = Field(
+        default=0,
+        description="Clip length in seconds. 0 uses the model default.",
+    ),
+    poll_interval: int = Field(
+        default=10,
+        description="Seconds between status polls.",
+    ),
+    max_polls: int = Field(
+        default=60,
+        description="Maximum number of status polls before timing out.",
+    ),
+) -> dict[str, Any]:
+    """Generate a video from a text prompt using Google Veo."""
+    final_prompt = load_prompt_text(
+        prompt or None, prompt_file or None, prompt_vars or None
+    )
+    if not final_prompt.strip():
+        raise ValueError("Prompt is required and cannot be empty")
+
+    provider, canonical_model, config = resolve_model(model)
+    if config.get("pricing_type") != "per_second":
+        raise ValueError(f"{canonical_model} is not a video generation model")
+
+    generation_func = get_adapter(provider, "video_generation")
+
+    kwargs: dict[str, Any] = {
+        "poll_interval": poll_interval,
+        "max_polls": max_polls,
+    }
+    if input_image:
+        kwargs["input_image"] = input_image
+    if negative_prompt:
+        kwargs["negative_prompt"] = negative_prompt
+    if aspect_ratio:
+        kwargs["aspect_ratio"] = aspect_ratio
+    if resolution:
+        kwargs["resolution"] = resolution
+    if duration_seconds:
+        kwargs["duration_seconds"] = duration_seconds
+
+    response_data = generation_func(
+        prompt=final_prompt, model=canonical_model, **kwargs
+    )
+
+    video_bytes = response_data["video_bytes"]
+    duration = response_data["duration_seconds"]
+
+    filepath = Path(output_file).expanduser()
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    filepath.write_bytes(video_bytes)
+
+    cost = calculate_cost(
+        canonical_model, provider=provider, seconds_generated=duration
+    )
+
+    return {
+        "file_path": str(filepath),
+        "file_size_bytes": len(video_bytes),
+        "model": canonical_model,
+        "provider": provider,
+        "cost": cost,
+        "duration_seconds": duration,
+        "mime_type": response_data["mime_type"],
+        "original_prompt": final_prompt,
+    }
+
+
+@mcp.tool(
     description="Transcribe audio to text using Groq Whisper. "
     "Supports MP3, WAV, FLAC, OGG, M4A. Use model://list resource to discover audio models. "
     "Returns: {text, segments?: [{start, end, text}]}. Segments included if include_timestamps=true."

--- a/tests/integration/test_video_generation_integration.py
+++ b/tests/integration/test_video_generation_integration.py
@@ -1,0 +1,120 @@
+"""Integration tests for video generation via the MCP protocol.
+
+The Veo SDK client is mocked at its boundary (`get_client`) rather than via a VCR
+cassette: a real recording would require credentials and commit a multi-megabyte video
+binary. Mocking the client still exercises the full tool path through `mcp.call_tool` —
+capability gating, kwarg forwarding, file write, cost calculation, and metadata shape.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from mcp_handley_lab.llm.tool import mcp
+
+ADAPTER = "mcp_handley_lab.llm.providers.gemini.adapter"
+
+
+def _done_client(video_bytes=b"fake-mp4-bytes", mime_type="video/mp4"):
+    video = SimpleNamespace(video_bytes=video_bytes, mime_type=mime_type)
+    response = SimpleNamespace(
+        generated_videos=[SimpleNamespace(video=video)],
+        rai_media_filtered_reasons=None,
+    )
+    operation = SimpleNamespace(done=True, error=None, response=response)
+    client = MagicMock()
+    client.models.generate_videos.return_value = operation
+    return client
+
+
+@pytest.fixture
+def video_path(tmp_path):
+    return str(tmp_path / "out.mp4")
+
+
+@pytest.mark.asyncio
+async def test_generate_video_writes_file_and_metadata(video_path):
+    client = _done_client()
+    with patch(f"{ADAPTER}.get_client", return_value=client):
+        _, response = await mcp.call_tool(
+            "generate_video",
+            {
+                "prompt": "a bee landing on a cork",
+                "output_file": video_path,
+                "model": "veo-3.1-generate-preview",
+            },
+        )
+
+    assert Path(response["file_path"]).exists()
+    assert Path(video_path).read_bytes() == b"fake-mp4-bytes"
+    assert response["file_size_bytes"] == len(b"fake-mp4-bytes")
+    assert response["model"] == "veo-3.1-generate-preview"
+    assert response["provider"] == "gemini"
+    assert response["mime_type"] == "video/mp4"
+    assert response["duration_seconds"] == 8
+    assert response["cost"] == pytest.approx(8 * 0.75)  # per_second pricing
+    assert response["original_prompt"] == "a bee landing on a cork"
+
+
+@pytest.mark.asyncio
+async def test_generate_video_forwards_config(video_path):
+    client = _done_client()
+    with patch(f"{ADAPTER}.get_client", return_value=client):
+        await mcp.call_tool(
+            "generate_video",
+            {
+                "prompt": "x",
+                "output_file": video_path,
+                "model": "veo-3.1-generate-preview",
+                "aspect_ratio": "9:16",
+                "duration_seconds": 6,
+            },
+        )
+    config = client.models.generate_videos.call_args.kwargs["config"]
+    assert config.aspect_ratio == "9:16"
+    assert config.duration_seconds == 6
+    assert config.generate_audio is None  # Developer API rejects this param
+
+
+@pytest.mark.asyncio
+async def test_generate_video_veo2_pricing(video_path):
+    client = _done_client()
+    with patch(f"{ADAPTER}.get_client", return_value=client):
+        _, response = await mcp.call_tool(
+            "generate_video",
+            {
+                "prompt": "x",
+                "output_file": video_path,
+                "model": "veo-2.0-generate-001",
+            },
+        )
+    assert response["cost"] == pytest.approx(8 * 0.35)
+
+
+@pytest.mark.asyncio
+async def test_generate_video_rejects_non_video_model(video_path):
+    with pytest.raises(ToolError, match="not a video generation model"):
+        await mcp.call_tool(
+            "generate_video",
+            {
+                "prompt": "x",
+                "output_file": video_path,
+                "model": "gemini-3.1-pro-preview",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_generate_video_rejects_blank_prompt(video_path):
+    with pytest.raises(ToolError, match="Prompt is required"):
+        await mcp.call_tool(
+            "generate_video",
+            {
+                "prompt": "   ",
+                "output_file": video_path,
+                "model": "veo-3.1-generate-preview",
+            },
+        )

--- a/tests/unit/test_video_generation.py
+++ b/tests/unit/test_video_generation.py
@@ -1,0 +1,199 @@
+"""Unit tests for Gemini Veo video generation adapter."""
+
+import base64
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_handley_lab.llm.providers.gemini import adapter
+
+ADAPTER = "mcp_handley_lab.llm.providers.gemini.adapter"
+
+
+def _video(video_bytes=b"mp4-bytes", mime_type="video/mp4"):
+    return SimpleNamespace(video_bytes=video_bytes, mime_type=mime_type)
+
+
+def _operation(done=True, error=None, videos=None, rai=None):
+    response = SimpleNamespace(generated_videos=videos, rai_media_filtered_reasons=rai)
+    return SimpleNamespace(done=done, error=error, response=response)
+
+
+def _client_returning(initial_op, poll_ops=()):
+    """Build a mock client whose generate_videos returns initial_op and whose
+    operations.get yields the supplied poll_ops in sequence."""
+    client = MagicMock()
+    client.models.generate_videos.return_value = initial_op
+    client.operations.get.side_effect = list(poll_ops)
+    return client
+
+
+class TestVideoGenerationAdapter:
+    def test_basic_success_no_download(self):
+        video = _video()
+        op = _operation(done=True, videos=[SimpleNamespace(video=video)])
+        client = _client_returning(op)
+        with patch(f"{ADAPTER}.get_client", return_value=client):
+            result = adapter.video_generation_adapter(
+                "a cat", "veo-3.1-generate-preview"
+            )
+        assert result["video_bytes"] == b"mp4-bytes"
+        assert result["mime_type"] == "video/mp4"
+        assert result["duration_seconds"] == 8  # YAML default
+        client.files.download.assert_not_called()
+
+    def test_audio_param_not_forwarded(self):
+        # The Developer API rejects generate_audio; Veo 3.1 emits native audio by
+        # default, so the adapter must never set it on the config.
+        op = _operation(videos=[SimpleNamespace(video=_video())])
+        client = _client_returning(op)
+        with patch(f"{ADAPTER}.get_client", return_value=client):
+            adapter.video_generation_adapter("x", "veo-3.1-generate-preview")
+        config = client.models.generate_videos.call_args.kwargs["config"]
+        assert config.generate_audio is None
+
+    def test_only_set_kwargs_forwarded(self):
+        op = _operation(videos=[SimpleNamespace(video=_video())])
+        client = _client_returning(op)
+        with patch(f"{ADAPTER}.get_client", return_value=client):
+            adapter.video_generation_adapter(
+                "x",
+                "veo-3.1-generate-preview",
+                aspect_ratio="16:9",
+                negative_prompt="blurry",
+            )
+        config = client.models.generate_videos.call_args.kwargs["config"]
+        assert config.aspect_ratio == "16:9"
+        assert config.negative_prompt == "blurry"
+        assert config.resolution is None
+        assert config.duration_seconds is None
+
+    def test_requested_duration_used_for_pricing(self):
+        op = _operation(videos=[SimpleNamespace(video=_video())])
+        client = _client_returning(op)
+        with patch(f"{ADAPTER}.get_client", return_value=client):
+            result = adapter.video_generation_adapter(
+                "x", "veo-3.1-generate-preview", duration_seconds=4
+            )
+        assert result["duration_seconds"] == 4
+
+    def test_polls_until_done_then_downloads_when_bytes_missing(self):
+        video = _video(video_bytes=None)
+        pending = _operation(done=False)
+        finished = _operation(done=True, videos=[SimpleNamespace(video=video)])
+        client = _client_returning(pending, poll_ops=[finished])
+
+        def _download(file):
+            file.video_bytes = b"downloaded"
+
+        client.files.download.side_effect = _download
+        with patch(f"{ADAPTER}.get_client", return_value=client):
+            result = adapter.video_generation_adapter(
+                "x", "veo-3.1-generate-preview", poll_interval=0
+            )
+        client.operations.get.assert_called_once()
+        client.files.download.assert_called_once()
+        assert result["video_bytes"] == b"downloaded"
+
+    def test_done_on_final_poll_does_not_timeout(self):
+        # max_polls=1: initial pending, single poll returns done — must NOT timeout.
+        pending = _operation(done=False)
+        finished = _operation(done=True, videos=[SimpleNamespace(video=_video())])
+        client = _client_returning(pending, poll_ops=[finished])
+        with patch(f"{ADAPTER}.get_client", return_value=client):
+            result = adapter.video_generation_adapter(
+                "x", "veo-3.1-generate-preview", poll_interval=0, max_polls=1
+            )
+        assert result["video_bytes"] == b"mp4-bytes"
+
+    def test_timeout_when_never_done(self):
+        pending = _operation(done=False)
+        client = _client_returning(
+            pending, poll_ops=[_operation(done=False), _operation(done=False)]
+        )
+        with (
+            patch(f"{ADAPTER}.get_client", return_value=client),
+            pytest.raises(TimeoutError),
+        ):
+            adapter.video_generation_adapter(
+                "x", "veo-3.1-generate-preview", poll_interval=0, max_polls=2
+            )
+
+    def test_operation_error_raises(self):
+        op = _operation(done=True, error="quota exceeded")
+        client = _client_returning(op)
+        with (
+            patch(f"{ADAPTER}.get_client", return_value=client),
+            pytest.raises(RuntimeError, match="quota exceeded"),
+        ):
+            adapter.video_generation_adapter("x", "veo-3.1-generate-preview")
+
+    def test_empty_videos_raises_with_rai_reasons(self):
+        op = _operation(done=True, videos=[], rai=["safety"])
+        client = _client_returning(op)
+        with (
+            patch(f"{ADAPTER}.get_client", return_value=client),
+            pytest.raises(RuntimeError, match="safety"),
+        ):
+            adapter.video_generation_adapter("x", "veo-3.1-generate-preview")
+
+    def test_image_to_video_resolves_input_image(self):
+        op = _operation(videos=[SimpleNamespace(video=_video())])
+        client = _client_returning(op)
+        sentinel = object()
+        with (
+            patch(f"{ADAPTER}.get_client", return_value=client),
+            patch(f"{ADAPTER}._resolve_video_image", return_value=sentinel) as rvi,
+        ):
+            adapter.video_generation_adapter(
+                "x", "veo-3.1-generate-preview", input_image="/tmp/a.png"
+            )
+        rvi.assert_called_once_with("/tmp/a.png")
+        assert client.models.generate_videos.call_args.kwargs["image"] is sentinel
+
+
+class TestDurationThreading:
+    def test_default_duration_threaded_from_yaml(self):
+        from mcp_handley_lab.llm.model_loader import build_model_configs_dict
+
+        configs = build_model_configs_dict("gemini")
+        assert configs["veo-3.1-generate-preview"]["default_duration_seconds"] == 8
+        assert configs["veo-2.0-generate-001"]["default_duration_seconds"] == 8
+
+
+class TestVideoCapabilityFlag:
+    def test_get_model_capabilities_marks_veo(self):
+        from mcp_handley_lab.llm.registry import get_model_capabilities
+
+        caps = get_model_capabilities("veo-3.1-generate-preview")["capabilities"]
+        assert caps["video_generation"] is True
+        assert caps["image_generation"] is False
+
+    def test_non_video_model_not_marked(self):
+        from mcp_handley_lab.llm.registry import get_model_capabilities
+
+        caps = get_model_capabilities("gemini-3.1-pro-preview")["capabilities"]
+        assert caps["video_generation"] is False
+
+    def test_list_all_models_marks_veo(self):
+        from mcp_handley_lab.llm.registry import list_all_models
+
+        gemini = {m["id"]: m for m in list_all_models()["gemini"]}
+        assert gemini["veo-3.1-generate-preview"]["capabilities"]["video_generation"]
+        assert gemini["veo-2.0-generate-001"]["capabilities"]["video_generation"]
+
+
+class TestResolveVideoImage:
+    def test_data_uri(self):
+        raw = b"\x89PNG\r\n\x1a\n"
+        uri = "data:image/png;base64," + base64.b64encode(raw).decode()
+        img = adapter._resolve_video_image(uri)
+        assert img.image_bytes == raw
+        assert img.mime_type == "image/png"
+
+    def test_local_path_uses_from_file(self):
+        with patch(f"{ADAPTER}.GenAIImage.from_file", return_value="IMG") as ff:
+            result = adapter._resolve_video_image("/tmp/pic.jpg")
+        ff.assert_called_once_with(location="/tmp/pic.jpg")
+        assert result == "IMG"


### PR DESCRIPTION
## Summary

Adds a `generate_video` MCP tool to the `llm` server so Google **Veo** models become callable.
Today `list_models()` advertises `veo-3.1-generate-preview` / `veo-2.0-generate-001` (defined in
`gemini/models.yaml`), but the only generation tool exposed is `generate_image` — there is no
binding that invokes the video API. This wires that up, mirroring `generate_image`'s provider
routing and adapter dispatch.

## What's included

- **`video_generation_adapter`** (gemini): async `generate_videos` + `operations.get` polling with
  a post-loop `done` check, `files.download` fallback when `video_bytes` is unpopulated, and
  image-to-video via `types.Image` (imported as `GenAIImage` to avoid colliding with the existing
  `from PIL import Image`).
- **Registry**: new `"video_generation"` adapter type; `video_generation` capability flag
  (`pricing_type == "per_second"`) added to both capability builders.
- **Model loader / YAML**: `default_duration_seconds` threaded from YAML through
  `build_model_configs_dict` for per-second pricing (fail-fast — no magic number in code).
- **`generate_video` tool**: capability-gated dispatch, set-only kwarg forwarding,
  `expanduser` file write, per-second cost via `seconds_generated`, metadata-only return
  (no inline preview — video is written to `output_file`).
- **Tests**: unit tests for the adapter (config construction, polling, download mutation,
  timeout/error/RAI paths, image resolution, duration threading, capability flag) and
  MCP-protocol integration tests for the tool.
- README + version bump (`0.31.11b10 → 0.32.0`).

## Design notes

- `generate_audio` is intentionally **not** exposed: the Gemini Developer API rejects the parameter
  (Enterprise-only), and Veo 3.1 emits native audio by default.
- Scoped to **Gemini Veo**. Grok video models (`grok-imagine-video*`) are real entries in
  `grok/models.yaml` and show `video_generation: true`, but use a separate SDK — a Grok video
  adapter is deferred to a follow-up; calling `generate_video` with a Grok model fails loud via
  `get_adapter`.

## Testing

- `718 passed`, `ruff check`/`ruff format` clean.
- **Live end-to-end verified** against the real Veo 3.1 API: an 8s 720p clip with an AAC audio
  track was generated, polled, downloaded, and written. The `generate_audio`-rejection above was
  caught by this live run — the mocked tests had passed straight through it.
- Integration tests mock the SDK at the `get_client` boundary by design (a real VCR cassette would
  require credentials and commit a multi-MB video binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
