### PR TITLE
Redact Messenger webhook query logs

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.33.0
+pkgver=0.33.1
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.33.0"
+version = "0.33.1"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/messenger/server.py
+++ b/src/mcp_handley_lab/messenger/server.py
@@ -1307,6 +1307,9 @@ for session continuity. Data is not shared with third parties.</p>
             _post_to_loop(event)
 
     def log_message(self, format, *args):
+        if format == '"%s" %s %s':
+            method, target, version = args[0].split(" ", 2)
+            args = (f"{method} {urlparse(target).path} {version}", *args[1:])
         print(f"{self.client_address[0]} - {format % args}", flush=True)
 
 

--- a/tests/messenger/test_commands.py
+++ b/tests/messenger/test_commands.py
@@ -8,12 +8,28 @@ import pytest
 from mcp_handley_lab.messenger.server import (
     ChatActor,
     IncomingEvent,
+    WebhookHandler,
     _context_footer,
     _dispatch,
     _extract_usage,
     _get_or_create_actor,
     _parse_command,
 )
+
+
+def test_webhook_log_omits_query_string(capsys):
+    handler = WebhookHandler.__new__(WebhookHandler)
+    handler.client_address = ("127.0.0.1", 1234)
+    handler.log_message(
+        '"%s" %s %s',
+        "GET /webhook?hub.verify_token=secret HTTP/1.1",
+        "200",
+        "-",
+    )
+    output = capsys.readouterr().out
+    assert '"GET /webhook HTTP/1.1" 200 -' in output
+    assert "secret" not in output
+
 
 # ---------------------------------------------------------------------------
 # _parse_command tests


### PR DESCRIPTION
Prevents WhatsApp webhook verification secrets from being written to the systemd journal by removing query strings from the standard HTTP request log. Error logs retain their status and message.

Adds a regression test proving the query value is absent, and bumps the package to 0.33.1.

Validated with 42 Messenger tests, Ruff, formatting, and pre-commit.