### PR TITLE
feat(llm): overrideable context-size cap for review and chat

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.32.0
-pkgver=0.32.0
+pkgver=0.32.1
+pkgver=0.32.1
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.32.0"
+version = "0.32.1"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/llm/shared.py
+++ b/src/mcp_handley_lab/llm/shared.py
@@ -16,6 +16,39 @@ from mcp_handley_lab.shared.models import (
     UsageStats,
 )
 
+# Aggressive default: a focused review is a diff or a handful of changed files,
+# not a whole-repo sweep. Whole-repo/large-context sends must be deliberate
+# (raise max_context_tokens, or 0 to disable). Tunable at server start via env.
+DEFAULT_MAX_CONTEXT_TOKENS = int(os.environ.get("MCP_LLM_MAX_CONTEXT_TOKENS", "25000"))
+
+
+def estimate_file_tokens(path: str) -> int:
+    """Rough token estimate for a file (text: chars/4; binary: base64 len/4)."""
+    data = Path(path).read_bytes()
+    try:
+        return len(data.decode("utf-8")) // 4
+    except UnicodeDecodeError:
+        import base64
+
+        return len(base64.b64encode(data)) // 4
+
+
+def enforce_context_cap(components: dict[str, int], cap: int, hint: str) -> None:
+    """Back-pressure: raise if the assembled fresh payload exceeds the cap.
+
+    components: labelled token counts (e.g. {"code": 540000, "plan": 6000}).
+    cap: token ceiling; 0 disables the check.
+    hint: tool-specific guidance on how to narrow scope.
+    """
+    total = sum(components.values())
+    if cap and total > cap:
+        parts = ", ".join(f"{k}={v // 1000}k" for k, v in components.items() if v)
+        raise ValueError(
+            f"Context payload {total // 1000}k tokens exceeds cap of {cap // 1000}k "
+            f"({parts}). {hint} To send anyway, set max_context_tokens={total + 1} "
+            f"(or 0 to disable)."
+        )
+
 
 def resolve_generation_adapter(
     provider: str, config: dict, images: list[str] | None = None

--- a/src/mcp_handley_lab/llm/tool.py
+++ b/src/mcp_handley_lab/llm/tool.py
@@ -22,9 +22,15 @@ from mcp_handley_lab.llm.registry import (
     list_all_models,
     resolve_model,
 )
+from mcp_handley_lab.llm.shared import (
+    DEFAULT_MAX_CONTEXT_TOKENS,
+    enforce_context_cap,
+    estimate_file_tokens,
+    process_llm_request,
+    resolve_generation_adapter,
+)
 from mcp_handley_lab.llm.shared import chat as _chat
 from mcp_handley_lab.llm.shared import conversation as _conversation
-from mcp_handley_lab.llm.shared import process_llm_request, resolve_generation_adapter
 from mcp_handley_lab.shared.models import LLMResult  # noqa: F401 - used in type hints
 
 mcp = FastMCP("LLM Tool")
@@ -141,8 +147,22 @@ def chat(
         description="Fork from this ref when creating a new conversation branch. "
         "Use commit_sha from a previous response to fork from that point.",
     ),
+    max_context_tokens: int = Field(
+        default=DEFAULT_MAX_CONTEXT_TOKENS,
+        description="Hard cap on the prompt+files payload. Raises if exceeded, so "
+        "large code summaries must be sent deliberately. Set higher to override, "
+        "or 0 to disable.",
+    ),
 ) -> LLMResult:
     """Send a message to an LLM with automatic provider detection."""
+    components = {"prompt": len(prompt) // 4}
+    if files:
+        components["files"] = sum(estimate_file_tokens(f) for f in files)
+    enforce_context_cap(
+        components,
+        max_context_tokens,
+        "Send a smaller summary, fewer files, or split the request.",
+    )
     return _chat(
         prompt=prompt or None,
         prompt_file=prompt_file or None,
@@ -287,8 +307,16 @@ def review(
         default=False,
         description="Use git diff mode instead of full codebase scan.",
     ),
+    max_context_tokens: int = Field(
+        default=DEFAULT_MAX_CONTEXT_TOKENS,
+        description="Hard cap on the code+plan+files payload sent to the reviewer. "
+        "Raises with a scoping breakdown if exceeded, so over-broad sweeps are "
+        "forced down to a diff or the changed files. Set higher to send a large "
+        "payload deliberately, or 0 to disable.",
+    ),
 ) -> LLMResult:
     """Review code by running code2prompt and sending to an LLM."""
+    import re
     import tempfile
 
     if plan:
@@ -314,7 +342,24 @@ def review(
         if diff:
             args.append("--diff")
 
-        run_command(["code2prompt"] + args, timeout=120)
+        _, c2p_stderr = run_command(["code2prompt"] + args, timeout=120)
+
+        # code2prompt prints "Token count: N" (with thousands separators) on stderr.
+        m = re.search(r"Token count:\s*([\d,]+)", c2p_stderr.decode(errors="replace"))
+        code_tokens = (
+            int(m.group(1).replace(",", "")) if m else estimate_file_tokens(c2p_output)
+        )
+        components = {"code": code_tokens}
+        if plan:
+            components["plan"] = estimate_file_tokens(plan)
+        if files:
+            components["files"] = sum(estimate_file_tokens(f) for f in files)
+        enforce_context_cap(
+            components,
+            max_context_tokens,
+            "Narrow scope: include=[<changed package/dir>], "
+            'exclude=["**/*.md","**/*.json"], or diff=True.',
+        )
 
         all_files = [c2p_output] + ([plan] if plan else []) + files
         final_prompt = prompt if prompt else DEFAULT_REVIEW_PROMPT


### PR DESCRIPTION
## Problem

External-LLM spend (OpenAI/Gemini) over the transcript history totalled **~\$1,198**, **87% from `mcp__llm__review`**. Root cause, from analysing `~/.claude/projects/*/*.jsonl`:

- `review` re-ships its payload **on every round** of an iterative loop, uncached.
- For **monorepos** (alan-home/alan, the bulk of the spend), a no-`include` or broad `**/*.py` sweep pulls in **every sibling package + ~63k tokens of docs + ~25k of JSON** that isn't under review.
- Distribution: median review payload **72k** tokens, p90 **206k**, max **587k**. 47% of calls exceeded 80k; **38% of all review tokens** sat above that line (~\$415 at gpt-5.5 rates).

It is *not* ephemera (code2prompt honours `.gitignore`) and *not* branch-memory accumulation (only review prose is stored). It is genuine-but-unchanged context re-sent at full price, and over-broad scope.

## Change

A hard, **overrideable** cap on the assembled fresh payload:

- `review`: code2prompt snapshot (measured from code2prompt's own stderr token count) + plan + files.
- `chat`: prompt + files.
- Exceeding the cap raises `ValueError` with a labelled breakdown and scoping guidance (narrow `include`, `exclude=["**/*.md","**/*.json"]`, or `diff=True`), so an over-broad sweep is forced down to a diff or the changed files instead of silently overspending.
- Replayed branch history is **not** counted — multi-round loops aren't penalised for remembering prior comments.

**Default 25k tokens** (a focused review is a diff or a handful of files). Tunable at server start via `MCP_LLM_MAX_CONTEXT_TOKENS`, or per-call via `max_context_tokens` (higher to send deliberately, `0` to disable).

## Verification

- Cap trips on mddb whole-repo (46k) and a 52k chat payload; `max_context_tokens=0` bypasses.
- `code=46k` in the breakdown matches code2prompt's exact count (stderr parsing correct).
- All 253 llm/review unit tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)