### PR TITLE
fix(email): detect tmux server instead of $TMUX; ghostty GUI fallback

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.32.0
-pkgver=0.32.0
+pkgver=0.32.1
+pkgver=0.32.1
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.32.0"
+version = "0.32.1"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/common/terminal.py
+++ b/src/mcp_handley_lab/common/terminal.py
@@ -6,6 +6,18 @@ import subprocess
 import uuid
 
 
+def _tmux_server_running() -> bool:
+    """True if a tmux server is reachable, regardless of whether $TMUX is set.
+
+    The MCP server process does not inherit $TMUX from its parent, so keying
+    off the environment variable misses an available tmux server. Probe the
+    server directly instead.
+    """
+    return (
+        subprocess.run(["tmux", "list-sessions"], capture_output=True).returncode == 0
+    )
+
+
 def launch_interactive(
     command: str,
     window_title: str | None = None,
@@ -14,40 +26,31 @@ def launch_interactive(
 ) -> str | tuple[str, int]:
     """Launch an interactive command in a new terminal window.
 
-    Automatically detects environment and chooses appropriate method:
-    - If in tmux session: creates new tmux window
-    - Otherwise: launches xterm window
+    Chooses the display method by capability, not by $TMUX:
+    - If a tmux server is reachable: creates a new tmux window in it.
+    - Otherwise: launches a ghostty window.
 
     Args:
         command: The command to execute
         window_title: Optional title for the window
-        prefer_tmux: Whether to prefer tmux over xterm when both available
+        prefer_tmux: Whether to prefer tmux over ghostty when a server is reachable
         wait: Whether to wait for the command to complete before returning
 
     Returns:
         If wait=True: tuple of (status_message, exit_code)
         If wait=False: status message string describing what was launched
-
-    Raises:
-        RuntimeError: If neither tmux nor xterm is available
     """
-    in_tmux = bool(os.environ.get("TMUX"))
-
-    if in_tmux and prefer_tmux:
+    if prefer_tmux and _tmux_server_running():
         if wait:
-            unique_id = str(uuid.uuid4())[:8]
-            channel = f"wait-{unique_id}"
-
+            channel = f"wait-{str(uuid.uuid4())[:8]}"
             sync_command = f"{command}; tmux wait-for -S {channel}"
-            tmux_cmd = ["tmux", "new-window", sync_command]
 
             current_window = subprocess.check_output(
                 ["tmux", "display-message", "-p", "#{window_index}"], text=True
             ).strip()
 
-            subprocess.run(tmux_cmd, check=True)
+            subprocess.run(["tmux", "new-window", sync_command], check=True)
             print(f"Waiting for user input from {window_title or 'tmux window'}...")
-
             subprocess.run(["tmux", "wait-for", channel], check=True)
 
             if current_window:
@@ -57,55 +60,44 @@ def launch_interactive(
                     )
 
             return f"Completed in tmux window: {command}", 0
-        else:
-            tmux_cmd = ["tmux", "new-window"]
 
-            if window_title:
-                tmux_cmd.extend(["-n", window_title])
+        tmux_cmd = ["tmux", "new-window"]
+        if window_title:
+            tmux_cmd.extend(["-n", window_title])
+        tmux_cmd.append(command)
 
-            tmux_cmd.append(command)
+        subprocess.run(tmux_cmd, check=True)
+        return f"Launched in new tmux window: {command}"
 
-            subprocess.run(tmux_cmd, check=True)
-            return f"Launched in new tmux window: {command}"
+    # A shell command string needs a shell; ghostty's -e consumes the rest of
+    # the args as the command, so it must come last. gtk-single-instance=false
+    # forces a new blocking process so wait=True actually waits.
+    ghostty_cmd = ["ghostty", "--gtk-single-instance=false"]
+    if window_title:
+        ghostty_cmd.append(f"--title={window_title}")
+    ghostty_cmd.extend(["-e", "sh", "-c", command])
 
-    else:
-        if wait:
-            xterm_cmd = ["xterm"]
+    if wait:
+        print(f"Waiting for user input from {window_title or 'ghostty window'}...")
+        result = subprocess.run(ghostty_cmd)
+        return f"Completed in ghostty: {command}", result.returncode
 
-            if window_title:
-                xterm_cmd.extend(["-title", window_title])
-
-            xterm_cmd.extend(["-e", command])
-
-            print(f"Waiting for user input from {window_title or 'xterm window'}...")
-            # Let FileNotFoundError propagate if xterm is not installed
-            result = subprocess.run(xterm_cmd)
-            return f"Completed in xterm: {command}", result.returncode
-        else:
-            xterm_cmd = ["xterm"]
-
-            if window_title:
-                xterm_cmd.extend(["-title", window_title])
-
-            xterm_cmd.extend(["-e", command])
-
-            # Let FileNotFoundError propagate if xterm is not installed
-            subprocess.Popen(xterm_cmd)
-            return f"Launched in xterm: {command}"
+    subprocess.Popen(ghostty_cmd)
+    return f"Launched in ghostty: {command}"
 
 
 def check_interactive_support() -> dict:
     """Check what interactive terminal options are available.
 
     Returns:
-        Dict with availability status of tmux and xterm
+        Dict with availability status of tmux and ghostty
     """
     result = {
         "tmux_session": bool(os.environ.get("TMUX")),
         "tmux_available": False,
         "tmux_error": None,
-        "xterm_available": False,
-        "xterm_error": None,
+        "ghostty_available": False,
+        "ghostty_error": None,
     }
 
     try:
@@ -117,11 +109,11 @@ def check_interactive_support() -> dict:
         result["tmux_error"] = str(e)
 
     try:
-        subprocess.run(["which", "xterm"], capture_output=True, check=True)
-        result["xterm_available"] = True
+        subprocess.run(["which", "ghostty"], capture_output=True, check=True)
+        result["ghostty_available"] = True
     except FileNotFoundError:
         pass
     except subprocess.CalledProcessError as e:
-        result["xterm_error"] = str(e)
+        result["ghostty_error"] = str(e)
 
     return result

--- a/tests/common/test_terminal_unit.py
+++ b/tests/common/test_terminal_unit.py
@@ -1,0 +1,54 @@
+"""Unit tests for interactive terminal launching."""
+
+from unittest.mock import MagicMock, patch
+
+from mcp_handley_lab.common.terminal import (
+    check_interactive_support,
+    launch_interactive,
+)
+
+
+@patch("mcp_handley_lab.common.terminal.subprocess.Popen")
+@patch("mcp_handley_lab.common.terminal.subprocess.run")
+def test_uses_tmux_window_when_server_reachable(mock_run, mock_popen):
+    # tmux list-sessions succeeds -> a server is reachable even without $TMUX.
+    mock_run.return_value = MagicMock(returncode=0)
+
+    result = launch_interactive("mutt -f inbox", window_title="Mutt")
+
+    assert "tmux window" in result
+    commands = [call.args[0] for call in mock_run.call_args_list]
+    assert ["tmux", "new-window", "-n", "Mutt", "mutt -f inbox"] in commands
+    mock_popen.assert_not_called()
+
+
+@patch("mcp_handley_lab.common.terminal.subprocess.Popen")
+@patch("mcp_handley_lab.common.terminal.subprocess.run")
+def test_falls_back_to_ghostty_without_tmux_server(mock_run, mock_popen):
+    # tmux list-sessions fails -> no server -> ghostty GUI fallback.
+    mock_run.return_value = MagicMock(returncode=1)
+
+    result = launch_interactive("mutt -f inbox", window_title="Mutt")
+
+    assert "ghostty" in result
+    mock_popen.assert_called_once_with(
+        [
+            "ghostty",
+            "--gtk-single-instance=false",
+            "--title=Mutt",
+            "-e",
+            "sh",
+            "-c",
+            "mutt -f inbox",
+        ]
+    )
+
+
+@patch("mcp_handley_lab.common.terminal.subprocess.run")
+def test_check_interactive_support_reports_ghostty_not_xterm(mock_run):
+    mock_run.return_value = MagicMock(returncode=0)
+
+    result = check_interactive_support()
+
+    assert "ghostty_available" in result
+    assert "xterm_available" not in result


### PR DESCRIPTION
## Description

The interactive Mutt send/edit path is broken after standardising the machines on ghostty (xterm uninstalled).

`launch_interactive()` gated the tmux-window path on the **`$TMUX` environment variable**. The `mcp-email` server process does **not** inherit `$TMUX`, so `email/mutt/tool.py` (`wait=True`) always fell through to the GUI branch — which shelled out to **`xterm`**. With xterm removed, that path raises `FileNotFoundError`.

## Fix

- Gate the tmux-window path on a **reachable tmux server** (`tmux list-sessions`) rather than `$TMUX`, so the email MCP opens a tmux window like the rest of the workflow — the intended behaviour that never actually triggered.
- Replace the `xterm` GUI fallback with **ghostty**: `--gtk-single-instance=false` (so `wait=True` blocks on a real process), and `-e sh -c "<cmd>"` for the `shlex.join`ed command string.
- Update `check_interactive_support()` to report `ghostty` instead of `xterm` (no external consumers of the dict).

## Source
`src/mcp_handley_lab/common/terminal.py`

## Tests
`tests/common/test_terminal_unit.py` (new) — verifies branch selection by server-reachability and the ghostty fallback command. 3 passed.

## Not covered by automated tests
The interactive Mutt window itself (GUI/tmux launch) can't be exercised headlessly — **please verify a real interactive send before merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)