### PR TITLE
fix(email): stop folder: search leaking cross-folder thread siblings

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 _pkgname=mcp-handley-lab
 pkgname=python-mcp-handley-lab
 
-pkgver=0.33.1
+pkgver=0.33.2
 pkgrel=1
 pkgdesc="MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-handley-lab"
 
-version = "0.33.1"
+version = "0.33.2"
 description = "MCP Handley Lab - A comprehensive MCP toolkit for research productivity and lab management"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_handley_lab/email/notmuch/tool.py
+++ b/src/mcp_handley_lab/email/notmuch/tool.py
@@ -334,25 +334,50 @@ def _search_emails(
     offset: int = 0,
     include_excluded: bool = False,
 ) -> list[SearchResult]:
-    """Internal search implementation using notmuch show --body=false for efficiency."""
-    cmd = ["notmuch", "show", "--format=json", "--body=false"]
+    """Internal search returning exactly the messages matching the query.
+
+    Resolve matching message IDs first via `notmuch search --output=messages`, so
+    limit/offset count messages (notmuch show's --limit counts threads) and only
+    matching messages are returned. Headers are then fetched with
+    --entire-thread=false; without it notmuch show defaults to entire-thread for
+    JSON and would harvest sibling replies living in other folders (Sent, Archive),
+    breaking the folder: constraint.
+    """
+    id_cmd = ["notmuch", "search", "--format=json", "--output=messages"]
     if include_excluded:
-        cmd.append("--exclude=false")
-    cmd.extend(["--limit", str(limit), "--offset", str(offset)])
-    cmd.append(query)
-    stdout, _ = run_command(cmd)
+        id_cmd.append("--exclude=false")
+    id_cmd.extend(["--limit", str(limit), "--offset", str(offset)])
+    id_cmd.append(query)
+    stdout, _ = run_command(id_cmd)
+    message_ids = json.loads(stdout.decode().strip())
+    if not message_ids:
+        return []
+
+    show_cmd = [
+        "notmuch",
+        "show",
+        "--format=json",
+        "--body=false",
+        "--entire-thread=false",
+    ]
+    if include_excluded:
+        show_cmd.append("--exclude=false")
+    show_cmd.append(" or ".join(f"id:{mid}" for mid in message_ids))
+    stdout, _ = run_command(show_cmd)
 
     # notmuch show returns nested structure: [[thread1], [thread2], ...]
     # Each thread contains messages: [msg1, [replies...], msg2, ...]
     threads = json.loads(stdout.decode().strip())
 
-    results = []
+    collected: list[SearchResult] = []
     for thread in threads:
         for item in thread:
             # item is either a message dict or a list of replies
-            _collect_messages_from_thread(item, results)
+            _collect_messages_from_thread(item, collected)
 
-    return results
+    # Restore the search order (notmuch show reorders by thread/date)
+    by_id = {r.id: r for r in collected}
+    return [by_id[mid] for mid in message_ids if mid in by_id]
 
 
 def _collect_messages_from_thread(item, results: list[SearchResult]) -> None:

--- a/tests/unit/test_email_search.py
+++ b/tests/unit/test_email_search.py
@@ -1,5 +1,6 @@
 """Tests for email search auto-relaxation, folder families, and query parsing."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 from mcp_handley_lab.email.notmuch.shared import (
@@ -585,3 +586,74 @@ class TestParseQueryTokens:
         tokens = list(_parse_query_tokens("NOT\tfolder:Spam"))
         assert len(tokens) == 1
         assert tokens[0][5] is True  # negated via tab-separated NOT
+
+
+# ============================================================================
+# TestSearchEmailsThreadLeak
+# ============================================================================
+
+
+class TestSearchEmailsThreadLeak:
+    """Regression tests for the entire-thread leak (folder: constraint bypass).
+
+    notmuch show defaults to --entire-thread=true for JSON, so a folder:INBOX
+    query used to harvest sibling replies living in Sent/Archive and count
+    threads (not messages) against the limit. _search_emails must resolve
+    matching message ids first, then show only those with --entire-thread=false.
+    """
+
+    @patch("mcp_handley_lab.email.notmuch.tool.run_command")
+    def test_only_matching_messages_returned_in_order(self, mock_run):
+        from mcp_handley_lab.email.notmuch.tool import _search_emails
+
+        def _msg(mid):
+            return {"id": mid, "headers": {"Subject": mid}, "tags": []}
+
+        def _fake(cmd, **kwargs):
+            if "--output=messages" in cmd:
+                # search step: exactly the two matching (INBOX) messages, in order
+                return json.dumps(["inbox-2", "inbox-1"]).encode(), b""
+            # show step: notmuch reorders and (if entire-thread leaked) would add
+            # a sibling from another folder — the reindex must drop/ignore it
+            threads = [
+                [_msg("inbox-1"), [_msg("sent-sibling")]],
+                [_msg("inbox-2")],
+            ]
+            return json.dumps(threads).encode(), b""
+
+        mock_run.side_effect = _fake
+        results = _search_emails("folder:Hermes/INBOX", limit=10)
+
+        ids = [r.id for r in results]
+        assert ids == ["inbox-2", "inbox-1"]  # search order preserved
+        assert "sent-sibling" not in ids  # no cross-folder leak
+
+    @patch("mcp_handley_lab.email.notmuch.tool.run_command")
+    def test_limit_offset_passed_to_message_search(self, mock_run):
+        from mcp_handley_lab.email.notmuch.tool import _search_emails
+
+        calls = []
+
+        def _fake(cmd, **kwargs):
+            calls.append(cmd)
+            if "--output=messages" in cmd:
+                return json.dumps(["m1"]).encode(), b""
+            return json.dumps([[{"id": "m1", "headers": {}, "tags": []}]]).encode(), b""
+
+        mock_run.side_effect = _fake
+        _search_emails("tag:inbox", limit=25, offset=50)
+
+        search_cmd = next(c for c in calls if "--output=messages" in c)
+        assert "--limit" in search_cmd and "25" in search_cmd
+        assert "--offset" in search_cmd and "50" in search_cmd
+        show_cmd = next(c for c in calls if "show" in c)
+        assert "--entire-thread=false" in show_cmd
+
+    @patch("mcp_handley_lab.email.notmuch.tool.run_command")
+    def test_empty_result_short_circuits(self, mock_run):
+        from mcp_handley_lab.email.notmuch.tool import _search_emails
+
+        mock_run.return_value = (b"[]", b"")
+        assert _search_emails("folder:Nonexistent") == []
+        # only the id-resolution call should have run, not the show step
+        assert mock_run.call_count == 1


### PR DESCRIPTION
## Symptom

`mcp__email__read(query="folder:Hermes/INBOX", limit=400, mode="headers")` returned **670 entries** for an inbox that contains **323 messages**, with results spanning `Hermes/INBOX`, `Hermes/Sent Items`, `Hermes/Archive` and `Hermes/Deleted Items` — and blew the caller's `limit` (a documented token-budget guard). No `search_note` was set, so the leak was silent. The inbox-processing skill has accumulated a whole section of warnings and workarounds for exactly this.

## Root cause

The default `mode=headers` path (`_search_emails`) ran:

```
notmuch show --format=json --body=false --limit N --offset M <query>
```

`notmuch show` defaults `--entire-thread=true` for `--format=json`. So any thread with **one** message matching `folder:INBOX` emitted **every** message in that thread — including replies sitting in other folders — and `_collect_messages_from_thread` harvested them all. `--limit` on `notmuch show` counts **threads**, not messages, so it was silently exceeded.

The `summary`/`full` path (`_show_email`) was already correct because it resolves IDs via `notmuch search --output=messages` first.

## Fix

Make `_search_emails` mirror the correct path: resolve matching message IDs with `notmuch search --output=messages` (message-granular limit/offset, no thread expansion), then fetch headers with `--entire-thread=false`, reindexing to preserve search order.

## Verification (against the live maildir)

| query | before | after |
|---|---|---|
| `folder:Hermes/INBOX`, limit=400 | 670 results, 4 folders | **323 results, 0 non-INBOX** |
| `folder:Hermes/INBOX`, limit=50 | 104 messages | **50 messages** |

All 117 email unit tests pass; 3 new regression tests cover the leak, the limit/offset plumbing, and the empty-result short-circuit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)