### PR TITLE
fix(gemini): parse real Deep Research Interactions schema (#358)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.31.11b10
-pkgver=0.31.11b10
+pkgver=0.31.11b11
+pkgver=0.31.11b11
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.31.11b10"
+version = "0.31.11b11"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/common/pricing.py
+++ b/src/mcp_handley_lab/common/pricing.py
@@ -55,6 +55,9 @@ class PricingCalculator:
             price_per_second = model_config.get("price_per_second", 0.0)
             return seconds_generated * price_per_second
 
+        elif pricing_type == "per_request":
+            return model_config.get("price_per_request", 0.0)
+
         elif "input_tiers" in model_config:
             for tier in model_config["input_tiers"]:
                 threshold = (

--- a/src/mcp_handley_lab/llm/providers/gemini/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/gemini/adapter.py
@@ -638,30 +638,48 @@ def deep_research_adapter(
                 f"Deep research timed out after {max_polls * poll_interval}s"
             )
 
-    # Extract and return response
-    # Response structure: {"outputs": [{"text": "...", "annotations": [...], "type": "..."}], "usage": {...}}
-    outputs = data.get("outputs", [])
-    output = outputs[0] if outputs else {}
-    usage = data.get("usage", {})
+    # Extract and return response.
+    # Completed payload structure:
+    #   {"steps": [{"type": "user_input", ...},
+    #              {"type": "model_output", "content": [{"text": "...",
+    #                                                     "annotations": [...]}]}],
+    #    "usage": {"total_input_tokens": N, "total_output_tokens": N,
+    #              "total_tokens": N, ...}}
+    steps = data.get("steps", [])
+    model_output = next(
+        (s for s in steps if s.get("type") == "model_output"), None
+    )
+    blocks = model_output.get("content", []) if model_output else []
 
-    # Convert annotations to grounding_chunks format for GroundingMetadata
-    annotations = output.get("annotations", [])
+    text = "\n".join(b["text"] for b in blocks if b.get("text"))
+
+    # Citations live at content[*].annotations, keyed by "url"
+    annotations = [a for b in blocks for a in b.get("annotations", [])]
     grounding_metadata = None
     if annotations:
         grounding_metadata = {
             "web_search_queries": [],
             "grounding_chunks": [
-                {"uri": a.get("source", ""), "title": ""}
+                {"uri": a.get("url", ""), "title": ""}
                 for a in annotations
-                if a.get("source")
+                if a.get("url")
             ],
             "grounding_supports": [],
         }
 
+    # Fail loudly on a completed task with no text, mirroring generation_adapter:
+    # a silent "" produces a 0-byte output file and an empty branch turn.
+    if status == "completed" and not text:
+        raise RuntimeError(
+            "Deep research completed but returned no report text"
+        )
+
+    usage = data.get("usage", {})
+
     return {
-        "text": output.get("text", ""),
-        "input_tokens": usage.get("input_tokens", 0),
-        "output_tokens": usage.get("output_tokens", 0),
+        "text": text,
+        "input_tokens": usage.get("total_input_tokens", 0),
+        "output_tokens": usage.get("total_output_tokens", 0),
         "total_tokens": usage.get("total_tokens", 0),
         "finish_reason": "stop" if status == "completed" else "error",
         "model_version": "deep-research-pro-preview-12-2025",

--- a/src/mcp_handley_lab/llm/providers/gemini/adapter.py
+++ b/src/mcp_handley_lab/llm/providers/gemini/adapter.py
@@ -646,9 +646,7 @@ def deep_research_adapter(
     #    "usage": {"total_input_tokens": N, "total_output_tokens": N,
     #              "total_tokens": N, ...}}
     steps = data.get("steps", [])
-    model_output = next(
-        (s for s in steps if s.get("type") == "model_output"), None
-    )
+    model_output = next((s for s in steps if s.get("type") == "model_output"), None)
     blocks = model_output.get("content", []) if model_output else []
 
     text = "\n".join(b["text"] for b in blocks if b.get("text"))
@@ -670,9 +668,7 @@ def deep_research_adapter(
     # Fail loudly on a completed task with no text, mirroring generation_adapter:
     # a silent "" produces a 0-byte output file and an empty branch turn.
     if status == "completed" and not text:
-        raise RuntimeError(
-            "Deep research completed but returned no report text"
-        )
+        raise RuntimeError("Deep research completed but returned no report text")
 
     usage = data.get("usage", {})
 

--- a/tests/unit/test_common_unit.py
+++ b/tests/unit/test_common_unit.py
@@ -103,6 +103,16 @@ class TestPricingCalculator:
         cost = calc.calculate_cost(model, 0, 0, provider, images_generated=num_images)
         assert cost == expected_cost
 
+    def test_per_request_pricing(self):
+        """Test flat per-request pricing (deep research agents)."""
+        calc = PricingCalculator()
+
+        # Cost is the flat per-request price, independent of token counts
+        cost = calc.calculate_cost(
+            "gemini-deep-research", 500000, 250000, "gemini"
+        )
+        assert cost == 3.00
+
     def test_gemini_tiered_pricing_high_usage(self):
         """Test Gemini 2.5 Pro tiered pricing for high token usage."""
         calc = PricingCalculator()

--- a/tests/unit/test_common_unit.py
+++ b/tests/unit/test_common_unit.py
@@ -108,9 +108,7 @@ class TestPricingCalculator:
         calc = PricingCalculator()
 
         # Cost is the flat per-request price, independent of token counts
-        cost = calc.calculate_cost(
-            "gemini-deep-research", 500000, 250000, "gemini"
-        )
+        cost = calc.calculate_cost("gemini-deep-research", 500000, 250000, "gemini")
         assert cost == 3.00
 
     def test_gemini_tiered_pricing_high_usage(self):

--- a/tests/unit/test_gemini_unit.py
+++ b/tests/unit/test_gemini_unit.py
@@ -155,9 +155,7 @@ class TestDeepResearchAdapter:
 
     def _patch(self, monkeypatch, get_payloads):
         def _factory(*args, **kwargs):
-            return _FakeHTTPClient(
-                {"id": "v1_abc123"}, get_payloads, *args, **kwargs
-            )
+            return _FakeHTTPClient({"id": "v1_abc123"}, get_payloads, *args, **kwargs)
 
         import httpx
 
@@ -183,9 +181,7 @@ class TestDeepResearchAdapter:
         assert result["finish_reason"] == "stop"
         assert result["response_id"] == "v1_abc123"
         chunks = result["grounding_metadata"]["grounding_chunks"]
-        assert chunks == [
-            {"uri": "https://en.wikipedia.org/wiki/Paris", "title": ""}
-        ]
+        assert chunks == [{"uri": "https://en.wikipedia.org/wiki/Paris", "title": ""}]
 
     def test_completed_but_empty_text_raises(self, monkeypatch):
         """A completed task with no report text fails loudly."""

--- a/tests/unit/test_gemini_unit.py
+++ b/tests/unit/test_gemini_unit.py
@@ -2,8 +2,10 @@
 
 import pytest
 
+from mcp_handley_lab.llm.providers.gemini import adapter as gemini_adapter
 from mcp_handley_lab.llm.providers.gemini.adapter import (
     MODEL_CONFIGS,
+    deep_research_adapter,
     get_model_config,
     resolve_files,
 )
@@ -82,3 +84,127 @@ class TestGeminiHelpers:
         # Should raise FileNotFoundError instead of adding error text
         with pytest.raises(FileNotFoundError):
             resolve_files(files)
+
+
+class _FakeHTTPResponse:
+    """Minimal stand-in for an httpx.Response."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeHTTPClient:
+    """Fake httpx.Client that returns scripted POST/GET payloads."""
+
+    def __init__(self, post_payload, get_payloads, **_kwargs):
+        self._post_payload = post_payload
+        self._get_payloads = list(get_payloads)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def post(self, *_args, **_kwargs):
+        return _FakeHTTPResponse(self._post_payload)
+
+    def get(self, *_args, **_kwargs):
+        return _FakeHTTPResponse(self._get_payloads.pop(0))
+
+
+# Representative completed Interactions API payload (real response schema)
+COMPLETED_PAYLOAD = {
+    "id": "v1_abc123",
+    "status": "completed",
+    "steps": [
+        {"type": "user_input", "content": [{"text": "What is the capital of France?"}]},
+        {
+            "type": "model_output",
+            "content": [
+                {
+                    "text": "The capital of France is Paris.",
+                    "annotations": [
+                        {
+                            "type": "url_citation",
+                            "url": "https://en.wikipedia.org/wiki/Paris",
+                            "start_index": 0,
+                            "end_index": 10,
+                        }
+                    ],
+                }
+            ],
+        },
+    ],
+    "usage": {
+        "total_input_tokens": 1234,
+        "total_output_tokens": 5678,
+        "total_tokens": 6912,
+    },
+}
+
+
+class TestDeepResearchAdapter:
+    """Test parsing of the Interactions API completed payload."""
+
+    def _patch(self, monkeypatch, get_payloads):
+        def _factory(*args, **kwargs):
+            return _FakeHTTPClient(
+                {"id": "v1_abc123"}, get_payloads, *args, **kwargs
+            )
+
+        import httpx
+
+        monkeypatch.setattr(httpx, "Client", _factory)
+        monkeypatch.setattr(gemini_adapter.time, "sleep", lambda *_: None)
+
+    def test_parses_completed_payload(self, monkeypatch):
+        """Text, tokens, and citations are extracted from the real schema."""
+        self._patch(monkeypatch, [COMPLETED_PAYLOAD])
+
+        result = deep_research_adapter(
+            prompt="What is the capital of France?",
+            model="gemini-deep-research",
+            history=[],
+            system_instruction="",
+            options={"poll_interval": 0},
+        )
+
+        assert result["text"] == "The capital of France is Paris."
+        assert result["input_tokens"] == 1234
+        assert result["output_tokens"] == 5678
+        assert result["total_tokens"] == 6912
+        assert result["finish_reason"] == "stop"
+        assert result["response_id"] == "v1_abc123"
+        chunks = result["grounding_metadata"]["grounding_chunks"]
+        assert chunks == [
+            {"uri": "https://en.wikipedia.org/wiki/Paris", "title": ""}
+        ]
+
+    def test_completed_but_empty_text_raises(self, monkeypatch):
+        """A completed task with no report text fails loudly."""
+        empty_payload = {
+            "id": "v1_abc123",
+            "status": "completed",
+            "steps": [
+                {"type": "user_input", "content": [{"text": "q"}]},
+                {"type": "model_output", "content": [{"text": ""}]},
+            ],
+            "usage": {},
+        }
+        self._patch(monkeypatch, [empty_payload])
+
+        with pytest.raises(RuntimeError, match="no report text"):
+            deep_research_adapter(
+                prompt="q",
+                model="gemini-deep-research",
+                history=[],
+                system_instruction="",
+                options={"poll_interval": 0},
+            )


### PR DESCRIPTION
Fixes #358.

`deep_research_adapter` parsed an Interactions API response schema that doesn't exist, so a completed Deep Research task returned empty `content`, zero input/output tokens, a 0-byte `output_file`, and an empty assistant branch turn — despite the job completing server-side.

## Changes

1. **Report text** — read from `steps[<model_output>].content[0].text` instead of the non-existent `outputs[0].text`.
2. **Citations** — map from `content[*].annotations` keyed by `url` (was `source`).
3. **Token counts** — read `total_input_tokens` / `total_output_tokens` / `total_tokens` (only `total_tokens` coincidentally matched the old keys, which is why the response showed a large total while input/output were 0).
4. **Empty-text guard** — raise `RuntimeError` when a task is `completed` but returns no text, mirroring `generation_adapter`, so a parse miss fails loudly instead of writing a 0-byte file and an empty branch turn.
5. **Pricing** — add a `per_request` branch to `calculate_cost`. `gemini-deep-research` declares `pricing_type: per_request` with `price_per_request: 3.00`, which previously fell through to `0.0`.

## Tests

- Unit coverage for the completed-payload parse path (text, tokens, citations), the empty-text guard, and per-request pricing.
- Full unit suite (700 tests) passes.

The integration cassette (`TestGeminiDeepResearch`) only ever captured `in_progress` + injected `Internal server error` responses, never a completed payload — which is why this schema mismatch was never caught. Re-recording it requires a live (~\$3) Deep Research run with a real API key, so it's left untouched and the success path is covered by the new unit tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)