### PR TITLE
fix(ci): require vcrpy>=8.2.1 for aiohttp 3.14 compatibility

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.31.11b11
-pkgver=0.31.11b11
+pkgver=0.31.11b12
+pkgver=0.31.11b12
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.31.11b11"
+version = "0.31.11b12"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -51,7 +51,7 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "pytest-vcr>=1.0.0",
     "pytest-xdist>=3.0.0",
-    "vcrpy>=4.0.0",
+    "vcrpy>=8.2.1",  # 8.2.1+ supports aiohttp>=3.14 (which dropped streams.AsyncStreamReaderMixin)
     "nest_asyncio>=1.6.0",
     "ruff>=0.1.0",
     "pre-commit>=3.0.0",


### PR DESCRIPTION
## Problem

Master CI has been failing since `aiohttp` 3.14 released. aiohttp 3.14 removed `aiohttp.streams.AsyncStreamReaderMixin`, which `vcrpy`'s aiohttp stub (`vcr/stubs/aiohttp_stubs.py:21`, `class MockStream(asyncio.StreamReader, streams.AsyncStreamReaderMixin)`) referenced until 8.2.x.

With the unpinned `vcrpy>=4.0.0`, fresh CI installs pair aiohttp 3.14 with a vcrpy that imports the removed symbol, so collection of every aiohttp-backed VCR test fails:

```
AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'
```

This took out the `google_maps` and `otter` integration suites (17 failed, 131 errors on a recent run), with no relation to the code under test.

## Fix

Bump the floor to `vcrpy>=8.2.1`, which supports aiohttp 3.14.

Verified in a clean venv:

```
aiohttp 3.14.1 vcrpy 8.2.1
aiohttp_stubs imported OK -> compatible
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)