### PR TITLE
fix(loop): only strip PATH entries when running inside a venv

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.32.1
-pkgver=0.32.1
+pkgver=0.32.2
+pkgver=0.32.2
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.32.1"
+version = "0.32.2"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/loop/backends.py
+++ b/src/mcp_handley_lab/loop/backends.py
@@ -258,6 +258,15 @@ def _parse_cells(pane_id: str, config: BackendConfig) -> list[dict[str, Any]]:
     return cells
 
 
+def _venv_stripped_path(path: str) -> str:
+    """Remove the active venv's directories from a PATH string (no-op outside a venv)."""
+    if sys.prefix == sys.base_prefix:
+        return path
+    return os.pathsep.join(
+        p for p in path.split(os.pathsep) if not p.startswith(sys.prefix)
+    )
+
+
 def _session_exists() -> bool:
     """Check if the tmux session exists."""
     result = subprocess.run(
@@ -316,11 +325,7 @@ class TmuxBackend:
         loop_id = f"{self.config.name}-{name or timestamp}"
 
         # Strip venv from environment so tmux windows start clean
-        clean_path = os.pathsep.join(
-            p
-            for p in os.environ.get("PATH", "").split(os.pathsep)
-            if not p.startswith(sys.prefix)
-        )
+        clean_path = _venv_stripped_path(os.environ.get("PATH", ""))
 
         # Handle venv: create if missing, then activate
         venv_path = None

--- a/tests/test_loop_backends.py
+++ b/tests/test_loop_backends.py
@@ -1,0 +1,27 @@
+"""Tests for loop tmux backend helpers."""
+
+import sys
+
+from mcp_handley_lab.loop.backends import _venv_stripped_path
+
+
+class TestVenvStrippedPath:
+    def test_system_python_path_untouched(self, monkeypatch):
+        """Under system Python (sys.prefix == sys.base_prefix) PATH must pass through.
+
+        Regression test for #371: sys.prefix is '/usr' outside a venv, so
+        prefix-stripping emptied PATH entirely and every spawned window died.
+        """
+        monkeypatch.setattr(sys, "prefix", "/usr")
+        monkeypatch.setattr(sys, "base_prefix", "/usr")
+        assert (
+            _venv_stripped_path("/usr/local/bin:/usr/bin") == "/usr/local/bin:/usr/bin"
+        )
+
+    def test_venv_entries_stripped(self, monkeypatch):
+        monkeypatch.setattr(sys, "prefix", "/home/user/.venv")
+        monkeypatch.setattr(sys, "base_prefix", "/usr")
+        assert (
+            _venv_stripped_path("/home/user/.venv/bin:/usr/local/bin:/usr/bin")
+            == "/usr/local/bin:/usr/bin"
+        )


### PR DESCRIPTION
## Summary

Fixes #371.

`TmuxBackend.spawn` stripped every PATH entry starting with `sys.prefix` to keep venv directories out of spawned tmux windows. Under the system Python `sys.prefix == '/usr'`, so a daemon started with `PATH=/usr/local/bin:/usr/bin` (e.g. auto-started from a systemd user service such as claude-messenger) computed an empty PATH. Every spawned window then ran `env PATH= <repl>`, exited 127 immediately, and collapsed the `mcp-loop` tmux session — after which every `run`/`read`/`kill` failed with a `capture-pane` error.

## Changes

- Extract the PATH-cleaning into `_venv_stripped_path()`, which is a no-op unless actually running in a venv (`sys.prefix != sys.base_prefix`).
- Regression tests in `tests/test_loop_backends.py` covering both the system-Python pass-through and venv stripping.
- Version bump 0.32.1 → 0.32.2 via `scripts/bump_version.py`.

## Verification

Built and installed via `makepkg -si` (full test suite runs in `check()`), restarted the daemon, then exercised the live MCP path: `spawn` → python REPL survives, `run` returns output (including an `mdgtd` query against the GTD decks), `kill` cleans up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)